### PR TITLE
feat: add 11e Section 2 schema deltas (attachment_role, detachment points, force dispositions)

### DIFF
--- a/data/core/_example/detachments.example.json
+++ b/data/core/_example/detachments.example.json
@@ -21,5 +21,17 @@
       "notes": "All units must have the Void Reapers keyword"
     },
     "game_version": { "edition": "10th", "dataslate": "2025-q3" }
+  },
+  {
+    "id": "ironclad-vanguard",
+    "name": "Ironclad Vanguard",
+    "faction_id": "stellar-wardens",
+    "detachment_points": 2,
+    "force_dispositions": ["take-and-hold", "priority-assets"],
+    "detachment_rule_id": null,
+    "enhancement_ids": ["vanguard-honors"],
+    "stratagem_ids": [],
+    "restrictions": null,
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
   }
 ]

--- a/data/core/_example/enhancements.example.json
+++ b/data/core/_example/enhancements.example.json
@@ -20,5 +20,19 @@
     "ability_id": null,
     "is_unique": true,
     "game_version": { "edition": "10th", "dataslate": "2025-q3" }
+  },
+  {
+    "id": "vanguard-honors",
+    "name": "Vanguard Honors",
+    "detachment_id": "ironclad-vanguard",
+    "cost": 10,
+    "points_provisional": true,
+    "upgrade_tag": true,
+    "max_targets": 3,
+    "keyword_restrictions": ["Stellar Wardens"],
+    "exclusion_keywords": ["Character"],
+    "ability_id": null,
+    "is_unique": false,
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
   }
 ]

--- a/data/core/_example/force-dispositions.example.json
+++ b/data/core/_example/force-dispositions.example.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "take-and-hold",
+    "name": "Take and Hold",
+    "text": "An army oriented toward seizing and controlling ground across the battlefield.",
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
+  },
+  {
+    "id": "disruption",
+    "name": "Disruption",
+    "text": "An army oriented toward unsettling the enemy and denying their plans.",
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
+  },
+  {
+    "id": "purge-the-foe",
+    "name": "Purge the Foe",
+    "text": "An army oriented toward the wholesale destruction of enemy forces.",
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
+  },
+  {
+    "id": "priority-assets",
+    "name": "Priority Assets",
+    "text": "An army oriented toward securing high-value positions and objectives.",
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
+  },
+  {
+    "id": "reconnaissance",
+    "name": "Reconnaissance",
+    "text": "An army oriented toward rapid scouting and battlefield intelligence.",
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
+  }
+]

--- a/data/core/_example/game-versions.example.json
+++ b/data/core/_example/game-versions.example.json
@@ -12,5 +12,12 @@
     "effective_date": "2025-07-07",
     "label": "Summer 2025 Balance Dataslate",
     "supersedes": "2025-q2"
+  },
+  {
+    "edition": "11th",
+    "dataslate": "pre-launch-provisional",
+    "effective_date": "2026-05-01",
+    "label": "Pre-launch provisional seed (ported from 10e archive)",
+    "supersedes": "2025-q3"
   }
 ]

--- a/data/core/_example/leader-attachments.example.json
+++ b/data/core/_example/leader-attachments.example.json
@@ -2,7 +2,6 @@
   {
     "leader_id": "warden-sergeant",
     "eligible_bodyguard_ids": ["ironclad-sentinels"],
-    "max_leaders_per_unit": 1,
     "game_version": { "edition": "10th", "dataslate": "2025-q3" }
   }
 ]

--- a/data/core/_example/units.example.json
+++ b/data/core/_example/units.example.json
@@ -92,5 +92,35 @@
     "weapon_ids": ["reaper-maw", "void-tendrils"],
     "game_version": { "edition": "10th", "dataslate": "2025-q3" },
     "is_legend": false
+  },
+  {
+    "id": "warden-standard-bearer",
+    "name": "Warden Standard Bearer",
+    "faction_id": "stellar-wardens",
+    "role": "character",
+    "attachment_role": "support",
+    "profiles": [
+      {
+        "name": "Warden Standard Bearer",
+        "M": 6,
+        "T": 4,
+        "W": 4,
+        "Sv": 3,
+        "invuln_sv": null,
+        "Ld": 6,
+        "OC": 1
+      }
+    ],
+    "points": [
+      { "models": 1, "cost": 55 }
+    ],
+    "points_provisional": true,
+    "keywords": ["Infantry", "Character", "Imperium", "Stellar Wardens"],
+    "faction_keywords": ["Stellar Wardens"],
+    "base_size_mm": { "shape": "round", "diameter": 32 },
+    "model_count": { "min": 1, "max": 1 },
+    "weapon_ids": ["bolt-carbine"],
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" },
+    "is_legend": false
   }
 ]

