### PR TITLE
fix: load the editor chunk CSS on #edit — split the ternary dynamic imports

### DIFF
--- a/examples/layout-editor/src/main.ts
+++ b/examples/layout-editor/src/main.ts
@@ -4,11 +4,24 @@ import "./app.css";
 // Viewer by default; the authoring editor stays behind #edit. The dynamic
 // imports keep the two as split bundles, so the editor's model/board weight
 // never loads for viewers.
+//
+// Each import() must be its own statement. Vite wraps every dynamic import in
+// a CSS-preload helper, and a `cond ? import(a) : import(b)` ternary gets a
+// single wrapper with one shared deps array — the other branch's chunk CSS
+// then never loads (#edit shipped unstyled this way).
 const editor = location.hash === "#edit";
-const load = editor ? import("./App.svelte") : import("./Viewer.svelte");
-void load.then(({ default: Root }) => {
-  mount(Root, { target: document.getElementById("app")! });
-});
+
+async function boot(): Promise<void> {
+  const target = document.getElementById("app")!;
+  if (editor) {
+    const { default: Root } = await import("./App.svelte");
+    mount(Root, { target });
+  } else {
+    const { default: Root } = await import("./Viewer.svelte");
+    mount(Root, { target });
+  }
+}
+void boot();
 
 // The mode is decided at boot; flipping the hash mid-session reloads into the
 // other app rather than hot-swapping component trees.


### PR DESCRIPTION
The viewer/editor code-split left https://layout-editor.alpacasoft.dev/#edit completely unstyled. Vite injects a code-split chunk's CSS through the importer's `__vitePreload(() => import(chunk), deps)` wrapper — but `editor ? import("./App.svelte") : import("./Viewer.svelte")` got a **single** wrapper around the whole ternary with one shared deps array, and it carried only the Viewer branch's deps. On `#edit` the browser still fetched the App JS natively (so the editor mounted and worked), but `App-*.css` was never attached. No console errors, no failed requests — just an unstyled page. The default viewer route was unaffected, which is why only `#edit` looked broken.

Fix: boot each branch from its own `import()` statement so Vite gives each its own preload deps. Verified in the built output (two `__vite__mapDeps` calls; the App branch now includes `App-*.css`) and headlessly via playwright against `vite preview` — both routes attach their correct stylesheet and render styled. `svelte-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)