### PR TITLE
fix: apply rustfmt to unblock CI

### DIFF
--- a/crates/wh40kdc/src/import/mod.rs
+++ b/crates/wh40kdc/src/import/mod.rs
@@ -208,7 +208,10 @@ fn looks_like_listforge_encoded(input: &str) -> bool {
     if input.contains("/listforge/") {
         return true;
     }
-    let lower = input.get(..8).map(str::to_ascii_lowercase).unwrap_or_default();
+    let lower = input
+        .get(..8)
+        .map(str::to_ascii_lowercase)
+        .unwrap_or_default();
     if lower.starts_with("http://") || lower.starts_with("https://") {
         return true;
     }

--- a/crates/wh40kdc/tests/try_import_roster.rs
+++ b/crates/wh40kdc/tests/try_import_roster.rs
@@ -74,11 +74,7 @@ fn positive_auto_detect_per_format() {
         match try_import_roster(&f.input, ds) {
             ImportResult::Ok { roster, format } => {
                 assert_eq!(format, f.format, "wrong format for {}", f.label);
-                assert!(
-                    !roster.units.is_empty(),
-                    "empty units for {}",
-                    f.label
-                );
+                assert!(!roster.units.is_empty(), "empty units for {}", f.label);
                 assert_eq!(roster.source.format, f.format);
             }
             ImportResult::Err {
@@ -129,9 +125,7 @@ fn rejects_empty_input() {
 fn rejects_base64_shaped_but_not_gzip() {
     let ds = Dataset::embedded();
     match try_import_roster("H4sIAAAAnotreallygzip====", ds) {
-        ImportResult::Err {
-            reason, trials, ..
-        } => {
+        ImportResult::Err { reason, trials, .. } => {
             assert_eq!(reason, ImportFailureReason::DecodeFailed);
             assert_eq!(trials[0].id, RosterFormat::Listforge);
         }
@@ -154,9 +148,7 @@ fn rejects_malformed_json() {
 fn rejects_unknown_json_shape() {
     let ds = Dataset::embedded();
     match try_import_roster(r#"{"hello":"world"}"#, ds) {
-        ImportResult::Err {
-            reason, trials, ..
-        } => {
+        ImportResult::Err { reason, trials, .. } => {
             assert_eq!(reason, ImportFailureReason::NoAdapterMatched);
             // Every adapter should have been polled.
             assert_eq!(trials.len(), 5);


### PR DESCRIPTION
## Why

`main` was red. The `rust` job in **Validate Data** failed at `cargo fmt --all -- --check`, which also blocks the `publish-crate`/`publish-npm` jobs that `needs:` it. Two files had drifted from rustfmt's canonical style.

This is a pure formatting change (no logic) produced by `cargo fmt --all`:
- `crates/wh40kdc/src/import/mod.rs` — wrap a method chain
- `crates/wh40kdc/tests/try_import_roster.rs` — collapse `match`/`assert!` arms

Verified locally: `cargo fmt --all -- --check` is clean, `cargo build --workspace` and `cargo test --workspace` pass.

> The separate **GitHub Pages** failure was a repo-settings issue (Pages not enabled) and was fixed out-of-band; it's unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)