### PR TITLE
chore: release 0.2.0 — defensive engine + cross-impl parity tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "wh40kdc"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "base64",
  "chrono",

--- a/crates/wh40kdc/Cargo.toml
+++ b/crates/wh40kdc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wh40kdc"
-version = "0.1.3"
+version = "0.2.0"
 description = "Warhammer 40K dataset for the 40kdc-data schema layer: generated types, an embedded dataset behind a linked typed API, plus ListForge + NewRecruit roster importers and exporters."
 readme = "README.md"
 keywords = ["warhammer", "40k", "wargaming", "schema", "serde"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1656,7 +1656,7 @@
     },
     "tools": {
       "name": "@alpaca-software/40kdc-data",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.0",
@@ -1666,6 +1666,7 @@
         "glob": "^11.0.0"
       },
       "bin": {
+        "40kdc-runner": "dist/runner.js",
         "40kdc-validate": "dist/cli.js"
       },
       "devDependencies": {

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alpaca-software/40kdc-data",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "type": "module",
   "description": "The 40kdc Warhammer 40K dataset behind a linked, typed API — find units, follow them to their weapons, abilities, phases, and factions. Also validates data against the canonical JSON Schemas.",
   "keywords": [


### PR DESCRIPTION
## Release: 0.2.0

Bumps both packages from 0.1.3 → 0.2.0. The CI `publish-crate` and `publish-npm` jobs auto-fire on main once green and the version isn't already on the registry.

## Changes since 0.1.3

### Cross-impl parity tooling — #11
- `tooling/parity/differ.py`: cross-impl differ + property fuzz, drives TS and Rust runners against the corpus and reports byte-level divergence within documented per-area tolerances.
- `crates/wh40kdc/src/bin/wh40kdc-runner.rs`: Rust counterpart to the TS runner, identical NDJSON wire protocol.
- `.github/workflows/parity.yml` runs the differ on push + PR (corpus + 200 fuzz seeds each on normalize and crunch).
- Normalize: `\p{Diacritic}` → `\p{M}` — the differ's first fuzz run caught the divergence with Rust's `is_combining_mark`. `SPEC_VERSION` 6 → 7.

### Defensive damage engine — #12
- New `BuffContribution` variants in both TS (`buffs.ts`) and Rust (`buffs.rs`):
  - `damage-reduction` — highest-wins, applied at the damage stage with a canonical "min 1" floor (only when reduction is active).
  - `invulnerable-save` — best-threshold-wins, combined with the unit's printed invuln; invuln bypasses AP and cover.
  - `feel-no-pain` extended with `scope?: "all" | "mortal"` — independent rolls per scope, with the mortal-only path firing on the existing `damageMortal` stream produced by `devastating-wounds`. Kills the `engine.ts:225` TODO.
- `from-dsl.ts` target-perspective translators for all three. Attacker-perspective walks drop silently.
- Three new `conformance/cruncher` cases (`08`, `09`, `10`); both impls byte-identical.
- `SPEC_VERSION` 7 → 8.

### Defensive-flag scrub — #13
- New `tools/src/scrub-defensive-flag.ts`: deterministic codemod that strips the stale `"defensive ability (skipped for damage calc)"` `community_notes` flag from entries the engine now reads. Idempotent.
- `npm run scrub:defensive-flag` (with `--check` mode for CI).
- 48 entries cleared across 19 factions.

### Translator extension + data fix — #14
- `translateRollModifier` accepts `roll-modifier {target:"attacker", roll:"hit"|"wound"}` as a defender-side incoming-roll penalty (functionally identical to `bs-modifier {target:"attacker"}`, the canonical form). Unblocks 69 corpus entries that used the alternate spelling.
- Two Drukhari/Aeldari Shadowfield entries had a hand-rolled `{type:"shadowfield", fragile:true}` modifier; corrected to canonical `{invuln_sv:4}` with a precise `community_notes` documenting the breakable mechanic.
- Re-scrub: 68 more entries cleared.

## Cumulative coverage shift (vs 0.1.3)

```
                    0.1.3       0.2.0
defensive coverage     96         233    (more than doubled)
def-skipped flags     177          59
conformance cases      74          77
TS test count         460         492
```

## Compatibility notes

- Schema changes are additive only. `effect.schema.json` gains a `$comment` documenting `feel-no-pain.modifier.scope`; `modifier` objects remain `additionalProperties: true`, so new keys cannot break existing data files.
- `RUNNER_PROTOCOL.md` adds the `attribution` op spec (previously implemented but not documented).
- The new `BuffContribution` variants are additive — existing wire-format buffs deserialize unchanged.
- Existing data files that carried `community_notes: "defensive ability (skipped for damage calc)"` now have either no note (cleared by the scrub) or a more specific note. Downstream consumers that hard-coded a check for the sentinel string should switch to reading the audit's `def-skipped` column from `data/_audit/summary.md`.

## Test plan

- [x] `cd tools && npm test` — 492/492
- [x] `cargo test -p wh40kdc` — all green
- [x] `cd tools && npm run validate` — 13915/13915
- [x] `python3 tooling/parity/differ.py` — OK: 77 cases, ts=0.2.0 rust=0.2.0
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo run -p xtask -- bundle-data` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)