### PR TITLE
feat: translator handles defender-side roll-modifier; shadowfield data fix

### DIFF
--- a/data/_audit/coverage.json
+++ b/data/_audit/coverage.json
@@ -15,243 +15,243 @@
       "faction": "adepta-sororitas",
       "total": 80,
       "offensive": 21,
-      "defensive": 6,
+      "defensive": 8,
       "inert": 53,
       "stub": 14,
       "stubStructural": 7,
       "gwTextLeak": 0,
-      "defensiveSkipped": 3
+      "defensiveSkipped": 1
     },
     {
       "faction": "adeptus-astartes",
       "total": 344,
       "offensive": 109,
-      "defensive": 24,
+      "defensive": 39,
       "inert": 211,
       "stub": 25,
       "stubStructural": 10,
       "gwTextLeak": 0,
-      "defensiveSkipped": 21
+      "defensiveSkipped": 7
     },
     {
       "faction": "adeptus-custodes",
       "total": 65,
       "offensive": 13,
-      "defensive": 7,
+      "defensive": 11,
       "inert": 45,
       "stub": 4,
       "stubStructural": 1,
       "gwTextLeak": 0,
-      "defensiveSkipped": 7
+      "defensiveSkipped": 3
     },
     {
       "faction": "adeptus-mechanicus",
       "total": 71,
       "offensive": 13,
-      "defensive": 7,
+      "defensive": 10,
       "inert": 51,
       "stub": 1,
       "stubStructural": 1,
       "gwTextLeak": 0,
-      "defensiveSkipped": 4
+      "defensiveSkipped": 2
     },
     {
       "faction": "aeldari",
       "total": 151,
       "offensive": 33,
-      "defensive": 7,
-      "inert": 111,
+      "defensive": 13,
+      "inert": 110,
       "stub": 19,
       "stubStructural": 12,
       "gwTextLeak": 0,
-      "defensiveSkipped": 10
+      "defensiveSkipped": 5
     },
     {
       "faction": "agents-of-the-imperium",
       "total": 92,
       "offensive": 23,
-      "defensive": 6,
+      "defensive": 8,
       "inert": 63,
       "stub": 3,
       "stubStructural": 3,
       "gwTextLeak": 0,
-      "defensiveSkipped": 3
+      "defensiveSkipped": 2
     },
     {
       "faction": "astra-militarum",
       "total": 148,
       "offensive": 35,
-      "defensive": 11,
+      "defensive": 14,
       "inert": 102,
       "stub": 7,
       "stubStructural": 5,
       "gwTextLeak": 0,
-      "defensiveSkipped": 7
+      "defensiveSkipped": 5
     },
     {
       "faction": "chaos-daemons",
       "total": 123,
       "offensive": 34,
-      "defensive": 8,
+      "defensive": 14,
       "inert": 81,
       "stub": 14,
       "stubStructural": 7,
       "gwTextLeak": 0,
-      "defensiveSkipped": 9
+      "defensiveSkipped": 4
     },
     {
       "faction": "chaos-knights",
       "total": 41,
       "offensive": 18,
-      "defensive": 0,
+      "defensive": 1,
       "inert": 23,
       "stub": 4,
       "stubStructural": 2,
       "gwTextLeak": 0,
-      "defensiveSkipped": 1
+      "defensiveSkipped": 0
     },
     {
       "faction": "chaos-space-marines",
       "total": 182,
       "offensive": 47,
-      "defensive": 9,
+      "defensive": 16,
       "inert": 126,
       "stub": 26,
       "stubStructural": 12,
       "gwTextLeak": 0,
-      "defensiveSkipped": 12
+      "defensiveSkipped": 6
     },
     {
       "faction": "death-guard",
       "total": 89,
       "offensive": 19,
-      "defensive": 4,
+      "defensive": 7,
       "inert": 66,
       "stub": 10,
       "stubStructural": 6,
       "gwTextLeak": 0,
-      "defensiveSkipped": 6
+      "defensiveSkipped": 3
     },
     {
       "faction": "drukhari",
       "total": 76,
       "offensive": 19,
-      "defensive": 3,
-      "inert": 54,
+      "defensive": 6,
+      "inert": 53,
       "stub": 15,
       "stubStructural": 10,
       "gwTextLeak": 0,
-      "defensiveSkipped": 3
+      "defensiveSkipped": 1
     },
     {
       "faction": "emperors-children",
       "total": 61,
       "offensive": 12,
-      "defensive": 2,
+      "defensive": 3,
       "inert": 47,
       "stub": 12,
       "stubStructural": 6,
       "gwTextLeak": 0,
-      "defensiveSkipped": 2
+      "defensiveSkipped": 1
     },
     {
       "faction": "genestealer-cults",
       "total": 63,
       "offensive": 13,
-      "defensive": 4,
+      "defensive": 6,
       "inert": 46,
       "stub": 2,
       "stubStructural": 2,
       "gwTextLeak": 0,
-      "defensiveSkipped": 2
+      "defensiveSkipped": 1
     },
     {
       "faction": "grey-knights",
       "total": 52,
       "offensive": 14,
-      "defensive": 4,
+      "defensive": 5,
       "inert": 34,
       "stub": 3,
       "stubStructural": 1,
       "gwTextLeak": 0,
-      "defensiveSkipped": 2
+      "defensiveSkipped": 1
     },
     {
       "faction": "imperial-knights",
       "total": 45,
       "offensive": 21,
-      "defensive": 1,
+      "defensive": 3,
       "inert": 23,
       "stub": 7,
       "stubStructural": 2,
       "gwTextLeak": 0,
-      "defensiveSkipped": 3
+      "defensiveSkipped": 1
     },
     {
       "faction": "leagues-of-votann",
       "total": 54,
       "offensive": 13,
-      "defensive": 5,
+      "defensive": 7,
       "inert": 36,
       "stub": 1,
       "stubStructural": 1,
       "gwTextLeak": 0,
-      "defensiveSkipped": 2
+      "defensiveSkipped": 1
     },
     {
       "faction": "necrons",
       "total": 122,
       "offensive": 22,
-      "defensive": 13,
+      "defensive": 21,
       "inert": 87,
       "stub": 10,
       "stubStructural": 8,
       "gwTextLeak": 0,
-      "defensiveSkipped": 8
+      "defensiveSkipped": 1
     },
     {
       "faction": "orks",
       "total": 118,
       "offensive": 29,
-      "defensive": 8,
+      "defensive": 12,
       "inert": 81,
       "stub": 6,
       "stubStructural": 1,
       "gwTextLeak": 0,
-      "defensiveSkipped": 6
+      "defensiveSkipped": 3
     },
     {
       "faction": "tau-empire",
       "total": 113,
       "offensive": 32,
-      "defensive": 4,
+      "defensive": 7,
       "inert": 77,
       "stub": 7,
       "stubStructural": 4,
       "gwTextLeak": 0,
-      "defensiveSkipped": 5
+      "defensiveSkipped": 3
     },
     {
       "faction": "thousand-sons",
       "total": 95,
       "offensive": 25,
-      "defensive": 3,
+      "defensive": 8,
       "inert": 67,
       "stub": 20,
       "stubStructural": 13,
       "gwTextLeak": 0,
-      "defensiveSkipped": 6
+      "defensiveSkipped": 2
     },
     {
       "faction": "tyranids",
       "total": 89,
       "offensive": 19,
-      "defensive": 5,
+      "defensive": 7,
       "inert": 66,
       "stub": 7,
       "stubStructural": 2,
       "gwTextLeak": 0,
-      "defensiveSkipped": 7
+      "defensiveSkipped": 6
     },
     {
       "faction": "world-eaters",
@@ -268,12 +268,12 @@
   "totals": {
     "total": 2397,
     "offensive": 598,
-    "defensive": 148,
-    "inert": 1652,
+    "defensive": 233,
+    "inert": 1650,
     "stub": 217,
     "stubStructural": 116,
     "gwTextLeak": 0,
-    "defensiveSkipped": 129
+    "defensiveSkipped": 59
   },
   "unsupportedReasons": [
     {
@@ -495,7 +495,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -1035,7 +1035,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -1915,7 +1915,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -1925,7 +1925,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -2045,7 +2045,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -2115,7 +2115,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -2335,7 +2335,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -2645,7 +2645,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -2775,7 +2775,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -2925,7 +2925,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -2955,7 +2955,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -3175,7 +3175,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -3555,7 +3555,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -4225,7 +4225,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -4445,7 +4445,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -4475,7 +4475,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -4495,7 +4495,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -4785,7 +4785,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -4915,7 +4915,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -4925,7 +4925,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -5165,7 +5165,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -5535,7 +5535,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -5625,7 +5625,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -6075,7 +6075,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -6185,7 +6185,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -6285,7 +6285,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -7145,7 +7145,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -7295,7 +7295,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -7325,7 +7325,7 @@
       "shape": "invulnerable-save",
       "stub": false,
       "offensive": false,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -7405,7 +7405,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -7855,7 +7855,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -8045,7 +8045,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -8795,7 +8795,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -9095,7 +9095,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -9365,7 +9365,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -10225,7 +10225,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -10365,7 +10365,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -10515,7 +10515,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -11005,7 +11005,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -11025,7 +11025,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -11035,7 +11035,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -11465,7 +11465,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -11785,7 +11785,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -11825,7 +11825,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -12235,7 +12235,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -12355,7 +12355,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -12435,7 +12435,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -12865,7 +12865,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -13245,7 +13245,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -13795,7 +13795,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -14025,7 +14025,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -14275,7 +14275,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -14525,7 +14525,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -14835,7 +14835,7 @@
       "shape": "invulnerable-save",
       "stub": false,
       "offensive": false,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -14885,7 +14885,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -15175,7 +15175,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -15735,7 +15735,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -16185,7 +16185,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -16815,7 +16815,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -16975,7 +16975,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -17225,7 +17225,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -17495,7 +17495,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -17565,7 +17565,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -17955,7 +17955,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -18295,7 +18295,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -18435,7 +18435,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -18455,7 +18455,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -18585,7 +18585,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -18785,7 +18785,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -18875,7 +18875,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -18995,7 +18995,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -19175,7 +19175,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -19385,7 +19385,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -19965,7 +19965,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -20005,7 +20005,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -20425,7 +20425,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -20535,7 +20535,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -20715,7 +20715,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -21615,7 +21615,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -21845,7 +21845,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -21915,7 +21915,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -22045,7 +22045,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -22245,7 +22245,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -22565,7 +22565,7 @@
       "shape": "roll-modifier",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {
@@ -22865,7 +22865,7 @@
       "shape": "conditional",
       "stub": false,
       "offensive": true,
-      "defensive": false,
+      "defensive": true,
       "gap": null
     },
     {

--- a/data/_audit/summary.md
+++ b/data/_audit/summary.md
@@ -7,30 +7,30 @@ abilities that translate into cruncher buffs via the real `effectToBuffs`
 | faction | total | offensive | defensive | inert | stub* | notes-stub | gw-leak | def-skipped |
 |---|--:|--:|--:|--:|--:|--:|--:|--:|
 | _core | 1 | 0 | 1 | 0 | 0 | 0 | 0 | 0 |
-| adepta-sororitas | 80 | 21 | 6 | 53 | 7 | 14 | 0 | 3 |
-| adeptus-astartes | 344 | 109 | 24 | 211 | 10 | 25 | 0 | 21 |
-| adeptus-custodes | 65 | 13 | 7 | 45 | 1 | 4 | 0 | 7 |
-| adeptus-mechanicus | 71 | 13 | 7 | 51 | 1 | 1 | 0 | 4 |
-| aeldari | 151 | 33 | 7 | 111 | 12 | 19 | 0 | 10 |
-| agents-of-the-imperium | 92 | 23 | 6 | 63 | 3 | 3 | 0 | 3 |
-| astra-militarum | 148 | 35 | 11 | 102 | 5 | 7 | 0 | 7 |
-| chaos-daemons | 123 | 34 | 8 | 81 | 7 | 14 | 0 | 9 |
-| chaos-knights | 41 | 18 | 0 | 23 | 2 | 4 | 0 | 1 |
-| chaos-space-marines | 182 | 47 | 9 | 126 | 12 | 26 | 0 | 12 |
-| death-guard | 89 | 19 | 4 | 66 | 6 | 10 | 0 | 6 |
-| drukhari | 76 | 19 | 3 | 54 | 10 | 15 | 0 | 3 |
-| emperors-children | 61 | 12 | 2 | 47 | 6 | 12 | 0 | 2 |
-| genestealer-cults | 63 | 13 | 4 | 46 | 2 | 2 | 0 | 2 |
-| grey-knights | 52 | 14 | 4 | 34 | 1 | 3 | 0 | 2 |
-| imperial-knights | 45 | 21 | 1 | 23 | 2 | 7 | 0 | 3 |
-| leagues-of-votann | 54 | 13 | 5 | 36 | 1 | 1 | 0 | 2 |
-| necrons | 122 | 22 | 13 | 87 | 8 | 10 | 0 | 8 |
-| orks | 118 | 29 | 8 | 81 | 1 | 6 | 0 | 6 |
-| tau-empire | 113 | 32 | 4 | 77 | 4 | 7 | 0 | 5 |
-| thousand-sons | 95 | 25 | 3 | 67 | 13 | 20 | 0 | 6 |
-| tyranids | 89 | 19 | 5 | 66 | 2 | 7 | 0 | 7 |
+| adepta-sororitas | 80 | 21 | 8 | 53 | 7 | 14 | 0 | 1 |
+| adeptus-astartes | 344 | 109 | 39 | 211 | 10 | 25 | 0 | 7 |
+| adeptus-custodes | 65 | 13 | 11 | 45 | 1 | 4 | 0 | 3 |
+| adeptus-mechanicus | 71 | 13 | 10 | 51 | 1 | 1 | 0 | 2 |
+| aeldari | 151 | 33 | 13 | 110 | 12 | 19 | 0 | 5 |
+| agents-of-the-imperium | 92 | 23 | 8 | 63 | 3 | 3 | 0 | 2 |
+| astra-militarum | 148 | 35 | 14 | 102 | 5 | 7 | 0 | 5 |
+| chaos-daemons | 123 | 34 | 14 | 81 | 7 | 14 | 0 | 4 |
+| chaos-knights | 41 | 18 | 1 | 23 | 2 | 4 | 0 | 0 |
+| chaos-space-marines | 182 | 47 | 16 | 126 | 12 | 26 | 0 | 6 |
+| death-guard | 89 | 19 | 7 | 66 | 6 | 10 | 0 | 3 |
+| drukhari | 76 | 19 | 6 | 53 | 10 | 15 | 0 | 1 |
+| emperors-children | 61 | 12 | 3 | 47 | 6 | 12 | 0 | 1 |
+| genestealer-cults | 63 | 13 | 6 | 46 | 2 | 2 | 0 | 1 |
+| grey-knights | 52 | 14 | 5 | 34 | 1 | 3 | 0 | 1 |
+| imperial-knights | 45 | 21 | 3 | 23 | 2 | 7 | 0 | 1 |
+| leagues-of-votann | 54 | 13 | 7 | 36 | 1 | 1 | 0 | 1 |
+| necrons | 122 | 22 | 21 | 87 | 8 | 10 | 0 | 1 |
+| orks | 118 | 29 | 12 | 81 | 1 | 6 | 0 | 3 |
+| tau-empire | 113 | 32 | 7 | 77 | 4 | 7 | 0 | 3 |
+| thousand-sons | 95 | 25 | 8 | 67 | 13 | 20 | 0 | 2 |
+| tyranids | 89 | 19 | 7 | 66 | 2 | 7 | 0 | 6 |
 | world-eaters | 122 | 14 | 6 | 102 | 0 | 0 | 0 | 0 |
-| **TOTAL** | **2397** | **598** | **148** | **1652** | **116** | **217** | **0** | **129** |
+| **TOTAL** | **2397** | **598** | **233** | **1650** | **116** | **217** | **0** | **59** |
 
 `stub*` = structural (empty-modifier placeholder node) — the authoring worklist. `notes-stub` = flagged in community_notes.
 

--- a/data/enrichment/adepta-sororitas/abilities.json
+++ b/data/enrichment/adepta-sororitas/abilities.json
@@ -31,8 +31,7 @@
       "celestian-sacresants"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "deadly-demise-1",
@@ -1730,8 +1729,7 @@
       "junith-eruita"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "fiery-conviction",

--- a/data/enrichment/adeptus-astartes/abilities.json
+++ b/data/enrichment/adeptus-astartes/abilities.json
@@ -2078,8 +2078,7 @@
       "sanguinary-guard"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "heirs-of-azkaellon",
@@ -2124,8 +2123,7 @@
       "sanguinary-guard"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "sanguinary-banner",
@@ -2498,8 +2496,7 @@
       "inner-circle-companions"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "enmity-for-the-unworthy",
@@ -2722,8 +2719,7 @@
       "nephilim-jetfighter"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "exemplar-of-hate",
@@ -4445,8 +4441,7 @@
       "darnath-lysander"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "rampart",
@@ -4899,8 +4894,7 @@
       "victrix-honour-guard"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "glory-of-ultramar",
@@ -5406,8 +5400,7 @@
       "hammerfall-bunker"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "ceramite-cover",
@@ -5505,8 +5498,7 @@
       "suppressor-squad"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "veil-of-time-psychic",
@@ -6165,8 +6157,7 @@
       "chief-librarian-tigurius"
     ],
     "ability_type": "unit",
-    "behavior": "activated",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "activated"
   },
   {
     "ability_id": "strafing-run",
@@ -7405,8 +7396,7 @@
       "company-heroes"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "company-heroes",
@@ -9635,8 +9625,7 @@
       "ultramarines-honour-guard"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "honour-guard-of-macragge",
@@ -10360,8 +10349,7 @@
       "wolf-guard-terminators"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "bestial-rage",
@@ -10472,8 +10460,7 @@
       "wulfen-with-storm-shields"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "death-totem",
@@ -10537,8 +10524,7 @@
       "bjorn-the-fell-handed"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "ancient-tactician",

--- a/data/enrichment/adeptus-custodes/abilities.json
+++ b/data/enrichment/adeptus-custodes/abilities.json
@@ -188,8 +188,7 @@
       "contemptor-galatus-dreadnought"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "unyielding-ancient",
@@ -555,8 +554,7 @@
       "vigilators"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "saturation-volleys",
@@ -593,8 +591,7 @@
       "sagittarum-custodians"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "disintegration-beams",
@@ -1340,8 +1337,7 @@
       "custodian-wardens"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "living-fortress",

--- a/data/enrichment/adeptus-mechanicus/abilities.json
+++ b/data/enrichment/adeptus-mechanicus/abilities.json
@@ -783,8 +783,7 @@
       "fulgurite-electro-priests"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "blistering-salvoes",
@@ -2323,8 +2322,7 @@
       "secutarii-peltasts"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "doctrina-imperatives",

--- a/data/enrichment/aeldari/abilities.json
+++ b/data/enrichment/aeldari/abilities.json
@@ -624,8 +624,7 @@
       "wave-serpent"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "word-of-the-phoenix-psychic",
@@ -3445,8 +3444,7 @@
       "warlock-conclave"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "guide-psychic",
@@ -3985,8 +3983,7 @@
       "skyweavers"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "overlord",
@@ -4068,8 +4065,7 @@
       "type": "invulnerable-save",
       "target": "self",
       "modifier": {
-        "type": "shadowfield",
-        "fragile": true
+        "invuln_sv": 4
       }
     },
     "scope": {
@@ -4081,7 +4077,7 @@
     ],
     "ability_type": "unit",
     "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "community_notes": "fragile invuln: lost on a failed save (engine reads the 4+; the breaking mechanic is not modelled)"
   },
   {
     "ability_id": "cloudstrider",
@@ -4347,8 +4343,7 @@
       "vyper"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "spiritseer",

--- a/data/enrichment/agents-of-the-imperium/abilities.json
+++ b/data/enrichment/agents-of-the-imperium/abilities.json
@@ -764,8 +764,7 @@
       "inquisitorial-agents"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "tome-skull",

--- a/data/enrichment/astra-militarum/abilities.json
+++ b/data/enrichment/astra-militarum/abilities.json
@@ -1768,8 +1768,7 @@
       "aegis-defence-line"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "deployment",
@@ -2697,8 +2696,7 @@
       "wyvern"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "horsemasters",

--- a/data/enrichment/chaos-daemons/abilities.json
+++ b/data/enrichment/chaos-daemons/abilities.json
@@ -765,8 +765,7 @@
       "nurglings"
     ],
     "ability_type": "unit",
-    "behavior": "activated",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "activated"
   },
   {
     "ability_id": "leader",
@@ -1209,8 +1208,7 @@
       "keeper-of-secrets"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "shining-aegis",
@@ -1747,8 +1745,7 @@
       "feculent-gnarlmaw"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "daemon-lord-of-nurgle-aura",
@@ -3395,8 +3392,7 @@
       "the-changeling"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "fluxmaster",
@@ -3430,8 +3426,7 @@
       "fluxmaster"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "altered-reality-psychic",

--- a/data/enrichment/chaos-knights/abilities.json
+++ b/data/enrichment/chaos-knights/abilities.json
@@ -817,8 +817,7 @@
       "chaos-cerastus-knight-castigator"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "offerings-for-the-dark-gods-aura",

--- a/data/enrichment/chaos-space-marines/abilities.json
+++ b/data/enrichment/chaos-space-marines/abilities.json
@@ -622,8 +622,7 @@
       "sorcerer"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "gift-of-chaos-psychic",
@@ -1994,8 +1993,7 @@
       "noctilith-crown"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "fearsome-aura",
@@ -2404,8 +2402,7 @@
       "chaos-predator-destructor"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "chosen-marauders",
@@ -2656,8 +2653,7 @@
       "forgefiend"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "furious-onslaught",
@@ -4214,8 +4210,7 @@
       "vashtorr-the-arkifane"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "indentured-daemon-engines",
@@ -5312,8 +5307,7 @@
       "mutoid-vermin"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "psychic-barrier-psychic",

--- a/data/enrichment/death-guard/abilities.json
+++ b/data/enrichment/death-guard/abilities.json
@@ -1076,8 +1076,7 @@
       "chaos-predator-destructor"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "explosive-blight",
@@ -1958,8 +1957,7 @@
       "miasmic-malignifier"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "dark-ascension-aura",
@@ -2756,8 +2754,7 @@
       "typhus"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "eater-plague-psychic",

--- a/data/enrichment/drukhari/abilities.json
+++ b/data/enrichment/drukhari/abilities.json
@@ -1490,8 +1490,7 @@
       "type": "invulnerable-save",
       "target": "self",
       "modifier": {
-        "type": "shadowfield",
-        "fragile": true
+        "invuln_sv": 4
       }
     },
     "scope": {
@@ -1503,7 +1502,7 @@
     ],
     "ability_type": "unit",
     "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "community_notes": "fragile invuln: lost on a failed save (engine reads the 4+; the breaking mechanic is not modelled)"
   },
   {
     "ability_id": "soul-trap",
@@ -1690,8 +1689,7 @@
       "ravager"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "eradicate-the-foe",

--- a/data/enrichment/emperors-children/abilities.json
+++ b/data/enrichment/emperors-children/abilities.json
@@ -227,8 +227,7 @@
       "sorcerer"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "gift-of-chaos-psychic",

--- a/data/enrichment/genestealer-cults/abilities.json
+++ b/data/enrichment/genestealer-cults/abilities.json
@@ -1493,8 +1493,7 @@
       "aberrants"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "claimed-for-the-cult",

--- a/data/enrichment/grey-knights/abilities.json
+++ b/data/enrichment/grey-knights/abilities.json
@@ -1473,8 +1473,7 @@
       "grand-master-voldus"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "hammer-aflame-psychic",

--- a/data/enrichment/imperial-knights/abilities.json
+++ b/data/enrichment/imperial-knights/abilities.json
@@ -367,8 +367,7 @@
       "cerastus-knight-castigator"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "paladin-s-duty-bondsman",
@@ -1163,8 +1162,7 @@
       "armiger-helverin"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "magaera-s-duty-bondsman",

--- a/data/enrichment/leagues-of-votann/abilities.json
+++ b/data/enrichment/leagues-of-votann/abilities.json
@@ -575,8 +575,7 @@
       "kapricus-carrier"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "smoke-launcher",

--- a/data/enrichment/necrons/abilities.json
+++ b/data/enrichment/necrons/abilities.json
@@ -283,8 +283,7 @@
       "canoptek-macrocytes"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "nanoscarab-projector",
@@ -1416,8 +1415,7 @@
       "convergence-of-dominion"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "deployment",
@@ -1837,8 +1835,7 @@
       "catacomb-command-barge"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "hard-wired-for-destruction",
@@ -1908,8 +1905,7 @@
       "lychguard"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "dispersion-shield",
@@ -3008,8 +3004,7 @@
       "doom-scythe"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "tectonic-reverberations",
@@ -3297,8 +3292,7 @@
       "chronomancer"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "chronometron",
@@ -3687,8 +3681,7 @@
       "anrakyr-the-traveller"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "lord-of-the-pyrrhian-eternals",

--- a/data/enrichment/orks/abilities.json
+++ b/data/enrichment/orks/abilities.json
@@ -327,8 +327,7 @@
       "kustom-boosta-blasta"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "dok-s-toolz",
@@ -3013,8 +3012,7 @@
       "nobz"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "thundering-stampede",
@@ -3130,8 +3128,7 @@
       "boomdakka-snazzwagon"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "firing-deck-20",

--- a/data/enrichment/tau-empire/abilities.json
+++ b/data/enrichment/tau-empire/abilities.json
@@ -891,8 +891,7 @@
       "strike-team"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "ds8-support-turret",
@@ -1477,8 +1476,7 @@
       "tidewall-gunrig"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "tidewall-cover",

--- a/data/enrichment/thousand-sons/abilities.json
+++ b/data/enrichment/thousand-sons/abilities.json
@@ -659,8 +659,7 @@
       "sorcerer"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "gift-of-chaos-psychic",
@@ -1383,8 +1382,7 @@
       "scarab-occult-terminators"
     ],
     "ability_type": "unit",