--- a/schemas/$defs/common.schema.json
+++ b/schemas/$defs/common.schema.json
@@ -17,8 +17,8 @@
     },
     "dataslate-version": {
       "type": "string",
-      "pattern": "^\\d{4}-q[1-4]$",
-      "description": "Quarterly dataslate version, e.g. '2025-q3'"
+      "pattern": "^(\\d{4}-q[1-4]|[a-z0-9][a-z0-9-]*[a-z0-9])$",
+      "description": "Dataslate version: a quarterly tag (e.g. '2025-q3') or a named kebab-case slug for non-quarterly slates (e.g. 'pre-launch-provisional')"
     },
     "keyword": {
       "type": "string",

--- a/schemas/core/detachment.schema.json
+++ b/schemas/core/detachment.schema.json
@@ -14,6 +14,19 @@
         { "type": "null" }
       ]
     },
+    "detachment_points": {
+      "oneOf": [
+        { "type": "integer", "minimum": 1, "maximum": 3 },
+        { "type": "null" }
+      ],
+      "description": "11e: the detachment-point cost (1–3) charged against the army's detachment-point budget. null when not yet assigned."
+    },
+    "force_dispositions": {
+      "type": "array",
+      "items": { "$ref": "../defs/common.schema.json#/$defs/entity-id" },
+      "uniqueItems": true,
+      "description": "11e: ids of the Force Disposition entities this detachment grants. Empty until assigned."
+    },
     "enhancement_ids": {
       "type": "array",
       "items": { "$ref": "../defs/common.schema.json#/$defs/entity-id" }

--- a/schemas/core/enhancement.schema.json
+++ b/schemas/core/enhancement.schema.json
@@ -9,6 +9,22 @@
     "name": { "type": "string", "minLength": 1, "maxLength": 128 },
     "detachment_id": { "$ref": "../defs/common.schema.json#/$defs/entity-id" },
     "cost": { "type": "integer", "minimum": 0 },
+    "points_provisional": {
+      "type": "boolean",
+      "default": false,
+      "description": "True when the cost is carried over provisionally (e.g. seeded from a prior edition during migration) and not yet confirmed against the current dataslate."
+    },
+    "upgrade_tag": {
+      "type": "boolean",
+      "default": false,
+      "description": "11e: when true, this enhancement applies to up to `max_targets` non-character units while counting as a single Enhancement choice."
+    },
+    "max_targets": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1,
+      "description": "Number of units this enhancement may be applied to. Only meaningful when `upgrade_tag` is true; defaults to 1."
+    },
     "keyword_restrictions": { "$ref": "../defs/common.schema.json#/$defs/keyword-list" },
     "exclusion_keywords": {
       "oneOf": [

--- a/schemas/core/force-disposition.schema.json
+++ b/schemas/core/force-disposition.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://40kdc.dev/schemas/core/force-disposition.schema.json",
+  "title": "Force Disposition",
+  "description": "A 11e strategic-intent tag granted by detachments. Players compare dispositions at game start to determine the shared mission; asymmetric primary objectives result.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "enum": ["take-and-hold", "disruption", "purge-the-foe", "priority-assets", "reconnaissance"],
+      "description": "One of the five confirmed launch Force Dispositions."
+    },
+    "name": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "text": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Community-authored description of the disposition's effect (original prose only — no reproduced rules text)."
+    },
+    "game_version": { "$ref": "../defs/game-version-ref.schema.json" }
+  },
+  "required": ["id", "name", "game_version"],
+  "additionalProperties": false
+}

--- a/schemas/core/leader-attachment.schema.json
+++ b/schemas/core/leader-attachment.schema.json
@@ -11,7 +11,6 @@
       "items": { "$ref": "../defs/common.schema.json#/$defs/entity-id" },
       "minItems": 1
     },