-    "behavior": "reactive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "reactive"
   },
   {
     "ability_id": "unearthly-power",
@@ -1631,8 +1629,7 @@
       "chaos-predator-destructor"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "daemonforge",
@@ -2796,8 +2793,7 @@
       "forgefiend"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "furious-onslaught",

--- a/data/enrichment/tyranids/abilities.json
+++ b/data/enrichment/tyranids/abilities.json
@@ -1627,8 +1627,7 @@
       "broodlord"
     ],
     "ability_type": "unit",
-    "behavior": "passive",
-    "community_notes": "defensive ability (skipped for damage calc)"
+    "behavior": "passive"
   },
   {
     "ability_id": "spore-mine-cysts",

--- a/tools/src/cruncher/from-dsl.ts
+++ b/tools/src/cruncher/from-dsl.ts
@@ -318,9 +318,22 @@ function translateRollModifier(
     if (!appliesToBuffedUnit(node, "attacker")) return;
     if (roll === "save") return; // saves apply to the defender, not the attacker.
   } else {
-    // target perspective: only `save` rolls on the buffed unit fire here.
-    if (roll !== "save") return;
-    if (!appliesToBuffedUnit(node, "target")) return;
+    // Target perspective accepts two shapes:
+    //  - `target: "self"/"unit"/...` + `roll: "save"` — the buffed unit's
+    //    own save rolls (mirrors the attacker path's reroll/stat handling).
+    //  - `target: "attacker"` + `roll: "hit"/"wound"` — a defender-side
+    //    rule that penalises the *incoming* attacker's hit/wound rolls (e.g.
+    //    "subtract 1 from hit rolls targeting this unit"). Functionally
+    //    identical to a `bs-modifier {target:"attacker"}` but with the
+    //    canonical `roll-modifier` shape; the data uses both forms.
+    const cls = classifyTarget(node);
+    if (cls === "attacker") {
+      if (roll !== "hit" && roll !== "wound") return; // damage/save against the attacker make no sense here.
+    } else if (cls === "self") {
+      if (roll !== "save") return;
+    } else {
+      return;
+    }
   }
   switch (roll) {
     case "hit":

--- a/tools/test/from-dsl.test.ts
+++ b/tools/test/from-dsl.test.ts
@@ -399,6 +399,54 @@ describe("effectToBuffs: target perspective", () => {
     expect(atk.applied).toEqual([]); // saves aren't attacker-side.
   });
 
+  it('roll-modifier {target:"attacker", roll:"hit"} translates to hit-mod (incoming-hit penalty)', () => {
+    // Functionally identical to bs-modifier {target:"attacker"} — both shapes
+    // appear in the corpus for "-1 to hit rolls targeting this unit". The
+    // translator now accepts both.
+    const result = effectToBuffs(
+      {
+        type: "roll-modifier",
+        target: "attacker",
+        modifier: { roll: "hit", operation: "subtract", value: 1 },
+      },
+      unitRule,
+      ctxT,
+      "target",
+    );
+    expect(result.applied[0].contribution).toEqual({ type: "hit-mod", value: -1 });
+    expect(result.unsupported).toEqual([]);
+  });
+
+  it('roll-modifier {target:"attacker", roll:"wound"} translates to wound-mod', () => {
+    const result = effectToBuffs(
+      {
+        type: "roll-modifier",
+        target: "attacker",
+        modifier: { roll: "wound", operation: "subtract", value: 1 },
+      },
+      unitRule,
+      ctxT,
+      "target",
+    );
+    expect(result.applied[0].contribution).toEqual({ type: "wound-mod", value: -1 });
+  });
+
+  it('roll-modifier {target:"attacker", roll:"damage"} is not a defender knob', () => {
+    // Damage rolls belong to the attacker's weapon; a defender-side
+    // "-1 to damage rolls" would be expressed as damage-reduction instead.
+    const result = effectToBuffs(
+      {
+        type: "roll-modifier",
+        target: "attacker",
+        modifier: { roll: "damage", operation: "subtract", value: 1 },
+      },
+      unitRule,
+      ctxT,
+      "target",
+    );
+    expect(result.applied).toEqual([]);
+  });
+
   it("bs-modifier on target: attacker translates to hit-mod under target perspective", () => {
     const result = effectToBuffs(
       {

--- a/tools/test/scrub-defensive-flag.test.ts
+++ b/tools/test/scrub-defensive-flag.test.ts
@@ -40,17 +40,17 @@ describe("scrubDefensiveFlags", () => {
     expect(abilities[0].community_notes).toBe(STALE_FLAG);
   });
 
-  it("leaves the flag on a roll-modifier defender effect the translator can't read yet", () => {
-    // The 69 flagged entries with this shape are blocked on a translator
-    // extension; the scrub correctly identifies them as not-yet-translatable.
+  it("leaves the flag on an ability-grant entry (genuinely outside the buff layer)", () => {
+    // Grants are not stat mods — the buff layer doesn't model them, and they
+    // legitimately remain in the residue worklist for downstream consumers.
     const abilities = [
       {
-        ability_id: "test-cover",
+        ability_id: "test-grant",
         ability_type: "unit",
         effect: {
-          type: "roll-modifier",
-          target: "attacker",
-          modifier: { roll: "hit", operation: "subtract", value: 1 },
+          type: "ability-grant",
+          target: "unit",
+          modifier: { grant_type: "label", value: "stealth" },
         },
         community_notes: STALE_FLAG,
       },


### PR DESCRIPTION
## Why

Two small follow-ons to the defensive engine work (#12) that together unblock 68 more defensive-ability translations.

## What's in the PR

### 1. Translator: `roll-modifier {target:"attacker", roll:"hit"|"wound"}` under target perspective

The corpus uses two equivalent ways to write "subtract 1 from incoming hit rolls":

- `bs-modifier {target:"attacker"}` — recognized by the translator since the start.
- `roll-modifier {target:"attacker", roll:"hit"}` — silently dropped until now.

These are functionally identical (both produce a `hit-mod` buff with the appropriate sign), but **69** of the 127 still-flagged defensive entries used the latter shape. `translateRollModifier` now classifies the target and accepts both branches: `target:"self"/"unit"/...` + `roll:"save"` *or* `target:"attacker"` + `roll:"hit"/"wound"`. `target:"attacker"` + `roll:"damage"` is correctly NOT translated — damage rolls belong to the attacker's weapon, not to a defender knob (defender-side damage reduction is `damage-reduction` per #22).

### 2. Shadowfield data fix

The Aeldari `shadow-field` and Drukhari `shadowfield` entries had hand-rolled modifier shapes (`{type:"shadowfield", fragile:true}`) instead of the canonical `{invuln_sv:N}`. The translator reported `invuln_sv "undefined" is not a valid save threshold` — correctly fail-safe but the data was just wrong. Corrected to `{invuln_sv:4}` and moved the "fragile" / breaking mechanic into a precise `community_notes` (the buff layer doesn't model "this invuln is lost on a failed save" — that's a fine residue, but the threshold itself should be readable).

### 3. Re-scrub

With 1+2 applied, re-running `npm run scrub:defensive-flag` clears 68 more stale `"defensive ability (skipped for damage calc)"` notes across 22 factions.

## Audit shifts (vs main pre-PR)

```
                   before     after
defensive coverage  148       233    (+85)
def-skipped         129        59    (-70)
```

The 59 remaining def-skipped entries are now the true engine residue — `"half"`/`"to-zero"` damage-reductions (deliberately unsupported per #22), `ability-grant` / `mortal-wounds` / movement effects outside the buff-layer domain, and a handful of compound sequences wrapping those.

## Test plan

- [x] `cd tools && npm test` — 492/492 (+3 new in `test/from-dsl.test.ts` covering each branch of the extended translator)
- [x] `cd tools && npm run validate` — 13915/13915
- [x] `cd tools && npm run audit:coverage` — see numbers above
- [x] `cargo test -p wh40kdc` — all green (no engine changes — the buff variants this leans on landed in #12)
- [x] `python3 tooling/parity/differ.py` — OK: 77 cases (no engine drift; the differ confirms TS+Rust still agree on the cruncher math)
- [x] `cargo run -p xtask -- bundle-data` — regenerated (2 abilities changed plus 68 community_notes deletions across 22 files)
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)