-    "max_leaders_per_unit": { "type": "integer", "minimum": 1, "default": 1 },
     "game_version": { "$ref": "../defs/game-version-ref.schema.json" }
   },
   "required": ["leader_id", "eligible_bodyguard_ids", "game_version"],

--- a/schemas/core/unit.schema.json
+++ b/schemas/core/unit.schema.json
@@ -13,6 +13,13 @@
       "enum": ["character", "battleline", "dedicated-transport", "fortification", "allied", "epic-hero"],
       "description": "Battlefield role from the datasheet header. Unit types (Infantry, Vehicle, etc.) belong in keywords."
     },
+    "attachment_role": {
+      "oneOf": [
+        { "enum": ["leader", "support"] },
+        { "type": "null" }
+      ],
+      "description": "Character attachment role (11e). 'support' implies the unit is only legal when attached to a host unit (cannot be taken solo); 'leader' is valid as a standalone list entry. null/absent for non-attaching units."
+    },
     "profiles": {
       "type": "array",
       "items": {
@@ -46,6 +53,11 @@
         },
         "required": ["models", "cost"]
       }
+    },
+    "points_provisional": {
+      "type": "boolean",
+      "default": false,
+      "description": "True when point costs are carried over provisionally (e.g. seeded from a prior edition during migration) and not yet confirmed against the current dataslate."
     },
     "keywords": { "$ref": "../defs/common.schema.json#/$defs/keyword-list" },
     "faction_keywords": { "$ref": "../defs/common.schema.json#/$defs/keyword-list" },

--- a/tools/src/validate.ts
+++ b/tools/src/validate.ts
@@ -35,6 +35,7 @@ const SCHEMA_MAP: Record<string, string> = {
   "wargear-options": "https://40kdc.dev/schemas/core/wargear-option.schema.json",
   "leader-attachments": "https://40kdc.dev/schemas/core/leader-attachment.schema.json",
   "unit-compositions": "https://40kdc.dev/schemas/core/unit-composition.schema.json",
+  "force-dispositions": "https://40kdc.dev/schemas/core/force-disposition.schema.json",
   "phase-mappings": "https://40kdc.dev/schemas/enrichment/phase-mapping.schema.json",
   "timing-flags": "https://40kdc.dev/schemas/enrichment/timing-flag.schema.json",
   "interaction-flags": "https://40kdc.dev/schemas/enrichment/interaction-flag.schema.json",

--- a/tools/test/fixtures/invalid/detachments-bad.json
+++ b/tools/test/fixtures/invalid/detachments-bad.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "bad-detachment-points",
+    "name": "Bad Detachment Points",
+    "faction_id": "test-faction",
+    "detachment_points": 4,
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
+  }
+]

--- a/tools/test/fixtures/invalid/enhancements-bad.json
+++ b/tools/test/fixtures/invalid/enhancements-bad.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "bad-max-targets",
+    "name": "Bad Max Targets",
+    "detachment_id": "test-detachment",
+    "cost": 10,
+    "upgrade_tag": true,
+    "max_targets": 0,
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
+  }
+]

--- a/tools/test/fixtures/invalid/force-dispositions-bad.json
+++ b/tools/test/fixtures/invalid/force-dispositions-bad.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "not-a-real-disposition",
+    "name": "Bad Disposition",
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
+  }
+]

--- a/tools/test/fixtures/invalid/leader-attachments-bad.json
+++ b/tools/test/fixtures/invalid/leader-attachments-bad.json
@@ -1,0 +1,8 @@
+[
+  {
+    "leader_id": "warden-sergeant",
+    "eligible_bodyguard_ids": ["ironclad-sentinels"],
+    "max_leaders_per_unit": 2,
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
+  }
+]

--- a/tools/test/fixtures/invalid/units-bad.json
+++ b/tools/test/fixtures/invalid/units-bad.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "bad-attachment-role",
+    "name": "Bad Attachment Role",
+    "faction_id": "test-faction",
+    "role": "character",
+    "attachment_role": "leader-and-support",
+    "profiles": [
+      { "M": 6, "T": 4, "W": 4, "Sv": 3, "invuln_sv": null, "Ld": 6, "OC": 1 }
+    ],
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
+  }
+]

--- a/tools/test/fixtures/valid/detachments-good.json
+++ b/tools/test/fixtures/valid/detachments-good.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "dp-detachment",
+    "name": "DP Detachment",
+    "faction_id": "test-faction",
+    "detachment_points": 2,
+    "force_dispositions": ["take-and-hold", "disruption"],
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
+  }
+]

--- a/tools/test/fixtures/valid/enhancements-good.json
+++ b/tools/test/fixtures/valid/enhancements-good.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "tag-enhancement",
+    "name": "Tag Enhancement",
+    "detachment_id": "test-detachment",
+    "cost": 10,
+    "points_provisional": true,
+    "upgrade_tag": true,
+    "max_targets": 3,
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
+  }
+]

--- a/tools/test/fixtures/valid/force-dispositions-good.json
+++ b/tools/test/fixtures/valid/force-dispositions-good.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "take-and-hold",
+    "name": "Take and Hold",
+    "text": "An army oriented toward seizing and controlling ground.",
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
+  }
+]

--- a/tools/test/fixtures/valid/units-good.json
+++ b/tools/test/fixtures/valid/units-good.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "support-character",
+    "name": "Support Character",
+    "faction_id": "test-faction",
+    "role": "character",
+    "attachment_role": "support",
+    "profiles": [
+      { "M": 6, "T": 4, "W": 4, "Sv": 3, "invuln_sv": null, "Ld": 6, "OC": 1 }
+    ],
+    "points": [{ "models": 1, "cost": 55 }],
+    "points_provisional": true,
+    "game_version": { "edition": "11th", "dataslate": "pre-launch-provisional" }
+  }
+]

--- a/tools/test/schema-loader.test.ts
+++ b/tools/test/schema-loader.test.ts
@@ -21,6 +21,7 @@ describe("schema-loader", () => {
     expect(ids).toContain("https://40kdc.dev/schemas/core/wargear-option.schema.json");
     expect(ids).toContain("https://40kdc.dev/schemas/core/leader-attachment.schema.json");
     expect(ids).toContain("https://40kdc.dev/schemas/core/unit-composition.schema.json");
+    expect(ids).toContain("https://40kdc.dev/schemas/core/force-disposition.schema.json");
     expect(ids).toContain("https://40kdc.dev/schemas/enrichment/phase-mapping.schema.json");
     expect(ids).toContain("https://40kdc.dev/schemas/enrichment/timing-flag.schema.json");
     expect(ids).toContain("https://40kdc.dev/schemas/enrichment/interaction-flag.schema.json");


### PR DESCRIPTION
## Why

These are the four Section 2 schema bumps that the 11e data-port playbook (Section 6.4, "Orks canary") names as prerequisites. The port script can't write the new 11e fields into ported data until the schemas accept them, so the schemas land first against a known-good target.

## What lands

**Schema changes** (`schemas/core/`):
- `unit` — `attachment_role: "leader" | "support" | null`. `"support"` is documented to imply the unit is only legal when attached to a host (cannot be taken solo); enforced by list-builders rather than a second field. Also `points_provisional: boolean`.
- `enhancement` — `upgrade_tag: boolean` + `max_targets: integer (≥1)` for the 11e "applies to up to 3 units, counts as one choice" rule. Also `points_provisional`.
- `detachment` — `detachment_points: 1–3 | null` and `force_dispositions: [entity-id]`.
- `leader-attachment` — **removed** `max_leaders_per_unit`. The 10e Support workaround is replaced by `attachment_role` on the character unit.
- **New** `force-disposition` schema — id constrained to the five confirmed launch dispositions; community-authored `text` only (no reproduced rules text).

**Supporting:**
- Widened the `dataslate-version` pattern to accept named kebab-case slugs (e.g. `pre-launch-provisional`) alongside quarterly tags — the prior `^\d{4}-q[1-4]$` rejected the provisional seed dataslate. Existing quarterly slates remain valid.
- `force-dispositions` wired into `SCHEMA_MAP` + the schema-loader test.
- Example data exercises every new field; new `force-dispositions.example.json`.
- Valid + invalid fixtures for each new constraint.

## Validation

`npm test` 9/9, `npm run validate` 44/44.

## Notes

- All schema additions are optional/defaulted, so existing 10e example data stays valid (only `leader-attachments` needed the dropped field removed).
- Section 2 checkbox ticking in `11e-migration.md` is intentionally **not** in this PR — that file is also touched by #4; the boxes get ticked in a follow-up once #4 merges, to avoid a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)