### PR TITLE
feat: listforge-text import adapter + newrecruit-simple edge cases, bump 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "wh40kdc"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "chrono",

--- a/conformance/roster/cd-daemonic-incursion/expected.newrecruit-json.json
+++ b/conformance/roster/cd-daemonic-incursion/expected.newrecruit-json.json
@@ -1,0 +1,343 @@
+{
+  "name": "all gas no breaks",
+  "generatedBy": "https://newrecruit.eu",
+  "roster": {
+    "name": "all gas no breaks",
+    "xmlns": "http://www.battlescribe.net/schema/rosterSchema",
+    "generatedBy": "https://newrecruit.eu",
+    "costs": [
+      {
+        "name": "pts",
+        "typeId": "pts-type",
+        "value": 795
+      }
+    ],
+    "forces": [
+      {
+        "id": "force-1",
+        "name": "Army Roster",
+        "catalogueName": "Chaos Daemons",
+        "selections": [
+          {
+            "id": "cfg-battle-size",
+            "name": "Battle Size",
+            "type": "upgrade",
+            "number": 1,
+            "categories": [
+              {
+                "name": "Configuration",
+                "primary": true
+              }
+            ],
+            "selections": [
+              {
+                "id": "cfg-battle-size-val",
+                "name": "Strike Force (1995 Point limit)",
+                "type": "upgrade",
+                "number": 1
+              }
+            ]
+          },
+          {
+            "id": "cfg-detachment",
+            "name": "Detachment",
+            "type": "upgrade",
+            "number": 1,
+            "categories": [
+              {
+                "name": "Configuration",
+                "primary": true
+              }
+            ],
+            "selections": [
+              {
+                "id": "cfg-detachment-val",
+                "name": "Daemonic Incursion",
+                "type": "upgrade",
+                "number": 1
+              }
+            ]
+          },
+          {
+            "id": "u-0",
+            "name": "Rotigus",
+            "type": "model",
+            "number": 1,
+            "categories": [
+              {
+                "name": "Faction: Chaos Daemons",
+                "primary": false
+              }
+            ],
+            "costs": [
+              {
+                "name": "pts",
+                "typeId": "pts-type",
+                "value": 250
+              }
+            ],
+            "selections": [
+              {
+                "id": "w-0",
+                "name": "Gnarlrod",
+                "type": "upgrade",
+                "number": 1,
+                "categories": [
+                  {
+                    "name": "Ranged Weapon",
+                    "primary": false
+                  }
+                ]
+              },
+              {
+                "id": "w-1",
+                "name": "Streams of brackish filth",
+                "type": "upgrade",
+                "number": 1,
+                "categories": [
+                  {
+                    "name": "Ranged Weapon",
+                    "primary": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "u-1",
+            "name": "Great Unclean One",
+            "type": "model",
+            "number": 1,
+            "categories": [
+              {
+                "name": "Faction: Chaos Daemons",
+                "primary": false
+              }
+            ],
+            "costs": [
+              {
+                "name": "pts",
+                "typeId": "pts-type",
+                "value": 295
+              }
+            ],
+            "selections": [
+              {
+                "id": "u1-warlord",
+                "name": "Warlord",
+                "type": "upgrade",
+                "number": 1
+              },
+              {
+                "id": "u1-enh",
+                "name": "The Endless Gift",
+                "type": "upgrade",
+                "number": 1,
+                "group": "Enhancements"
+              },
+              {
+                "id": "w-0",
+                "name": "Putrid vomit",
+                "type": "upgrade",
+                "number": 1,
+                "categories": [
+                  {
+                    "name": "Ranged Weapon",
+                    "primary": false
+                  }
+                ]
+              },
+              {
+                "id": "w-1",
+                "name": "Bileblade",
+                "type": "upgrade",
+                "number": 1,
+                "categories": [
+                  {
+                    "name": "Ranged Weapon",
+                    "primary": false
+                  }
+                ]
+              },
+              {
+                "id": "w-2",
+                "name": "Bilesword",
+                "type": "upgrade",
+                "number": 1,
+                "categories": [
+                  {
+                    "name": "Ranged Weapon",
+                    "primary": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "u-2",
+            "name": "Bloodmaster",
+            "type": "model",
+            "number": 1,
+            "categories": [
+              {
+                "name": "Faction: Chaos Daemons",
+                "primary": false
+              }
+            ],
+            "costs": [
+              {
+                "name": "pts",
+                "typeId": "pts-type",
+                "value": 65
+              }
+            ],
+            "selections": [
+              {
+                "id": "w-0",
+                "name": "Blade of blood",
+                "type": "upgrade",
+                "number": 1,
+                "categories": [
+                  {
+                    "name": "Ranged Weapon",
+                    "primary": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "u-3",
+            "name": "Bloodletters",
+            "type": "unit",
+            "number": 1,
+            "categories": [
+              {
+                "name": "Faction: Chaos Daemons",
+                "primary": false
+              }
+            ],
+            "costs": [
+              {
+                "name": "pts",
+                "typeId": "pts-type",
+                "value": 110
+              }
+            ],
+            "selections": [
+              {
+                "id": "u3-model",
+                "name": "Bloodletters",
+                "type": "model",
+                "number": 10,
+                "selections": [
+                  {
+                    "id": "w-0",
+                    "name": "Hellblade",
+                    "type": "upgrade",
+                    "number": 10,
+                    "categories": [
+                      {
+                        "name": "Ranged Weapon",
+                        "primary": false
+                      }
+                    ]
+                  },
+                  {
+                    "id": "w-1",
+                    "name": "Instrument of Chaos",
+                    "type": "upgrade",
+                    "number": 1,
+                    "categories": [
+                      {
+                        "name": "Ranged Weapon",
+                        "primary": false
+                      }
+                    ]
+                  },
+                  {
+                    "id": "w-2",
+                    "name": "Daemonic Icon",
+                    "type": "upgrade",
+                    "number": 1,
+                    "categories": [
+                      {
+                        "name": "Ranged Weapon",
+                        "primary": false
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "u-4",
+            "name": "Flesh Hounds",
+            "type": "unit",
+            "number": 1,
+            "categories": [
+              {
+                "name": "Faction: Chaos Daemons",
+                "primary": false
+              }
+            ],
+            "costs": [
+              {
+                "name": "pts",
+                "typeId": "pts-type",
+                "value": 75
+              }
+            ],
+            "selections": [
+              {
+                "id": "u4-model",
+                "name": "Flesh Hounds",
+                "type": "model",
+                "number": 5,
+                "selections": [
+                  {
+                    "id": "w-0",
+                    "name": "Burning maw",
+                    "type": "upgrade",
+                    "number": 1,
+                    "categories": [
+                      {
+                        "name": "Ranged Weapon",
+                        "primary": false
+                      }
+                    ]
+                  },
+                  {
+                    "id": "w-1",
+                    "name": "Collar of Khorne",
+                    "type": "upgrade",
+                    "number": 5,
+                    "categories": [
+                      {
+                        "name": "Ranged Weapon",
+                        "primary": false
+                      }
+                    ]
+                  },
+                  {
+                    "id": "w-2",
+                    "name": "Gore-drenched fangs",
+                    "type": "upgrade",
+                    "number": 5,
+                    "categories": [
+                      {
+                        "name": "Ranged Weapon",
+                        "primary": false
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/conformance/roster/cd-daemonic-incursion/expected.newrecruit-simple.txt
+++ b/conformance/roster/cd-daemonic-incursion/expected.newrecruit-simple.txt
@@ -1,0 +1,15 @@
+Chaos Daemons - all gas no breaks - [1995 pts]
+
+# ++ Army Roster ++ [795 pts]
+## Configuration
+Battle Size: Strike Force (1995 Point limit)
+Detachment: Daemonic Incursion
+
+## Battleline [795 pts]
+Rotigus [250 pts]: Gnarlrod, Streams of brackish filth
+Great Unclean One [295 pts]: The Endless Gift, Warlord, Putrid vomit, Bileblade, Bilesword
+Bloodmaster [65 pts]: Blade of blood
+Bloodletters [110 pts]:
+• 10x Bloodletters: 10x Hellblade, Instrument of Chaos, Daemonic Icon
+Flesh Hounds [75 pts]:
+• 5x Flesh Hounds: Burning maw, 5x Collar of Khorne, 5x Gore-drenched fangs

--- a/conformance/roster/cd-daemonic-incursion/expected.newrecruit-wtc-compact.txt
+++ b/conformance/roster/cd-daemonic-incursion/expected.newrecruit-wtc-compact.txt
@@ -1,0 +1,18 @@
++++++++++++++++++++++++++++++++++++++++++++++++
++ LIST NAME: all gas no breaks
++ FACTION KEYWORD: Chaos Daemons
++ DETACHMENT: Daemonic Incursion
++ TOTAL ARMY POINTS: 1995pts
++ POINTS LIMIT: 1995pts
++
++ WARLORD: Char1: Great Unclean One
++ ENHANCEMENT: The Endless Gift (on Char1: Great Unclean One)
++ NUMBER OF UNITS: 5
++++++++++++++++++++++++++++++++++++++++++++++++
+
+1x Rotigus (250 pts): Gnarlrod, Streams of brackish filth
+Char1: 1x Great Unclean One (295 pts): Putrid vomit, Bileblade, Bilesword, Warlord
+Enhancement: The Endless Gift
+Char2: 1x Bloodmaster (65 pts): Blade of blood
+10x Bloodletters (110 pts): 10x Hellblade, Instrument of Chaos, Daemonic Icon
+5x Flesh Hounds (75 pts): Burning maw, 5x Collar of Khorne, 5x Gore-drenched fangs

--- a/conformance/roster/cd-daemonic-incursion/expected.newrecruit-wtc-full.txt
+++ b/conformance/roster/cd-daemonic-incursion/expected.newrecruit-wtc-full.txt
@@ -1,0 +1,29 @@
++++++++++++++++++++++++++++++++++++++++++++++++
++ LIST NAME: all gas no breaks
++ FACTION KEYWORD: Chaos Daemons
++ DETACHMENT: Daemonic Incursion
++ TOTAL ARMY POINTS: 1995pts
++ POINTS LIMIT: 1995pts
++
++ WARLORD: Char1: Great Unclean One
++ ENHANCEMENT: The Endless Gift (on Char1: Great Unclean One)
++ NUMBER OF UNITS: 5
++++++++++++++++++++++++++++++++++++++++++++++++
+
+BATTLELINE
+
+1x Rotigus (250 pts)
+1 with Gnarlrod, Streams of brackish filth
+
+Char1: 1x Great Unclean One (295 pts)
+1 with Putrid vomit, Bileblade, Bilesword, Warlord
+Enhancement: The Endless Gift
+
+Char2: 1x Bloodmaster (65 pts)
+1 with Blade of blood
+
+10x Bloodletters (110 pts)
+1 with 10x Hellblade, Instrument of Chaos, Daemonic Icon
+
+5x Flesh Hounds (75 pts)
+1 with Burning maw, 5x Collar of Khorne, 5x Gore-drenched fangs

--- a/conformance/roster/cd-daemonic-incursion/expected.parsed.json
+++ b/conformance/roster/cd-daemonic-incursion/expected.parsed.json
@@ -1,0 +1,116 @@
+{
+  "name": "all gas no breaks",
+  "generated_by": "List Forge",
+  "faction_raw_name": "Chaos Daemons",
+  "detachment_raw_name": "Daemonic Incursion",
+  "battle_size_raw": "Strike Force (2000 Point limit)",
+  "declared_limit": 1995,
+  "total_reported": 1995,
+  "total_computed": 795,
+  "units": [
+    {
+      "raw_name": "Rotigus",
+      "is_character": true,
+      "model_count": 1,
+      "points": 250,
+      "is_warlord": false,
+      "enhancement_raw_name": null,
+      "enhancement_points": null,
+      "wargear": [
+        {
+          "raw_name": "Gnarlrod",
+          "count": 1
+        },
+        {
+          "raw_name": "Streams of brackish filth",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "raw_name": "Great Unclean One",
+      "is_character": true,
+      "model_count": 1,
+      "points": 295,
+      "is_warlord": true,
+      "enhancement_raw_name": "The Endless Gift",
+      "enhancement_points": null,
+      "wargear": [
+        {
+          "raw_name": "Putrid vomit",
+          "count": 1
+        },
+        {
+          "raw_name": "Bileblade",
+          "count": 1
+        },
+        {
+          "raw_name": "Bilesword",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "raw_name": "Bloodmaster",
+      "is_character": true,
+      "model_count": 1,
+      "points": 65,
+      "is_warlord": false,
+      "enhancement_raw_name": null,
+      "enhancement_points": null,
+      "wargear": [
+        {
+          "raw_name": "Blade of blood",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "raw_name": "Bloodletters",
+      "is_character": false,
+      "model_count": 10,
+      "points": 110,
+      "is_warlord": false,
+      "enhancement_raw_name": null,
+      "enhancement_points": null,
+      "wargear": [
+        {
+          "raw_name": "Hellblade",
+          "count": 10
+        },
+        {
+          "raw_name": "Instrument of Chaos",
+          "count": 1
+        },
+        {
+          "raw_name": "Daemonic Icon",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "raw_name": "Flesh Hounds",
+      "is_character": false,
+      "model_count": 5,
+      "points": 75,
+      "is_warlord": false,
+      "enhancement_raw_name": null,
+      "enhancement_points": null,
+      "wargear": [
+        {
+          "raw_name": "Burning maw",
+          "count": 1
+        },
+        {
+          "raw_name": "Collar of Khorne",
+          "count": 5
+        },
+        {
+          "raw_name": "Gore-drenched fangs",
+          "count": 5
+        }
+      ]
+    }
+  ],
+  "multi_force": false
+}

--- a/conformance/roster/cd-daemonic-incursion/expected.roster-json.json
+++ b/conformance/roster/cd-daemonic-incursion/expected.roster-json.json
@@ -1,0 +1,260 @@
+{
+  "name": "all gas no breaks",
+  "source": {
+    "format": "listforge-text",
+    "generated_by": "List Forge"
+  },
+  "faction_id": "chaos-daemons",
+  "detachment_id": "daemonic-incursion",
+  "battle_size": "strike-force",
+  "points": {
+    "declared_limit": 1995,
+    "total_reported": 1995,
+    "total_computed": 795
+  },
+  "units": [
+    {
+      "ref": {
+        "id": "rotigus",
+        "raw_name": "Rotigus",
+        "resolved": true,
+        "candidates": []
+      },
+      "model_count": 1,
+      "points": 250,
+      "is_warlord": false,
+      "enhancement": null,
+      "enhancement_points": null,
+      "wargear": [
+        {
+          "ref": {
+            "id": "gnarlrod",
+            "raw_name": "Gnarlrod",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 1
+        },
+        {
+          "ref": {
+            "id": "streams-of-brackish-filth",
+            "raw_name": "Streams of brackish filth",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 1
+        }
+      ],
+      "leader_attachment": null
+    },
+    {
+      "ref": {
+        "id": "great-unclean-one",
+        "raw_name": "Great Unclean One",
+        "resolved": true,
+        "candidates": []
+      },
+      "model_count": 1,
+      "points": 295,
+      "is_warlord": true,
+      "enhancement": {
+        "id": "the-endless-gift",
+        "raw_name": "The Endless Gift",
+        "resolved": true,
+        "candidates": []
+      },
+      "enhancement_points": null,
+      "wargear": [
+        {
+          "ref": {
+            "id": "putrid-vomit",
+            "raw_name": "Putrid vomit",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 1
+        },
+        {
+          "ref": {
+            "id": "bileblade",
+            "raw_name": "Bileblade",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 1
+        },
+        {
+          "ref": {
+            "id": "bilesword",
+            "raw_name": "Bilesword",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 1
+        }
+      ],
+      "leader_attachment": null
+    },
+    {
+      "ref": {
+        "id": "bloodmaster",
+        "raw_name": "Bloodmaster",
+        "resolved": true,
+        "candidates": []
+      },
+      "model_count": 1,
+      "points": 65,
+      "is_warlord": false,
+      "enhancement": null,
+      "enhancement_points": null,
+      "wargear": [
+        {
+          "ref": {
+            "id": "blade-of-blood",
+            "raw_name": "Blade of blood",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 1
+        }
+      ],
+      "leader_attachment": {
+        "bodyguard_ref": {
+          "id": "bloodletters",
+          "raw_name": "Bloodletters",
+          "resolved": true,
+          "candidates": []
+        },
+        "provisional": true
+      }
+    },
+    {
+      "ref": {
+        "id": "bloodletters",
+        "raw_name": "Bloodletters",
+        "resolved": true,
+        "candidates": []
+      },
+      "model_count": 10,
+      "points": 110,
+      "is_warlord": false,
+      "enhancement": null,
+      "enhancement_points": null,
+      "wargear": [
+        {
+          "ref": {
+            "id": "hellblade",
+            "raw_name": "Hellblade",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 10
+        },
+        {
+          "ref": {
+            "id": null,
+            "raw_name": "Instrument of Chaos",
+            "resolved": false,
+            "candidates": []
+          },
+          "count": 1
+        },
+        {
+          "ref": {
+            "id": null,
+            "raw_name": "Daemonic Icon",
+            "resolved": false,
+            "candidates": []
+          },
+          "count": 1
+        }
+      ],
+      "leader_attachment": null
+    },
+    {
+      "ref": {
+        "id": "flesh-hounds",
+        "raw_name": "Flesh Hounds",
+        "resolved": true,
+        "candidates": []
+      },
+      "model_count": 5,
+      "points": 75,
+      "is_warlord": false,
+      "enhancement": null,
+      "enhancement_points": null,
+      "wargear": [
+        {
+          "ref": {
+            "id": null,
+            "raw_name": "Burning maw",
+            "resolved": false,
+            "candidates": []
+          },
+          "count": 1
+        },
+        {
+          "ref": {
+            "id": null,
+            "raw_name": "Collar of Khorne",
+            "resolved": false,
+            "candidates": []
+          },
+          "count": 5
+        },
+        {
+          "ref": {
+            "id": "gore-drenched-fangs",
+            "raw_name": "Gore-drenched fangs",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 5
+        }
+      ],
+      "leader_attachment": null
+    }
+  ],
+  "game_version": {
+    "edition": "11th",
+    "dataslate": "pre-launch-provisional"
+  },
+  "diagnostics": {
+    "resolved_units": 5,
+    "unresolved_units": 0,
+    "resolved_weapons": 8,
+    "unresolved_weapons": 4,
+    "warnings": [
+      {
+        "code": "weapon-unresolved",
+        "message": "Weapon name did not match any 40kdc weapon.",
+        "raw_name": "Instrument of Chaos"
+      },
+      {
+        "code": "weapon-unresolved",
+        "message": "Weapon name did not match any 40kdc weapon.",
+        "raw_name": "Daemonic Icon"
+      },
+      {
+        "code": "weapon-unresolved",
+        "message": "Weapon name did not match any 40kdc weapon.",
+        "raw_name": "Burning maw"
+      },
+      {
+        "code": "weapon-unresolved",
+        "message": "Weapon name did not match any 40kdc weapon.",
+        "raw_name": "Collar of Khorne"
+      },
+      {
+        "code": "leader-attachment-inferred",
+        "message": "Leader attachment was inferred from leader-attachment data and is provisional.",
+        "raw_name": "Bloodmaster"
+      },
+      {
+        "code": "points-mismatch",
+        "message": "Source-reported total (1995) differs from the sum of cost lines (795).",
+        "raw_name": null
+      }
+    ]
+  }
+}

--- a/conformance/roster/cd-daemonic-incursion/expected.roster.json
+++ b/conformance/roster/cd-daemonic-incursion/expected.roster.json
@@ -1,0 +1,260 @@
+{
+  "name": "all gas no breaks",
+  "source": {
+    "format": "listforge-text",
+    "generated_by": "List Forge"
+  },
+  "faction_id": "chaos-daemons",
+  "detachment_id": "daemonic-incursion",
+  "battle_size": "strike-force",
+  "points": {
+    "declared_limit": 1995,
+    "total_reported": 1995,
+    "total_computed": 795
+  },
+  "units": [
+    {
+      "ref": {
+        "id": "rotigus",
+        "raw_name": "Rotigus",
+        "resolved": true,
+        "candidates": []
+      },
+      "model_count": 1,
+      "points": 250,
+      "is_warlord": false,
+      "enhancement": null,
+      "enhancement_points": null,
+      "wargear": [
+        {
+          "ref": {
+            "id": "gnarlrod",
+            "raw_name": "Gnarlrod",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 1
+        },
+        {
+          "ref": {
+            "id": "streams-of-brackish-filth",
+            "raw_name": "Streams of brackish filth",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 1
+        }
+      ],
+      "leader_attachment": null
+    },
+    {
+      "ref": {
+        "id": "great-unclean-one",
+        "raw_name": "Great Unclean One",
+        "resolved": true,
+        "candidates": []
+      },
+      "model_count": 1,
+      "points": 295,
+      "is_warlord": true,
+      "enhancement": {
+        "id": "the-endless-gift",
+        "raw_name": "The Endless Gift",
+        "resolved": true,
+        "candidates": []
+      },
+      "enhancement_points": null,
+      "wargear": [
+        {
+          "ref": {
+            "id": "putrid-vomit",
+            "raw_name": "Putrid vomit",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 1
+        },
+        {
+          "ref": {
+            "id": "bileblade",
+            "raw_name": "Bileblade",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 1
+        },
+        {
+          "ref": {
+            "id": "bilesword",
+            "raw_name": "Bilesword",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 1
+        }
+      ],
+      "leader_attachment": null
+    },
+    {
+      "ref": {
+        "id": "bloodmaster",
+        "raw_name": "Bloodmaster",
+        "resolved": true,
+        "candidates": []
+      },
+      "model_count": 1,
+      "points": 65,
+      "is_warlord": false,
+      "enhancement": null,
+      "enhancement_points": null,
+      "wargear": [
+        {
+          "ref": {
+            "id": "blade-of-blood",
+            "raw_name": "Blade of blood",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 1
+        }
+      ],
+      "leader_attachment": {
+        "bodyguard_ref": {
+          "id": "bloodletters",
+          "raw_name": "Bloodletters",
+          "resolved": true,
+          "candidates": []
+        },
+        "provisional": true
+      }
+    },
+    {
+      "ref": {
+        "id": "bloodletters",
+        "raw_name": "Bloodletters",
+        "resolved": true,
+        "candidates": []
+      },
+      "model_count": 10,
+      "points": 110,
+      "is_warlord": false,
+      "enhancement": null,
+      "enhancement_points": null,
+      "wargear": [
+        {
+          "ref": {
+            "id": "hellblade",
+            "raw_name": "Hellblade",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 10
+        },
+        {
+          "ref": {
+            "id": null,
+            "raw_name": "Instrument of Chaos",
+            "resolved": false,
+            "candidates": []
+          },
+          "count": 1
+        },
+        {
+          "ref": {
+            "id": null,
+            "raw_name": "Daemonic Icon",
+            "resolved": false,
+            "candidates": []
+          },
+          "count": 1
+        }
+      ],
+      "leader_attachment": null
+    },
+    {
+      "ref": {
+        "id": "flesh-hounds",
+        "raw_name": "Flesh Hounds",
+        "resolved": true,
+        "candidates": []
+      },
+      "model_count": 5,
+      "points": 75,
+      "is_warlord": false,
+      "enhancement": null,
+      "enhancement_points": null,
+      "wargear": [
+        {
+          "ref": {
+            "id": null,
+            "raw_name": "Burning maw",
+            "resolved": false,
+            "candidates": []
+          },
+          "count": 1
+        },
+        {
+          "ref": {
+            "id": null,
+            "raw_name": "Collar of Khorne",
+            "resolved": false,
+            "candidates": []
+          },
+          "count": 5
+        },
+        {
+          "ref": {
+            "id": "gore-drenched-fangs",
+            "raw_name": "Gore-drenched fangs",
+            "resolved": true,
+            "candidates": []
+          },
+          "count": 5
+        }
+      ],
+      "leader_attachment": null
+    }
+  ],
+  "game_version": {
+    "edition": "11th",
+    "dataslate": "pre-launch-provisional"
+  },
+  "diagnostics": {
+    "resolved_units": 5,
+    "unresolved_units": 0,
+    "resolved_weapons": 8,
+    "unresolved_weapons": 4,
+    "warnings": [
+      {
+        "code": "weapon-unresolved",
+        "message": "Weapon name did not match any 40kdc weapon.",
+        "raw_name": "Instrument of Chaos"
+      },
+      {
+        "code": "weapon-unresolved",
+        "message": "Weapon name did not match any 40kdc weapon.",
+        "raw_name": "Daemonic Icon"
+      },
+      {
+        "code": "weapon-unresolved",
+        "message": "Weapon name did not match any 40kdc weapon.",
+        "raw_name": "Burning maw"
+      },
+      {
+        "code": "weapon-unresolved",
+        "message": "Weapon name did not match any 40kdc weapon.",
+        "raw_name": "Collar of Khorne"
+      },
+      {
+        "code": "leader-attachment-inferred",
+        "message": "Leader attachment was inferred from leader-attachment data and is provisional.",
+        "raw_name": "Bloodmaster"
+      },
+      {
+        "code": "points-mismatch",
+        "message": "Source-reported total (1995) differs from the sum of cost lines (795).",
+        "raw_name": null
+      }
+    ]
+  }
+}

--- a/conformance/roster/cd-daemonic-incursion/expected.rosterizer.json
+++ b/conformance/roster/cd-daemonic-incursion/expected.rosterizer.json
@@ -1,0 +1,184 @@
+{
+  "slug": "",
+  "key": "",
+  "visible": "hidden",
+  "locked": false,
+  "rulebook": {
+    "name": "40kdc",
+    "game": "Warhammer 40,000",
+    "publisher": "Alpaca Software",
+    "url": "https://40kdc.dev",
+    "genre": "wargame"
+  },
+  "snapshot": {
+    "item": "Roster§Roster",
+    "name": "all gas no breaks",
+    "quantity": 1,
+    "stats": {
+      "Points": {
+        "value": 795
+      }
+    },
+    "assets": {
+      "included": [
+        {
+          "item": "Faction§Chaos Daemons",
+          "name": "Chaos Daemons",
+          "quantity": 1
+        },
+        {
+          "item": "Detachment§Daemonic Incursion",
+          "name": "Daemonic Incursion",
+          "quantity": 1
+        },
+        {
+          "item": "Battle Size§Strike Force (1995 Point limit)",
+          "name": "Strike Force (1995 Point limit)",
+          "quantity": 1
+        },
+        {
+          "item": "Unit§Rotigus",
+          "name": "Rotigus",
+          "quantity": 1,
+          "stats": {
+            "Points": {
+              "value": 250
+            }
+          },
+          "assets": {
+            "included": [
+              {
+                "item": "Weapon§Gnarlrod",
+                "name": "Gnarlrod",
+                "quantity": 1
+              },
+              {
+                "item": "Weapon§Streams of brackish filth",
+                "name": "Streams of brackish filth",
+                "quantity": 1
+              }
+            ]
+          }
+        },
+        {
+          "item": "Unit§Great Unclean One",
+          "name": "Great Unclean One",
+          "quantity": 1,
+          "stats": {
+            "Points": {
+              "value": 295
+            }
+          },
+          "assets": {
+            "included": [
+              {
+                "item": "Enhancement§The Endless Gift",
+                "name": "The Endless Gift",
+                "quantity": 1
+              },
+              {
+                "item": "Weapon§Putrid vomit",
+                "name": "Putrid vomit",
+                "quantity": 1
+              },
+              {
+                "item": "Weapon§Bileblade",
+                "name": "Bileblade",
+                "quantity": 1
+              },
+              {
+                "item": "Weapon§Bilesword",
+                "name": "Bilesword",
+                "quantity": 1
+              }
+            ],
+            "traits": [
+              {
+                "item": "Trait§Warlord",
+                "name": "Warlord",
+                "quantity": 1
+              }
+            ]
+          }
+        },
+        {
+          "item": "Unit§Bloodmaster",
+          "name": "Bloodmaster",
+          "quantity": 1,
+          "stats": {
+            "Points": {
+              "value": 65
+            }
+          },
+          "assets": {
+            "included": [
+              {
+                "item": "Weapon§Blade of blood",
+                "name": "Blade of blood",
+                "quantity": 1
+              }
+            ]
+          }
+        },
+        {
+          "item": "Unit§Bloodletters",
+          "name": "Bloodletters",
+          "quantity": 10,
+          "stats": {
+            "Points": {
+              "value": 110
+            }
+          },
+          "assets": {
+            "included": [
+              {
+                "item": "Weapon§Hellblade",
+                "name": "Hellblade",
+                "quantity": 10
+              },
+              {
+                "item": "Weapon§Instrument of Chaos",
+                "name": "Instrument of Chaos",
+                "quantity": 1
+              },
+              {
+                "item": "Weapon§Daemonic Icon",
+                "name": "Daemonic Icon",
+                "quantity": 1
+              }
+            ]
+          }
+        },
+        {
+          "item": "Unit§Flesh Hounds",
+          "name": "Flesh Hounds",
+          "quantity": 5,
+          "stats": {
+            "Points": {
+              "value": 75
+            }
+          },
+          "assets": {
+            "included": [
+              {
+                "item": "Weapon§Burning maw",
+                "name": "Burning maw",
+                "quantity": 1
+              },
+              {
+                "item": "Weapon§Collar of Khorne",
+                "name": "Collar of Khorne",
+                "quantity": 5
+              },
+              {
+                "item": "Weapon§Gore-drenched fangs",
+                "name": "Gore-drenched fangs",
+                "quantity": 5
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/conformance/roster/cd-daemonic-incursion/input.listforge-text.txt
+++ b/conformance/roster/cd-daemonic-incursion/input.listforge-text.txt
@@ -1,0 +1,40 @@
+all gas no breaks - Chaos Daemons - Daemonic Incursion (1995 Points)
+
+
+Epic Hero:
+Rotigus (250 pts)
+  • Gnarlrod
+  • Streams of brackish filth
+
+
+Character:
+Great Unclean One (295 pts)
+  • Putrid vomit
+  • Bileblade
+  • Bilesword
+  • E: The Endless Gift
+  • Warlord
+
+Bloodmaster (65 pts)
+  • Blade of blood
+
+
+Battleline:
+Bloodletters (110 pts)
+  • Bloodreaper
+    • Hellblade
+  • Instrument of Chaos
+  • Daemonic Icon
+  • 9x Bloodletter
+    • 9x Hellblade
+
+
+Beast:
+Flesh Hounds (75 pts)
+  • Gore Hound
+    • Burning maw
+    • Collar of Khorne
+    • Gore-drenched fangs
+  • 4x Flesh Hound
+    • 4x Collar of Khorne
+    • 4x Gore-drenched fangs

--- a/crates/wh40kdc/Cargo.toml
+++ b/crates/wh40kdc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wh40kdc"
-version = "0.5.0"
+version = "0.5.1"
 description = "Warhammer 40K dataset for the 40kdc-data schema layer: generated types, an embedded dataset behind a linked typed API, plus ListForge + NewRecruit roster importers and exporters."
 readme = "README.md"
 keywords = ["warhammer", "40k", "wargaming", "schema", "serde"]

--- a/crates/wh40kdc/src/bin/wh40kdc-runner.rs
+++ b/crates/wh40kdc/src/bin/wh40kdc-runner.rs
@@ -275,6 +275,7 @@ fn roster_format_str(f: RosterFormat) -> &'static str {
         RosterFormat::NewrecruitSimple => "newrecruit-simple",
         RosterFormat::Rosterizer => "rosterizer",
         RosterFormat::Gw => "gw",
+        RosterFormat::ListforgeText => "listforge-text",
     }
 }
 

--- a/crates/wh40kdc/src/import/adapter.rs
+++ b/crates/wh40kdc/src/import/adapter.rs
@@ -82,5 +82,6 @@ pub fn format_id(fmt: RosterFormat) -> &'static str {
         RosterFormat::NewrecruitSimple => "newrecruit-simple",
         RosterFormat::Rosterizer => "rosterizer",
         RosterFormat::Gw => "gw",
+        RosterFormat::ListforgeText => "listforge-text",
     }
 }

--- a/crates/wh40kdc/src/import/listforge_text.rs
+++ b/crates/wh40kdc/src/import/listforge_text.rs
@@ -1,0 +1,483 @@
+//! ListForge plain-text adapter: lower ListForge's copy-paste text export to a
+//! [`ParsedRoster`].
+//!
+//! This is the bullet-list text users copy out of the ListForge app (distinct
+//! from the base64+gzip share-JSON the `listforge` adapter handles). Shape:
+//!
+//! ```text
+//! all gas no breaks - Chaos Daemons - Daemonic Incursion (1995 Points)
+//!
+//! Epic Hero:
+//! Rotigus (250 pts)
+//!   • Gnarlrod
+//!   • Streams of brackish filth
+//!
+//! Battleline:
+//! Bloodletters (110 pts)
+//!   • Bloodreaper
+//!     • Hellblade
+//!   • Daemonic Icon
+//!   • 9x Bloodletter
+//!     • 9x Hellblade
+//! ```
+//!
+//! - The first non-blank line is `<list name> - <faction> - <detachment>
+//!   (<N> Points)`. A list name containing ` - ` breaks the split — a
+//!   documented ListForge limitation, not ours.
+//! - Sections are mixed-case battlefield-role lines ending with `:`
+//!   (`Epic Hero:`, `Character:`, `Battleline:`, …). Units under `Epic Hero:`
+//!   or `Character:` are characters.
+//! - Bullet classification mirrors the GW adapter: a top-level bullet with
+//!   deeper children is a **model group** (its `Nx` count — implicitly 1 —
+//!   adds to the model count); without children it's **wargear**. Child-bullet
+//!   `Nx` counts are already squad-wide totals; a child without a count is one
+//!   item (`• Hellblade` under a lone Bloodreaper).
+//! - `E: <name>` is the enhancement annotation (ListForge reports no points for
+//!   it, so `enhancement_points` stays null and unit points stay as displayed).
+//!   A bare `Warlord` bullet flags the warlord.
+//!
+//! **Disjointness**: the `(N Points)` first-line suffix is unique to this
+//! format — newrecruit-simple's first line ends `- [N pts]`, the GW export
+//! opens with a `++++` fence, and the WTC formats carry `N with` lines or no
+//! bullets at all.
+//!
+//! Rust mirror of `tools/src/import/listforge-text.ts`.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde_json::Value;
+
+use super::adapter::{FormatAdapter, ParseError};
+use super::newrecruit_text::infer_battle_size_raw;
+use super::types::{ParsedRoster, ParsedUnit, ParsedWargear, RosterFormat};
+
+static RE_FIRST_LINE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)^(.+)\s\(\s*(\d+)\s*Points?\s*\)\s*$").unwrap());
+static RE_SECTION_HEADER: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[A-Za-z][A-Za-z0-9 /&'-]*:$").unwrap());
+static RE_UNIT_HEADER: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)^(.+?)\s*\(\s*(\d+)\s*pts?\s*\)\s*$").unwrap());
+static RE_BULLET_LINE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^([\t ]*)•\s*(.+?)\s*$").unwrap());
+static RE_NX_PREFIX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(\d+)x\s+(.+)$").unwrap());
+static RE_BULLET_ANYWHERE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?m)^[\t ]*•").unwrap());
+static RE_WITH_LINE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?m)^[\t ]*\d+\s+with\b").unwrap());
+
+const ENHANCEMENT_PREFIX: &str = "E: ";
+const WARLORD_MARKER: &str = "Warlord";
+
+fn is_character_section(heading: &str) -> bool {
+    matches!(heading, "epic hero" | "character")
+}
+
+/// Accept plain text whose first non-blank line is the ListForge
+/// `name - faction - detachment (N Points)` header, with `•` bullets and no
+/// WTC `N with` lines.
+fn is_listforge_text(decoded: &Value) -> Option<&str> {
+    let s = decoded.as_str()?;
+    let first_non_blank = s
+        .split('\n')
+        .map(|l| l.trim_end_matches('\r').trim())
+        .find(|l| !l.is_empty())?;
+    let first = RE_FIRST_LINE.captures(first_non_blank)?;
+    if first[1].split(" - ").count() < 3 {
+        return None;
+    }
+    if !RE_BULLET_ANYWHERE.is_match(s) {
+        return None;
+    }
+    if RE_WITH_LINE.is_match(s) {
+        return None;
+    }
+    Some(s)
+}
+
+struct Header {
+    name: String,
+    faction_raw_name: Option<String>,
+    detachment_raw_name: Option<String>,
+    total_reported: Option<u64>,
+}
+
+fn parse_first_line(line: &str) -> Option<Header> {
+    let m = RE_FIRST_LINE.captures(line.trim())?;
+    let parts: Vec<&str> = m[1]
+        .split(" - ")
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if parts.len() < 3 {
+        return None;
+    }
+    // `<list name> - <faction> - <detachment>`; the name is everything before
+    // the trailing two segments so faction names with hyphens stay intact only
+    // when ListForge itself doesn't insert ` - ` (it doesn't).
+    let name = parts[..parts.len() - 2].join(" - ");
+    let faction_raw_name = Some(parts[parts.len() - 2].to_string());
+    let detachment_raw_name = Some(parts[parts.len() - 1].to_string());
+    Some(Header {
+        name,
+        faction_raw_name,
+        detachment_raw_name,
+        total_reported: m[2].parse().ok(),
+    })
+}
+
+struct Bullet {
+    indent: usize,
+    count: Option<u64>,
+    text: String,
+}
+
+struct UnitAcc {
+    raw_name: String,
+    displayed_pts: Option<u64>,
+    is_character: bool,
+    bullets: Vec<Bullet>,
+}
+
+fn finish_unit(acc: UnitAcc) -> ParsedUnit {
+    let top_indent = acc.bullets.iter().map(|b| b.indent).min().unwrap_or(0);
+
+    // Insertion-ordered wargear with duplicate-name merge (mirrors the TS Map).
+    let mut wargear: Vec<ParsedWargear> = Vec::new();
+    let mut add_wargear = |raw_name: &str, count: u64| {
+        if let Some(w) = wargear.iter_mut().find(|w| w.raw_name == raw_name) {
+            w.count += count;
+        } else {
+            wargear.push(ParsedWargear {
+                raw_name: raw_name.to_string(),
+                count,
+            });
+        }
+    };
+
+    let mut model_count: u64 = 0;
+    let mut is_warlord = false;
+    let mut enhancement_raw_name: Option<String> = None;
+
+    for (i, b) in acc.bullets.iter().enumerate() {
+        // Child bullet: a model group's weapon. ListForge child counts are
+        // squad-wide totals; a count-less child is a single item.
+        if b.indent > top_indent {
+            add_wargear(&b.text, b.count.unwrap_or(1));
+            continue;
+        }
+
+        // Top-level annotations.
+        if b.count.is_none() {
+            if b.text == WARLORD_MARKER {
+                is_warlord = true;
+                continue;
+            }
+            if let Some(rest) = b.text.strip_prefix(ENHANCEMENT_PREFIX) {
+                if enhancement_raw_name.is_none() {
+                    enhancement_raw_name = Some(rest.trim().to_string());
+                }
+                continue;
+            }
+        }
+
+        // Top-level entry: a model group when it has child bullets beneath it,
+        // otherwise plain wargear. Either way a missing `Nx` count means 1.
+        let next_is_child = acc
+            .bullets
+            .get(i + 1)
+            .map(|n| n.indent > b.indent)
+            .unwrap_or(false);
+        if next_is_child {
+            model_count += b.count.unwrap_or(1);
+        } else {
+            add_wargear(&b.text, b.count.unwrap_or(1));
+        }
+    }
+
+    if model_count == 0 {
+        model_count = 1;
+    }
+
+    ParsedUnit {
+        raw_name: acc.raw_name,
+        is_character: acc.is_character,
+        model_count,
+        points: acc.displayed_pts,
+        is_warlord,
+        enhancement_raw_name,
+        // ListForge's text export reports no enhancement cost, so the unit's
+        // displayed points stay as-is and no enhancement points are claimed.
+        enhancement_points: None,
+        wargear,
+    }
+}
+
+pub struct ListForgeTextAdapter;
+
+impl FormatAdapter for ListForgeTextAdapter {
+    fn format(&self) -> RosterFormat {
+        RosterFormat::ListforgeText
+    }
+
+    fn detect(&self, decoded: &Value) -> bool {
+        is_listforge_text(decoded).is_some()
+    }
+
+    fn parse(&self, decoded: &Value) -> Result<ParsedRoster, ParseError> {
+        let text = is_listforge_text(decoded).ok_or_else(|| {
+            ParseError("listforge-text: input is not a ListForge text export".into())
+        })?;
+
+        let lines: Vec<&str> = text.split('\n').map(|l| l.trim_end_matches('\r')).collect();
+        let mut header: Option<Header> = None;
+        let mut units: Vec<ParsedUnit> = Vec::new();
+        let mut current: Option<UnitAcc> = None;
+        let mut section_is_character = false;
+
+        for raw in &lines {
+            let line = raw.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            if header.is_none() {
+                header = parse_first_line(line);
+                if header.is_some() {
+                    continue;
+                }
+            }
+
+            if let Some(c) = RE_BULLET_LINE.captures(raw) {
+                if let Some(unit) = current.as_mut() {
+                    let indent = c[1].len();
+                    let rest = c[2].to_string();
+                    let (count, bullet_text) = match RE_NX_PREFIX.captures(&rest) {
+                        Some(nx) => (nx[1].parse::<u64>().ok(), nx[2].trim().to_string()),
+                        None => (None, rest.trim().to_string()),
+                    };
+                    unit.bullets.push(Bullet {
+                        indent,
+                        count,
+                        text: bullet_text,
+                    });
+                }
+                continue;
+            }
+
+            if RE_SECTION_HEADER.is_match(line) {
+                if let Some(unit) = current.take() {
+                    units.push(finish_unit(unit));
+                }
+                let heading = line[..line.len() - 1].trim().to_ascii_lowercase();
+                section_is_character = is_character_section(&heading);
+                continue;
+            }
+
+            if let Some(c) = RE_UNIT_HEADER.captures(line) {
+                if let Some(unit) = current.take() {
+                    units.push(finish_unit(unit));
+                }
+                current = Some(UnitAcc {
+                    raw_name: c[1].trim().to_string(),
+                    displayed_pts: c[2].parse().ok(),
+                    is_character: section_is_character,
+                    bullets: Vec::new(),
+                });
+            }
+        }
+
+        if let Some(unit) = current.take() {
+            units.push(finish_unit(unit));
+        }
+
+        let header =
+            header.ok_or_else(|| ParseError("listforge-text: missing ListForge header line".into()))?;
+
+        let mut total_computed: u64 = 0;
+        for u in &units {
+            total_computed += u.points.unwrap_or(0);
+        }
+
+        // Like the GW export, ListForge text reports only the army total — use
+        // it as the declared limit so battle-size inference stays
+        // round-trippable.
+        let declared_limit = header.total_reported;
+
+        Ok(ParsedRoster {
+            name: header.name,
+            generated_by: Some("List Forge".to_string()),
+            faction_raw_name: header.faction_raw_name,
+            detachment_raw_name: header.detachment_raw_name,
+            battle_size_raw: infer_battle_size_raw(declared_limit),
+            declared_limit,
+            total_reported: header.total_reported,
+            total_computed,
+            units,
+            multi_force: false,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // Condensed from the reference Chaos Daemons export.
+    const SAMPLE: &str = "all gas no breaks - Chaos Daemons - Daemonic Incursion (1995 Points)
+
+
+Epic Hero:
+Rotigus (250 pts)
+  • Gnarlrod
+  • Streams of brackish filth
+
+
+Character:
+Great Unclean One (295 pts)
+  • Putrid vomit
+  • Bileblade
+  • Bilesword
+  • E: The Endless Gift
+  • Warlord
+
+Bloodmaster (65 pts)
+  • Blade of blood
+
+
+Battleline:
+Bloodletters (110 pts)
+  • Bloodreaper
+    • Hellblade
+  • Instrument of Chaos
+  • Daemonic Icon
+  • 9x Bloodletter
+    • 9x Hellblade
+
+
+Beast:
+Flesh Hounds (75 pts)
+  • Gore Hound
+    • Burning maw
+    • Collar of Khorne
+    • Gore-drenched fangs
+  • 4x Flesh Hound
+    • 4x Collar of Khorne
+    • 4x Gore-drenched fangs
+";
+
+    #[test]
+    fn recognises_the_listforge_text_export() {
+        assert!(ListForgeTextAdapter.detect(&json!(SAMPLE)));
+    }
+
+    #[test]
+    fn rejects_non_string_payloads_and_other_text_formats() {
+        assert!(!ListForgeTextAdapter.detect(&json!({ "roster": {} })));
+        // newrecruit-simple first line ends `- [N pts]`, not `(N Points)`.
+        assert!(!ListForgeTextAdapter.detect(&json!(
+            "Chaos - Chaos Knights - List - [2000 pts]\n\n# ++ Army Roster ++ [2000 pts]\nUnit [5 pts]:\n• 1x Model: Gun"
+        )));
+        // A GW export's first non-blank line is the `++++` fence.
+        assert!(!ListForgeTextAdapter.detect(&json!(
+            "++++\n+ FACTION KEYWORD: Chaos - Chaos Knights\n++++\nUnit (5 pts)\n• 1x Gun"
+        )));
+    }
+
+    #[test]
+    fn requires_bullets_and_refuses_wtc_with_bodies() {
+        let no_bullets = "name - Faction - Detachment (1000 Points)\nUnit (50 pts)";
+        assert!(!ListForgeTextAdapter.detect(&json!(no_bullets)));
+        let with_lines =
+            "name - Faction - Detachment (1000 Points)\nUnit (50 pts)\n  • Gun\n1 with Sword";
+        assert!(!ListForgeTextAdapter.detect(&json!(with_lines)));
+    }
+
+    #[test]
+    fn reads_header_from_the_first_line() {
+        let parsed = ListForgeTextAdapter.parse(&json!(SAMPLE)).unwrap();
+        assert_eq!(parsed.name, "all gas no breaks");
+        assert_eq!(parsed.faction_raw_name.as_deref(), Some("Chaos Daemons"));
+        assert_eq!(
+            parsed.detachment_raw_name.as_deref(),
+            Some("Daemonic Incursion")
+        );
+        assert_eq!(parsed.total_reported, Some(1995));
+        // ListForge reports only the army total — it doubles as the limit.
+        assert_eq!(parsed.declared_limit, Some(1995));
+        assert_eq!(parsed.generated_by.as_deref(), Some("List Forge"));
+    }
+
+    #[test]
+    fn captures_units_in_declaration_order() {
+        let parsed = ListForgeTextAdapter.parse(&json!(SAMPLE)).unwrap();
+        let names: Vec<&str> = parsed.units.iter().map(|u| u.raw_name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "Rotigus",
+                "Great Unclean One",
+                "Bloodmaster",
+                "Bloodletters",
+                "Flesh Hounds",
+            ]
+        );
+    }
+
+    #[test]
+    fn flags_characters_from_epic_hero_and_character_sections() {
+        let parsed = ListForgeTextAdapter.parse(&json!(SAMPLE)).unwrap();
+        let by_name = |n: &str| parsed.units.iter().find(|u| u.raw_name == n).unwrap();
+        assert!(by_name("Rotigus").is_character);
+        assert!(by_name("Great Unclean One").is_character);
+        assert!(by_name("Bloodmaster").is_character);
+        assert!(!by_name("Bloodletters").is_character);
+        assert!(!by_name("Flesh Hounds").is_character);
+    }
+
+    #[test]
+    fn reads_enhancement_annotation_without_claiming_points() {
+        let parsed = ListForgeTextAdapter.parse(&json!(SAMPLE)).unwrap();
+        let guo = parsed
+            .units
+            .iter()
+            .find(|u| u.raw_name == "Great Unclean One")
+            .unwrap();
+        assert_eq!(guo.enhancement_raw_name.as_deref(), Some("The Endless Gift"));
+        assert_eq!(guo.enhancement_points, None);
+        assert_eq!(guo.points, Some(295)); // displayed points stay as-is
+        assert!(guo.is_warlord);
+    }
+
+    #[test]
+    fn derives_model_counts_from_bulleted_model_groups() {
+        let parsed = ListForgeTextAdapter.parse(&json!(SAMPLE)).unwrap();
+        let by_name = |n: &str| parsed.units.iter().find(|u| u.raw_name == n).unwrap();
+        assert_eq!(by_name("Bloodletters").model_count, 10); // Bloodreaper + 9x
+        assert_eq!(by_name("Flesh Hounds").model_count, 5); // Gore Hound + 4x
+        assert_eq!(by_name("Rotigus").model_count, 1); // wargear-only bullets
+    }
+
+    #[test]
+    fn aggregates_squad_wide_wargear_from_child_and_leaf_bullets() {
+        let parsed = ListForgeTextAdapter.parse(&json!(SAMPLE)).unwrap();
+        let bloodletters = parsed
+            .units
+            .iter()
+            .find(|u| u.raw_name == "Bloodletters")
+            .unwrap();
+        let gear = |n: &str| {
+            bloodletters
+                .wargear
+                .iter()
+                .find(|w| w.raw_name == n)
+                .map(|w| w.count)
+        };
+        assert_eq!(gear("Hellblade"), Some(10)); // 1 (Bloodreaper) + 9 (squad)
+        assert_eq!(gear("Instrument of Chaos"), Some(1));
+        assert_eq!(gear("Daemonic Icon"), Some(1));
+    }
+
+    #[test]
+    fn sums_total_computed_from_unit_points() {
+        let parsed = ListForgeTextAdapter.parse(&json!(SAMPLE)).unwrap();
+        assert_eq!(parsed.total_computed, 250 + 295 + 65 + 110 + 75);
+    }
+}

--- a/crates/wh40kdc/src/import/mod.rs
+++ b/crates/wh40kdc/src/import/mod.rs
@@ -39,6 +39,8 @@ mod gw_headerless;
 #[cfg(feature = "import")]
 mod listforge;
 #[cfg(feature = "import")]
+mod listforge_text;
+#[cfg(feature = "import")]
 mod newrecruit_json;
 #[cfg(feature = "import")]
 mod newrecruit_simple;
@@ -67,6 +69,8 @@ pub use gw::GwAdapter;
 pub use gw_headerless::GwHeaderlessAdapter;
 #[cfg(feature = "import")]
 pub use listforge::ListForgeAdapter;
+#[cfg(feature = "import")]
+pub use listforge_text::ListForgeTextAdapter;
 #[cfg(feature = "import")]
 pub use newrecruit_json::NewRecruitJsonAdapter;
 #[cfg(feature = "import")]
@@ -137,6 +141,10 @@ fn adapters() -> Vec<Box<dyn FormatAdapter>> {
         Box::new(NewRecruitWtcFullAdapter),
         Box::new(NewRecruitWtcCompactAdapter),
         Box::new(NewRecruitSimpleAdapter),
+        // listforge-text requires the `name - faction - detachment (N Points)`
+        // first line none of the others accept; it runs right before the
+        // listforge (JSON) adapter, mirroring the TS ADAPTERS order.
+        Box::new(ListForgeTextAdapter),
         // Fallback for bullet-bearing plain text without a summary fence (GW app
         // export, NewRecruit copy-text, `##` markdown lists). Placed after the
         // framed text adapters so they win when their headers are present.

--- a/crates/wh40kdc/src/import/newrecruit_simple.rs
+++ b/crates/wh40kdc/src/import/newrecruit_simple.rs
@@ -29,19 +29,31 @@ use super::adapter::{FormatAdapter, ParseError};
 use super::newrecruit_text::{classify_wargear_list, split_wargear_list};
 use super::types::{ParsedRoster, ParsedUnit, ParsedWargear, RosterFormat};
 
+// Point brackets may carry comma-separated faction resources after the pts
+// figure (e.g. `[4485pts, 29Cabal Points]`); the `(?:,[^\]]*)?` tail is
+// recognized and discarded — only the pts figure is consumed.
 static RE_FIRST_LINE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)^(.+)\s-\s\[\s*(\d+)\s*pts?\s*\]\s*$").unwrap());
+    Lazy::new(|| Regex::new(r"(?i)^(.+)\s-\s\[\s*(\d+)\s*pts?\s*(?:,[^\]]*)?\]\s*$").unwrap());
 static RE_ROSTER_HEADER: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(?i)^#\s*\+\+\s*Army Roster\s*\+\+\s*\[\s*(\d+)\s*pts?\s*\]\s*$").unwrap()
+    Regex::new(r"(?i)^#\s*\+\+\s*Army Roster\s*\+\+\s*\[\s*(\d+)\s*pts?\s*(?:,[^\]]*)?\]\s*$")
+        .unwrap()
 });
 static RE_ROSTER_HEADER_SIG: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"(?im)^#\s*\+\+\s*Army Roster\s*\+\+").unwrap());
-static RE_SECTION_HEADER: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^##\s*(.+?)(?:\s*\[\s*(\d+)\s*pts?\s*\])?\s*$").unwrap());
-static RE_UNIT_LINE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)^(.+?)\s*\[\s*(\d+)\s*pts?\s*\](?:\s*:\s*(.*))?$").unwrap());
+// Some exports omit the `# ++ Army Roster ++` line and open straight with a
+// `## Section` heading — accept either marker in `detect`.
+static RE_SECTION_SIG: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?m)^##\s+").unwrap());
+static RE_SECTION_HEADER: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^##\s*(.+?)(?:\s*\[\s*(\d+)\s*pts?\s*(?:,[^\]]*)?\])?\s*$").unwrap()
+});
+static RE_UNIT_LINE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)^(.+?)\s*\[\s*(\d+)\s*pts?\s*(?:,[^\]]*)?\](?:\s*:\s*(.*))?$").unwrap()
+});
 static RE_BULLET: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^\s*•\s*(\d+)x\s+(.+?)(?:\s*\[\s*(\d+)\s*pts?\s*\])?(?:\s*:\s*(.*))?\s*$").unwrap()
+    Regex::new(
+        r"^\s*•\s*(\d+)x\s+(.+?)(?:\s*\[\s*(\d+)\s*pts?\s*(?:,[^\]]*)?\])?(?:\s*:\s*(.*))?\s*$",
+    )
+    .unwrap()
 });
 
 #[derive(Default)]
@@ -190,7 +202,9 @@ impl FormatAdapter for NewRecruitSimpleAdapter {
         if !RE_FIRST_LINE.is_match(first) {
             return false;
         }
-        RE_ROSTER_HEADER_SIG.is_match(text)
+        // Some exports omit the `# ++ Army Roster ++` line and open straight
+        // with a `## Section` heading — accept either marker.
+        RE_ROSTER_HEADER_SIG.is_match(text) || RE_SECTION_SIG.is_match(text)
     }
 
     fn parse(&self, decoded: &Value) -> Result<ParsedRoster, ParseError> {
@@ -256,18 +270,25 @@ impl FormatAdapter for NewRecruitSimpleAdapter {
             }
 
             if section == Section::Configuration {
-                if let Some(idx) = line.find(':') {
-                    if idx > 0 {
-                        let key = line[..idx].trim().to_ascii_lowercase();
-                        let value = line[idx + 1..].trim();
-                        if key == "battle size" {
-                            battle_size_raw = Some(value.to_string());
-                        } else if key == "detachment" {
-                            detachment_raw_name = Some(value.to_string());
+                // Some exports list units directly after Configuration with no
+                // units section heading; a `Name [N pts]` line ends the
+                // configuration block and is processed as a unit below.
+                if RE_UNIT_LINE.is_match(line) {
+                    section = Section::Units;
+                } else {
+                    if let Some(idx) = line.find(':') {
+                        if idx > 0 {
+                            let key = line[..idx].trim().to_ascii_lowercase();
+                            let value = line[idx + 1..].trim();
+                            if key == "battle size" {
+                                battle_size_raw = Some(value.to_string());
+                            } else if key == "detachment" {
+                                detachment_raw_name = Some(value.to_string());
+                            }
                         }
                     }
+                    continue;
                 }
-                continue;
             }
 
             // Unit section.
@@ -321,5 +342,140 @@ impl FormatAdapter for NewRecruitSimpleAdapter {
             units,
             multi_force,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const SAMPLE: &str = "Chaos - Chaos Knights - Dog Kill God? - [2000 pts]
+
+# ++ Army Roster ++ [2000 pts]
+## Configuration
+Battle Size: Strike Force (2000 Point limit)
+Detachment: Houndpack Lance
+Show/Hide Options: Nurgle Daemons are visible
+
+## Battleline [1855 pts]
+War Dog Karnivore [165 pts]: Houndpack Lance Character, Preyslayer's Mantle [15 pts], Reaper chaintalon, Slaughterclaw, Havoc multi-launcher
+War Dog Karnivore [150 pts]: Reaper chaintalon, Slaughterclaw, Havoc multi-launcher
+War Dog Executioner [130 pts]: Houndpack Lance Character, Warlord, Armoured feet, 2x War Dog autocannon, Diabolus heavy stubber
+
+## Allied Units [145 pts]
+Nurglings [40 pts]:
+• 3x Nurgling Swarm: Diseased claws and teeth
+Beasts of Nurgle [65 pts]:
+• 1x Beast of Nurgle [65 pts]: Putrid appendages
+";
+
+    #[test]
+    fn matches_simple_text_only() {
+        assert!(NewRecruitSimpleAdapter.detect(&json!(SAMPLE)));
+        assert!(!NewRecruitSimpleAdapter.detect(&json!("+ FACTION KEYWORD: …")));
+        assert!(!NewRecruitSimpleAdapter.detect(&json!({ "roster": { "forces": [] } })));
+    }
+
+    #[test]
+    fn parses_name_faction_limit_and_units() {
+        let parsed = NewRecruitSimpleAdapter.parse(&json!(SAMPLE)).unwrap();
+        assert_eq!(parsed.name, "Dog Kill God?");
+        assert_eq!(parsed.faction_raw_name.as_deref(), Some("Chaos Knights"));
+        assert_eq!(parsed.declared_limit, Some(2000));
+        assert_eq!(parsed.total_reported, Some(2000));
+        assert_eq!(
+            parsed.battle_size_raw.as_deref(),
+            Some("Strike Force (2000 Point limit)")
+        );
+        assert_eq!(parsed.detachment_raw_name.as_deref(), Some("Houndpack Lance"));
+
+        let names: Vec<&str> = parsed.units.iter().map(|u| u.raw_name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "War Dog Karnivore",
+                "War Dog Karnivore",
+                "War Dog Executioner",
+                "Nurglings",
+                "Beasts of Nurgle",
+            ]
+        );
+
+        // Inline enhancement is recognised and its cost subtracted from points.
+        let kar = &parsed.units[0];
+        assert_eq!(kar.enhancement_raw_name.as_deref(), Some("Preyslayer's Mantle"));
+        assert_eq!(kar.points, Some(150)); // 165 − 15
+        assert!(kar.is_character);
+        assert!(!kar.is_warlord);
+
+        // 150 + 15 + 150 + 130 + 40 + 65 = 550
+        assert_eq!(parsed.total_computed, 550);
+        assert!(parsed.multi_force);
+    }
+
+    // --- edge cases (mirror of tools/test/import/newrecruit-simple.test.ts) ---
+
+    #[test]
+    fn parses_points_brackets_with_comma_separated_faction_resources() {
+        let cabal = "Chaos - Thousand Sons - Tester - [4485pts, 29Cabal Points]
+
+# ++ Army Roster ++ [4485pts, 29Cabal Points]
+## Epic Hero [895pts, 13Cabal Points]
+Ahriman [140pts, 3Cabal Points]: Black Staff of Ahriman, Inferno bolt pistol
+";
+        assert!(NewRecruitSimpleAdapter.detect(&json!(cabal)));
+        let parsed = NewRecruitSimpleAdapter.parse(&json!(cabal)).unwrap();
+        assert_eq!(parsed.declared_limit, Some(4485));
+        assert_eq!(parsed.total_reported, Some(4485));
+        assert_eq!(parsed.units.len(), 1);
+        assert_eq!(parsed.units[0].raw_name, "Ahriman");
+        assert_eq!(parsed.units[0].points, Some(140));
+    }
+
+    #[test]
+    fn matches_exports_that_omit_the_army_roster_line_but_carry_sections() {
+        let headerless = "Chaos - World Eaters - Proxy List - [2000pts]
+
+## Epic Hero [675pts]
+Angron [435pts]: Samni'arius and Spinegrinder, Warlord
+";
+        assert!(NewRecruitSimpleAdapter.detect(&json!(headerless)));
+        let parsed = NewRecruitSimpleAdapter.parse(&json!(headerless)).unwrap();
+        assert_eq!(parsed.faction_raw_name.as_deref(), Some("World Eaters"));
+        assert_eq!(parsed.total_reported, None);
+        assert_eq!(parsed.units.len(), 1);
+        assert!(parsed.units[0].is_warlord);
+    }
+
+    #[test]
+    fn treats_a_unit_line_directly_after_configuration_as_ending_that_section() {
+        let no_units_header = "Xenos - T'au Empire - Base Tau - [2000pts]
+
+# ++ Army Roster ++ [2000pts]
+## Configuration
+Battle Size: Strike Force (2000 Point limit)
+Detachment: Auxiliary Cadre
+Show/Hide Options: Legends are visible
+
+Broadside Battlesuits [90pts]:
+• 1x Broadside Shas'vre: Crushing bulk, 2x Shield Drone, Heavy rail rifle
+Broadside Battlesuits [90pts]:
+• 1x Broadside Shas'vre: Crushing bulk, 2x Shield Drone, Heavy rail rifle
+";
+        let parsed = NewRecruitSimpleAdapter.parse(&json!(no_units_header)).unwrap();
+        assert_eq!(parsed.detachment_raw_name.as_deref(), Some("Auxiliary Cadre"));
+        assert_eq!(parsed.units.len(), 2);
+        assert_eq!(parsed.units[0].raw_name, "Broadside Battlesuits");
+        assert_eq!(parsed.units[0].model_count, 1);
+        let gear = |n: &str| {
+            parsed.units[0]
+                .wargear
+                .iter()
+                .find(|w| w.raw_name == n)
+                .map(|w| w.count)
+        };
+        assert_eq!(gear("Shield Drone"), Some(2));
+        assert_eq!(gear("Heavy rail rifle"), Some(1));
     }
 }

--- a/crates/wh40kdc/src/import/types.rs
+++ b/crates/wh40kdc/src/import/types.rs
@@ -37,6 +37,7 @@ pub enum RosterFormat {
     NewrecruitSimple,
     Rosterizer,
     Gw,
+    ListforgeText,
 }
 
 /// Diagnostic warning codes emitted during an import.

--- a/crates/wh40kdc/tests/conformance.rs
+++ b/crates/wh40kdc/tests/conformance.rs
@@ -24,8 +24,9 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 use wh40kdc::import::{
     import_roster, import_roster_text, select_adapter, try_import_roster, FormatAdapter, GwAdapter,
-    ImportResult, ListForgeAdapter, NewRecruitJsonAdapter, NewRecruitSimpleAdapter,
-    NewRecruitWtcCompactAdapter, NewRecruitWtcFullAdapter, RosterFormat, RosterizerAdapter,
+    ImportResult, ListForgeAdapter, ListForgeTextAdapter, NewRecruitJsonAdapter,
+    NewRecruitSimpleAdapter, NewRecruitWtcCompactAdapter, NewRecruitWtcFullAdapter, RosterFormat,
+    RosterizerAdapter,
 };
 use wh40kdc::{normalize_name, Dataset};
 
@@ -40,6 +41,7 @@ fn conformance_adapters() -> Vec<Box<dyn FormatAdapter>> {
         Box::new(NewRecruitWtcFullAdapter),
         Box::new(NewRecruitWtcCompactAdapter),
         Box::new(NewRecruitSimpleAdapter),
+        Box::new(ListForgeTextAdapter),
         Box::new(ListForgeAdapter),
     ]
 }
@@ -130,6 +132,7 @@ fn expected_format_for(filename: &str) -> RosterFormat {
         "newrecruit-simple" => RosterFormat::NewrecruitSimple,
         "rosterizer" => RosterFormat::Rosterizer,
         "gw" => RosterFormat::Gw,
+        "listforge-text" => RosterFormat::ListforgeText,
         other => panic!("unmapped input fixture stem: {other}"),
     }
 }
@@ -204,7 +207,8 @@ fn imported_rosters_match_reference_goldens() {
 
             let is_canonical = filename == "input.json"
                 || filename == "input.newrecruit-json.json"
-                || filename == "input.gw.txt";
+                || filename == "input.gw.txt"
+                || filename == "input.listforge-text.txt";
             if is_canonical {
                 assert_eq!(
                     actual_value, expected,
@@ -251,6 +255,11 @@ fn parsed_stage_matches_reference_goldens() {
             (
                 Value::String(read_text(&case_dir.join("input.gw.txt"))),
                 "input.gw.txt",
+            )
+        } else if dir_entries.iter().any(|n| n == "input.listforge-text.txt") {
+            (
+                Value::String(read_text(&case_dir.join("input.listforge-text.txt"))),
+                "input.listforge-text.txt",
             )
         } else {
             panic!("roster/{case_name}: no canonical seed");
@@ -331,6 +340,11 @@ fn exported_rosters_match_reference_goldens() {
                     .find(|n| n.as_str() == "input.newrecruit-json.json")
             })
             .or_else(|| files.iter().find(|n| n.as_str() == "input.gw.txt"))
+            .or_else(|| {
+                files
+                    .iter()
+                    .find(|n| n.as_str() == "input.listforge-text.txt")
+            })
             .unwrap_or_else(|| {
                 panic!("roster/{case_name}: export goldens present but no canonical input")
             });

--- a/crates/wh40kdc/tests/try_import_roster.rs
+++ b/crates/wh40kdc/tests/try_import_roster.rs
@@ -14,8 +14,8 @@ use flate2::Compression;
 use serde_json::Value;
 use wh40kdc::import::{
     try_import_roster, GwAdapter, GwHeaderlessAdapter, ImportFailureReason, ImportResult,
-    NewRecruitJsonAdapter, NewRecruitSimpleAdapter, NewRecruitWtcCompactAdapter,
-    NewRecruitWtcFullAdapter, RosterFormat, RosterizerAdapter,
+    ListForgeTextAdapter, NewRecruitJsonAdapter, NewRecruitSimpleAdapter,
+    NewRecruitWtcCompactAdapter, NewRecruitWtcFullAdapter, RosterFormat, RosterizerAdapter,
 };
 use wh40kdc::import::{FormatAdapter, ListForgeAdapter};
 use wh40kdc::Dataset;
@@ -74,6 +74,11 @@ fn fixtures() -> Vec<Fixture> {
             label: "GW app text (gw-chaos-knights)",
             input: conformance("gw-chaos-knights/input.gw.txt"),
             format: RosterFormat::Gw,
+        },
+        Fixture {
+            label: "ListForge text (cd-daemonic-incursion)",
+            input: conformance("cd-daemonic-incursion/input.listforge-text.txt"),
+            format: RosterFormat::ListforgeText,
         },
     ]
 }
@@ -162,7 +167,7 @@ fn rejects_unknown_json_shape() {
         ImportResult::Err { reason, trials, .. } => {
             assert_eq!(reason, ImportFailureReason::NoAdapterMatched);
             // Every adapter should have been polled.
-            assert_eq!(trials.len(), 8);
+            assert_eq!(trials.len(), 9);
             for t in trials {
                 assert!(!t.matched, "{:?} should not have matched", t.id);
             }
@@ -186,6 +191,7 @@ fn rejects_freeform_text() {
 fn adapter_matchers_are_disjoint_per_fixture() {
     // Greedy first-match dispatch relies on at most one adapter accepting a
     // given decoded payload. Guard the invariant against regressions.
+    // Registry order matches `try_import_roster`'s dispatch.
     let adapters: Vec<Box<dyn FormatAdapter>> = vec![
         Box::new(RosterizerAdapter),
         Box::new(NewRecruitJsonAdapter),
@@ -193,6 +199,7 @@ fn adapter_matchers_are_disjoint_per_fixture() {
         Box::new(NewRecruitWtcFullAdapter),
         Box::new(NewRecruitWtcCompactAdapter),
         Box::new(NewRecruitSimpleAdapter),
+        Box::new(ListForgeTextAdapter),
         Box::new(GwHeaderlessAdapter),
         Box::new(ListForgeAdapter),
     ];
@@ -210,6 +217,26 @@ fn adapter_matchers_are_disjoint_per_fixture() {
             .filter(|a| a.detect(&decoded))
             .map(|a| a.format())
             .collect();
+
+        // The bullet-text fallback `GwHeaderlessAdapter` legitimately also
+        // accepts a ListForge-text payload (same body grammar); the framed
+        // listforge-text matcher wins only by sitting ahead of it in the
+        // registry. For that fixture assert the order-decided winner rather
+        // than strict disjointness; every other fixture stays disjoint.
+        if f.format == RosterFormat::ListforgeText {
+            assert_eq!(
+                matched.first().copied(),
+                Some(RosterFormat::ListforgeText),
+                "listforge-text fixture: first matcher should be listforge-text, got {matched:?}"
+            );
+            assert!(
+                matched
+                    .iter()
+                    .all(|m| matches!(m, RosterFormat::ListforgeText | RosterFormat::Gw)),
+                "listforge-text fixture: unexpected extra matcher in {matched:?}"
+            );
+            continue;
+        }
 
         assert_eq!(
             matched.len(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9964,13 +9964,14 @@
     },
     "tools": {
       "name": "@alpaca-software/40kdc-data",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "SEE LICENSE IN LICENSE-TOOLS",
       "dependencies": {
         "ajv": "^8.17.0",
         "ajv-formats": "^3.0.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
+        "fflate": "^0.8.2",
         "glob": "^11.0.0"
       },
       "bin": {

--- a/python/src/wh40kdc/_version.py
+++ b/python/src/wh40kdc/_version.py
@@ -4,4 +4,4 @@ Kept in lockstep with tools/package.json and crates/wh40kdc/Cargo.toml;
 CI hard-fails on mismatch.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/python/src/wh40kdc/imports/__init__.py
+++ b/python/src/wh40kdc/imports/__init__.py
@@ -21,6 +21,7 @@ from wh40kdc.imports.adapter import FormatAdapter, select_adapter
 from wh40kdc.imports.decode import decode_listforge
 from wh40kdc.imports.gw import gw_adapter
 from wh40kdc.imports.listforge import listforge_adapter
+from wh40kdc.imports.listforge_text import listforge_text_adapter
 from wh40kdc.imports.newrecruit_json import newrecruit_json_adapter
 from wh40kdc.imports.newrecruit_simple import newrecruit_simple_adapter
 from wh40kdc.imports.newrecruit_wtc import (
@@ -49,6 +50,7 @@ ADAPTERS: tuple[FormatAdapter, ...] = (
     newrecruit_wtc_full_adapter,
     newrecruit_wtc_compact_adapter,
     newrecruit_simple_adapter,
+    listforge_text_adapter,
     listforge_adapter,
 )
 

--- a/python/src/wh40kdc/imports/listforge_text.py
+++ b/python/src/wh40kdc/imports/listforge_text.py
@@ -1,0 +1,248 @@
+"""ListForge plain-text adapter: lower ListForge's copy-paste text export to a
+``ParsedRoster``.
+
+This is the bullet-list text users copy out of the ListForge app (distinct
+from the base64+gzip share-JSON the ``listforge`` adapter handles). Shape::
+
+    all gas no breaks - Chaos Daemons - Daemonic Incursion (1995 Points)
+
+    Epic Hero:
+    Rotigus (250 pts)
+      • Gnarlrod
+      • Streams of brackish filth
+
+    Battleline:
+    Bloodletters (110 pts)
+      • Bloodreaper
+        • Hellblade
+      • Daemonic Icon
+      • 9x Bloodletter
+        • 9x Hellblade
+
+- The first non-blank line is ``<list name> - <faction> - <detachment>
+  (<N> Points)``. A list name containing `` - `` breaks the split — a
+  documented ListForge limitation, not ours.
+- Sections are mixed-case battlefield-role lines ending with ``:``
+  (``Epic Hero:``, ``Character:``, ``Battleline:``, …). Units under
+  ``Epic Hero:`` or ``Character:`` are characters.
+- Bullet classification mirrors the GW adapter: a top-level bullet with deeper
+  children is a **model group** (its ``Nx`` count — implicitly 1 — adds to the
+  model count); without children it's **wargear**. Child-bullet ``Nx`` counts
+  are already squad-wide totals; a child without a count is one item
+  (``• Hellblade`` under a lone Bloodreaper).
+- ``E: <name>`` is the enhancement annotation (ListForge reports no points for
+  it, so ``enhancement_points`` stays None and unit points stay as displayed).
+  A bare ``Warlord`` bullet flags the warlord.
+
+**Disjointness**: the ``(N Points)`` first-line suffix is unique to this
+format — newrecruit-simple's first line ends ``- [N pts]``, the GW export opens
+with a ``++++`` fence, and the WTC formats carry ``N with`` lines or no bullets
+at all.
+
+Python mirror of ``tools/src/import/listforge-text.ts``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from wh40kdc.imports.adapter import FormatAdapter
+from wh40kdc.imports.newrecruit_text import infer_battle_size_raw
+
+_FIRST_LINE = re.compile(r"^(.+)\s\(\s*(\d+)\s*Points?\s*\)\s*$", re.IGNORECASE)
+_SECTION_HEADER = re.compile(r"^[A-Za-z][A-Za-z0-9 /&'-]*:$")
+_UNIT_HEADER = re.compile(r"^(.+?)\s*\(\s*(\d+)\s*pts?\s*\)\s*$", re.IGNORECASE)
+_BULLET_LINE = re.compile(r"^(\s*)•\s*(.+?)\s*$")
+_NX_PREFIX = re.compile(r"^(\d+)x\s+(.+)$")
+_BULLET = re.compile(r"^[\t ]*•", re.MULTILINE)
+_WITH_LINE = re.compile(r"^[\t ]*\d+\s+with\b", re.MULTILINE)
+_SPLIT_LINES = re.compile(r"\r?\n")
+
+_ENHANCEMENT_PREFIX = "E: "
+_WARLORD_MARKER = "Warlord"
+_CHARACTER_SECTIONS = frozenset({"epic hero", "character"})
+
+
+def _is_listforge_text(decoded: Any) -> str | None:
+    """Accept plain text whose first non-blank line is the ListForge
+    ``name - faction - detachment (N Points)`` header, with ``•`` bullets and
+    no WTC ``N with`` lines."""
+    if not isinstance(decoded, str):
+        return None
+    first_non_blank = next(
+        (line for line in _SPLIT_LINES.split(decoded) if line.strip()), None
+    )
+    if not first_non_blank:
+        return None
+    first = _FIRST_LINE.match(first_non_blank.strip())
+    if not first or len(first.group(1).split(" - ")) < 3:
+        return None
+    if _BULLET.search(decoded) is None:
+        return None
+    if _WITH_LINE.search(decoded) is not None:
+        return None
+    return decoded
+
+
+def _parse_first_line(line: str) -> dict[str, Any] | None:
+    m = _FIRST_LINE.match(line.strip())
+    if not m:
+        return None
+    parts = [s for s in (p.strip() for p in m.group(1).split(" - ")) if s]
+    if len(parts) < 3:
+        return None
+    # `<list name> - <faction> - <detachment>`; the name is everything before
+    # the trailing two segments so faction names with hyphens stay intact only
+    # when ListForge itself doesn't insert ` - ` (it doesn't).
+    return {
+        "name": " - ".join(parts[: len(parts) - 2]),
+        "faction_raw_name": parts[-2],
+        "detachment_raw_name": parts[-1],
+        "total_reported": int(m.group(2)),
+    }
+
+
+def _finish_unit(acc: dict[str, Any]) -> dict[str, Any]:
+    bullets: list[dict[str, Any]] = acc["bullets"]
+    top_indent = min((b["indent"] for b in bullets), default=0)
+
+    # Insertion-ordered aggregation (dict preserves order, matching the TS Map).
+    wargear: dict[str, int] = {}
+    model_count = 0
+    is_warlord = False
+    enhancement_raw_name: str | None = None
+
+    def add_wargear(raw_name: str, count: int) -> None:
+        wargear[raw_name] = wargear.get(raw_name, 0) + count
+
+    for i, b in enumerate(bullets):
+        # Child bullet: a model group's weapon. ListForge child counts are
+        # squad-wide totals; a count-less child is a single item.
+        if b["indent"] > top_indent:
+            add_wargear(b["text"], b["count"] if b["count"] is not None else 1)
+            continue
+
+        # Top-level annotations.
+        if b["count"] is None:
+            if b["text"] == _WARLORD_MARKER:
+                is_warlord = True
+                continue
+            if b["text"].startswith(_ENHANCEMENT_PREFIX):
+                if enhancement_raw_name is None:
+                    enhancement_raw_name = b["text"][len(_ENHANCEMENT_PREFIX) :].strip()
+                continue
+
+        # Top-level entry: a model group when it has child bullets beneath it,
+        # otherwise plain wargear. Either way a missing `Nx` count means 1.
+        next_bullet = bullets[i + 1] if i + 1 < len(bullets) else None
+        if next_bullet is not None and next_bullet["indent"] > b["indent"]:
+            model_count += b["count"] if b["count"] is not None else 1
+        else:
+            add_wargear(b["text"], b["count"] if b["count"] is not None else 1)
+
+    if model_count == 0:
+        model_count = 1
+
+    return {
+        "raw_name": acc["raw_name"],
+        "is_character": acc["is_character"],
+        "model_count": model_count,
+        "points": acc["displayed_pts"],
+        "is_warlord": is_warlord,
+        "enhancement_raw_name": enhancement_raw_name,
+        # ListForge's text export reports no enhancement cost, so the unit's
+        # displayed points stay as-is and no enhancement points are claimed.
+        "enhancement_points": None,
+        "wargear": [{"raw_name": n, "count": c} for n, c in wargear.items()],
+    }
+
+
+def _matches(decoded: Any) -> bool:
+    return _is_listforge_text(decoded) is not None
+
+
+def _parse(decoded: Any) -> dict[str, Any]:
+    text = _is_listforge_text(decoded)
+    if text is None:
+        raise ValueError("listforge-text: input is not a ListForge text export")
+
+    lines = _SPLIT_LINES.split(text)
+    header: dict[str, Any] | None = None
+    units: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    section_is_character = False
+
+    def finalize() -> None:
+        nonlocal current
+        if current is not None:
+            units.append(_finish_unit(current))
+            current = None
+
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+
+        if header is None:
+            header = _parse_first_line(line)
+            if header is not None:
+                continue
+
+        bullet_match = _BULLET_LINE.match(raw)
+        if bullet_match:
+            if current is not None:
+                rest = bullet_match.group(2)
+                nx = _NX_PREFIX.match(rest)
+                current["bullets"].append(
+                    {
+                        "indent": len(bullet_match.group(1)),
+                        "count": int(nx.group(1)) if nx else None,
+                        "text": (nx.group(2) if nx else rest).strip(),
+                    }
+                )
+            continue
+
+        if _SECTION_HEADER.match(line):
+            finalize()
+            section_is_character = line[:-1].strip().lower() in _CHARACTER_SECTIONS
+            continue
+
+        unit_match = _UNIT_HEADER.match(line)
+        if unit_match:
+            finalize()
+            current = {
+                "raw_name": unit_match.group(1).strip(),
+                "displayed_pts": int(unit_match.group(2)),
+                "is_character": section_is_character,
+                "bullets": [],
+            }
+
+    finalize()
+
+    if header is None:
+        raise ValueError("listforge-text: missing ListForge header line")
+
+    total_computed = 0
+    for u in units:
+        total_computed += u["points"] or 0
+
+    # Like the GW export, ListForge text reports only the army total — use it as
+    # the declared limit so battle-size inference stays round-trippable.
+    declared_limit = header["total_reported"]
+
+    return {
+        "name": header["name"],
+        "generated_by": "List Forge",
+        "faction_raw_name": header["faction_raw_name"],
+        "detachment_raw_name": header["detachment_raw_name"],
+        "battle_size_raw": infer_battle_size_raw(declared_limit),
+        "declared_limit": declared_limit,
+        "total_reported": header["total_reported"],
+        "total_computed": total_computed,
+        "units": units,
+        "multi_force": False,
+    }
+
+
+listforge_text_adapter = FormatAdapter(id="listforge-text", matches=_matches, parse=_parse)

--- a/python/src/wh40kdc/imports/newrecruit_simple.py
+++ b/python/src/wh40kdc/imports/newrecruit_simple.py
@@ -31,15 +31,26 @@ from typing import Any
 from wh40kdc.imports.adapter import FormatAdapter
 from wh40kdc.imports.newrecruit_text import classify_wargear_list, split_wargear_list
 
-_FIRST_LINE = re.compile(r"^(.+)\s-\s\[\s*(\d+)\s*pts?\s*\]\s*$", re.IGNORECASE)
+# Point brackets may carry comma-separated faction resources after the pts
+# figure (e.g. `[4485pts, 29Cabal Points]`); the tail is recognized and
+# discarded — only the pts figure is consumed.
+_FIRST_LINE = re.compile(
+    r"^(.+)\s-\s\[\s*(\d+)\s*pts?\s*(?:,[^\]]*)?\]\s*$", re.IGNORECASE
+)
 _ROSTER_HEADER = re.compile(
-    r"^#\s*\+\+\s*Army Roster\s*\+\+\s*\[\s*(\d+)\s*pts?\s*\]\s*$", re.IGNORECASE
+    r"^#\s*\+\+\s*Army Roster\s*\+\+\s*\[\s*(\d+)\s*pts?\s*(?:,[^\]]*)?\]\s*$",
+    re.IGNORECASE,
 )
 _ROSTER_HEADER_ANYWHERE = re.compile(r"^#\s*\+\+\s*Army Roster\s*\+\+", re.MULTILINE)
-_SECTION_HEADER = re.compile(r"^##\s*(.+?)(?:\s*\[\s*(\d+)\s*pts?\s*\])?\s*$")
-_UNIT_LINE = re.compile(r"^(.+?)\s*\[\s*(\d+)\s*pts?\s*\](?:\s*:\s*(.*))?$", re.IGNORECASE)
+# Some exports omit the `# ++ Army Roster ++` line and open straight with a
+# `## Section` heading — accept either marker.
+_SECTION_HEADER_ANYWHERE = re.compile(r"^##\s+", re.MULTILINE)
+_SECTION_HEADER = re.compile(r"^##\s*(.+?)(?:\s*\[\s*(\d+)\s*pts?\s*(?:,[^\]]*)?\])?\s*$")
+_UNIT_LINE = re.compile(
+    r"^(.+?)\s*\[\s*(\d+)\s*pts?\s*(?:,[^\]]*)?\](?:\s*:\s*(.*))?$", re.IGNORECASE
+)
 _BULLET = re.compile(
-    r"^\s*•\s*(\d+)x\s+(.+?)(?:\s*\[\s*(\d+)\s*pts?\s*\])?(?:\s*:\s*(.*))?\s*$"
+    r"^\s*•\s*(\d+)x\s+(.+?)(?:\s*\[\s*(\d+)\s*pts?\s*(?:,[^\]]*)?\])?(?:\s*:\s*(.*))?\s*$"
 )
 _SPLIT_LINES = re.compile(r"\r?\n")
 
@@ -115,7 +126,12 @@ def _matches(decoded: Any) -> bool:
         return False
     if not _FIRST_LINE.match(first_non_blank):
         return False
-    return _ROSTER_HEADER_ANYWHERE.search(decoded) is not None
+    # Some exports omit the `# ++ Army Roster ++` line and open straight with
+    # a `## Section` heading — accept either marker.
+    return (
+        _ROSTER_HEADER_ANYWHERE.search(decoded) is not None
+        or _SECTION_HEADER_ANYWHERE.search(decoded) is not None
+    )
 
 
 def _parse(decoded: Any) -> dict[str, Any]:
@@ -174,15 +190,20 @@ def _parse(decoded: Any) -> dict[str, Any]:
             continue
 
         if section == "configuration":
-            idx = line.find(":")
-            if idx > 0:
-                key = line[:idx].strip().lower()
-                value = line[idx + 1 :].strip()
-                if key == "battle size":
-                    battle_size_raw = value
-                elif key == "detachment":
-                    detachment_raw_name = value
-            continue
+            # Some exports list units directly after Configuration with no units
+            # section heading; a `Name [N pts]` line ends the configuration block.
+            if _UNIT_LINE.match(line):
+                section = "units"
+            else:
+                idx = line.find(":")
+                if idx > 0:
+                    key = line[:idx].strip().lower()
+                    value = line[idx + 1 :].strip()
+                    if key == "battle size":
+                        battle_size_raw = value
+                    elif key == "detachment":
+                        detachment_raw_name = value
+                continue
 
         # Unit section. A bullet line extends the *current* unit.
         bullet_match = _BULLET.match(raw)

--- a/python/tests/conformance/test_roster_import.py
+++ b/python/tests/conformance/test_roster_import.py
@@ -24,7 +24,12 @@ from ..conftest import CORPUS
 _ROSTER_DIR = CORPUS / "roster"
 _CASES = sorted(p.name for p in _ROSTER_DIR.iterdir() if p.is_dir()) if _ROSTER_DIR.exists() else []
 
-_CANONICAL_SEEDS = ("input.json", "input.newrecruit-json.json", "input.gw.txt")
+_CANONICAL_SEEDS = (
+    "input.json",
+    "input.newrecruit-json.json",
+    "input.gw.txt",
+    "input.listforge-text.txt",
+)
 _NEWRECRUIT_INPUT = re.compile(r"^input\.(newrecruit-[a-z-]+)\.[a-z]+$")
 
 
@@ -42,6 +47,8 @@ def _expected_format_for(filename: str) -> str:
         return "rosterizer"
     if filename == "input.gw.txt":
         return "gw"
+    if filename == "input.listforge-text.txt":
+        return "listforge-text"
     match = _NEWRECRUIT_INPUT.match(filename)
     if not match:
         raise AssertionError(f"unrecognised input fixture filename: {filename}")

--- a/python/tests/imports/test_listforge_text.py
+++ b/python/tests/imports/test_listforge_text.py
@@ -1,0 +1,173 @@
+"""ListForge plain-text adapter unit tests.
+
+ListForge's copy-paste export: a ``name - faction - detachment (N Points)``
+first line, mixed-case role sections ending with ``:``, units as
+``Name (N pts)`` headers, and indented ``•`` bullets for model groups, wargear,
+the ``E: <name>`` enhancement annotation, and the bare ``Warlord`` marker.
+These tests pin the parse and the disjointness from the other text matchers.
+
+Python mirror of ``tools/test/import/listforge-text.test.ts``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from wh40kdc.imports import try_import_roster
+from wh40kdc.imports.gw import gw_adapter
+from wh40kdc.imports.listforge_text import listforge_text_adapter
+from wh40kdc.imports.newrecruit_simple import newrecruit_simple_adapter
+
+# Condensed from the reference Chaos Daemons export.
+SAMPLE = """all gas no breaks - Chaos Daemons - Daemonic Incursion (1995 Points)
+
+
+Epic Hero:
+Rotigus (250 pts)
+  • Gnarlrod
+  • Streams of brackish filth
+
+
+Character:
+Great Unclean One (295 pts)
+  • Putrid vomit
+  • Bileblade
+  • Bilesword
+  • E: The Endless Gift
+  • Warlord
+
+Bloodmaster (65 pts)
+  • Blade of blood
+
+
+Battleline:
+Bloodletters (110 pts)
+  • Bloodreaper
+    • Hellblade
+  • Instrument of Chaos
+  • Daemonic Icon
+  • 9x Bloodletter
+    • 9x Hellblade
+
+
+Beast:
+Flesh Hounds (75 pts)
+  • Gore Hound
+    • Burning maw
+    • Collar of Khorne
+    • Gore-drenched fangs
+  • 4x Flesh Hound
+    • 4x Collar of Khorne
+    • 4x Gore-drenched fangs
+"""
+
+
+def _by_name(parsed: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {u["raw_name"]: u for u in parsed["units"]}
+
+
+def _gear(unit: dict[str, Any]) -> dict[str, int]:
+    return {w["raw_name"]: w["count"] for w in unit["wargear"]}
+
+
+class TestMatches:
+    def test_recognises_the_listforge_text_export(self) -> None:
+        assert listforge_text_adapter.matches(SAMPLE) is True
+
+    def test_rejects_non_string_and_other_text_formats(self) -> None:
+        assert listforge_text_adapter.matches({"roster": {}}) is False
+        # newrecruit-simple first line ends `- [N pts]`, not `(N Points)`.
+        assert (
+            listforge_text_adapter.matches(
+                "Chaos - Chaos Knights - List - [2000 pts]\n\n"
+                "# ++ Army Roster ++ [2000 pts]\nUnit [5 pts]:\n• 1x Model: Gun"
+            )
+            is False
+        )
+        # A GW export's first non-blank line is the `++++` fence.
+        assert (
+            listforge_text_adapter.matches(
+                "++++\n+ FACTION KEYWORD: Chaos - Chaos Knights\n++++\n"
+                "Unit (5 pts)\n• 1x Gun"
+            )
+            is False
+        )
+
+    def test_requires_bullets_and_refuses_wtc_with_bodies(self) -> None:
+        no_bullets = "name - Faction - Detachment (1000 Points)\nUnit (50 pts)"
+        assert listforge_text_adapter.matches(no_bullets) is False
+        with_lines = (
+            "name - Faction - Detachment (1000 Points)\n"
+            "Unit (50 pts)\n  • Gun\n1 with Sword"
+        )
+        assert listforge_text_adapter.matches(with_lines) is False
+
+    def test_stays_disjoint_from_other_text_matchers(self) -> None:
+        assert gw_adapter.matches(SAMPLE) is False
+        assert newrecruit_simple_adapter.matches(SAMPLE) is False
+
+
+class TestTryImportRoster:
+    def test_auto_detects_and_resolves(self, dataset: Any) -> None:
+        result = try_import_roster(SAMPLE, dataset)
+        assert result["ok"] is True
+        assert result["format"] == "listforge-text"
+        assert result["roster"]["faction_id"] == "chaos-daemons"
+
+
+class TestParse:
+    parsed = listforge_text_adapter.parse(SAMPLE)
+
+    def test_reads_header_fields(self) -> None:
+        assert self.parsed["name"] == "all gas no breaks"
+        assert self.parsed["faction_raw_name"] == "Chaos Daemons"
+        assert self.parsed["detachment_raw_name"] == "Daemonic Incursion"
+        assert self.parsed["total_reported"] == 1995
+        # ListForge reports only the army total — it doubles as the limit.
+        assert self.parsed["declared_limit"] == 1995
+
+    def test_captures_units_in_declaration_order(self) -> None:
+        assert [u["raw_name"] for u in self.parsed["units"]] == [
+            "Rotigus",
+            "Great Unclean One",
+            "Bloodmaster",
+            "Bloodletters",
+            "Flesh Hounds",
+        ]
+
+    def test_flags_characters_from_epic_hero_and_character_sections(self) -> None:
+        flags = {u["raw_name"]: u["is_character"] for u in self.parsed["units"]}
+        assert flags["Rotigus"] is True
+        assert flags["Great Unclean One"] is True
+        assert flags["Bloodmaster"] is True
+        assert flags["Bloodletters"] is False
+        assert flags["Flesh Hounds"] is False
+
+    def test_reads_enhancement_without_claiming_points(self) -> None:
+        guo = _by_name(self.parsed)["Great Unclean One"]
+        assert guo["enhancement_raw_name"] == "The Endless Gift"
+        assert guo["enhancement_points"] is None
+        assert guo["points"] == 295  # displayed points stay as-is
+        assert guo["is_warlord"] is True
+
+    def test_derives_model_counts_from_bulleted_model_groups(self) -> None:
+        units = _by_name(self.parsed)
+        assert units["Bloodletters"]["model_count"] == 10  # Bloodreaper + 9x
+        assert units["Flesh Hounds"]["model_count"] == 5  # Gore Hound + 4x
+        assert units["Rotigus"]["model_count"] == 1  # wargear-only bullets
+
+    def test_aggregates_squad_wide_wargear(self) -> None:
+        gear = _gear(_by_name(self.parsed)["Bloodletters"])
+        assert gear["Hellblade"] == 10  # 1 (Bloodreaper's) + 9 (squad line)
+        assert gear["Instrument of Chaos"] == 1
+        assert gear["Daemonic Icon"] == 1
+
+    def test_sums_total_computed_from_unit_points(self) -> None:
+        assert self.parsed["total_computed"] == 250 + 295 + 65 + 110 + 75
+
+    def test_does_not_leak_prose_fields(self) -> None:
+        import json
+
+        blob = json.dumps(self.parsed)
+        assert "description" not in blob
+        assert "rules" not in blob

--- a/python/tests/imports/test_newrecruit_simple.py
+++ b/python/tests/imports/test_newrecruit_simple.py
@@ -1,0 +1,72 @@
+"""NewRecruit "simple" text adapter edge-case unit tests.
+
+Ports the "edge cases" block from
+``tools/test/import/newrecruit-simple.test.ts``:
+
+1. Points brackets may carry comma-separated faction resources
+   (``[4485pts, 29Cabal Points]``) — the tail is discarded.
+2. ``matches()`` accepts exports that omit the ``# ++ Army Roster ++`` line but
+   carry a ``## Section`` heading.
+3. A unit line directly after Configuration ends the configuration block.
+"""
+
+from __future__ import annotations
+
+from wh40kdc.imports.newrecruit_simple import newrecruit_simple_adapter
+
+
+def test_parses_points_brackets_with_comma_separated_faction_resources() -> None:
+    cabal = (
+        "Chaos - Thousand Sons - Tester - [4485pts, 29Cabal Points]\n"
+        "\n"
+        "# ++ Army Roster ++ [4485pts, 29Cabal Points]\n"
+        "## Epic Hero [895pts, 13Cabal Points]\n"
+        "Ahriman [140pts, 3Cabal Points]: Black Staff of Ahriman, Inferno bolt pistol\n"
+    )
+    assert newrecruit_simple_adapter.matches(cabal) is True
+    parsed = newrecruit_simple_adapter.parse(cabal)
+    assert parsed["declared_limit"] == 4485
+    assert parsed["total_reported"] == 4485
+    assert len(parsed["units"]) == 1
+    assert parsed["units"][0]["raw_name"] == "Ahriman"
+    assert parsed["units"][0]["points"] == 140
+
+
+def test_matches_exports_that_omit_army_roster_line_but_carry_sections() -> None:
+    headerless = (
+        "Chaos - World Eaters - Proxy List - [2000pts]\n"
+        "\n"
+        "## Epic Hero [675pts]\n"
+        "Angron [435pts]: Samni'arius and Spinegrinder, Warlord\n"
+    )
+    assert newrecruit_simple_adapter.matches(headerless) is True
+    parsed = newrecruit_simple_adapter.parse(headerless)
+    assert parsed["faction_raw_name"] == "World Eaters"
+    assert parsed["total_reported"] is None
+    assert len(parsed["units"]) == 1
+    assert parsed["units"][0]["is_warlord"] is True
+
+
+def test_unit_line_directly_after_configuration_ends_that_section() -> None:
+    no_units_header = (
+        "Xenos - T'au Empire - Base Tau - [2000pts]\n"
+        "\n"
+        "# ++ Army Roster ++ [2000pts]\n"
+        "## Configuration\n"
+        "Battle Size: Strike Force (2000 Point limit)\n"
+        "Detachment: Auxiliary Cadre\n"
+        "Show/Hide Options: Legends are visible\n"
+        "\n"
+        "Broadside Battlesuits [90pts]:\n"
+        "• 1x Broadside Shas'vre: Crushing bulk, 2x Shield Drone, Heavy rail rifle\n"
+        "Broadside Battlesuits [90pts]:\n"
+        "• 1x Broadside Shas'vre: Crushing bulk, 2x Shield Drone, Heavy rail rifle\n"
+    )
+    parsed = newrecruit_simple_adapter.parse(no_units_header)
+    assert parsed["detachment_raw_name"] == "Auxiliary Cadre"
+    assert len(parsed["units"]) == 2
+    assert parsed["units"][0]["raw_name"] == "Broadside Battlesuits"
+    assert parsed["units"][0]["model_count"] == 1
+    gear = {w["raw_name"]: w["count"] for w in parsed["units"][0]["wargear"]}
+    assert gear["Shield Drone"] == 2
+    assert gear["Heavy rail rifle"] == 1

--- a/schemas/core/roster.schema.json
+++ b/schemas/core/roster.schema.json
@@ -14,6 +14,7 @@
           "type": "string",
           "enum": [
             "listforge",
+            "listforge-text",
             "newrecruit-json",
             "newrecruit-wtc-compact",
             "newrecruit-wtc-full",

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@alpaca-software/40kdc-data",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
-  "description": "The 40kdc Warhammer 40K dataset behind a linked, typed API \u2014 find units, follow them to their weapons, abilities, phases, and factions. Also validates data against the canonical JSON Schemas.",
+  "description": "The 40kdc Warhammer 40K dataset behind a linked, typed API — find units, follow them to their weapons, abilities, phases, and factions. Also validates data against the canonical JSON Schemas.",
   "keywords": [
     "warhammer",
     "warhammer-40k",
@@ -28,6 +28,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./validate": {
+      "types": "./dist/schema-loader.d.ts",
+      "default": "./dist/schema-loader.js"
     },
     "./schemas/*": "./schemas/*"
   },
@@ -79,6 +83,7 @@
     "ajv-formats": "^3.0.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
+    "fflate": "^0.8.2",
     "glob": "^11.0.0"
   },
   "devDependencies": {

--- a/tools/src/gen-conformance.ts
+++ b/tools/src/gen-conformance.ts
@@ -101,7 +101,8 @@ function genNormalize(): void {
 
 /** Locate the canonical input for a fixture dir: prefer `input.json` (legacy
  * ListForge), then `input.newrecruit-json.json` (NewRecruit), then the
- * text-only `input.gw.txt` (GW app export — import-only, like ListForge). */
+ * text-only `input.gw.txt` / `input.listforge-text.txt` (app text exports —
+ * import-only, like ListForge). */
 function seedRoster(caseDir: string, ds: Dataset): Roster {
   const decoded = decodeCanonicalSeed(caseDir);
   return importRoster(decoded, { dataset: ds });
@@ -122,6 +123,10 @@ function decodeCanonicalSeed(caseDir: string): unknown {
   const gwSeed = join(caseDir, "input.gw.txt");
   if (existsSync(gwSeed)) {
     return readFileSync(gwSeed, "utf8");
+  }
+  const lfTextSeed = join(caseDir, "input.listforge-text.txt");
+  if (existsSync(lfTextSeed)) {
+    return readFileSync(lfTextSeed, "utf8");
   }
   throw new Error(`no canonical input found in ${caseDir}`);
 }

--- a/tools/src/import/decode.ts
+++ b/tools/src/import/decode.ts
@@ -12,11 +12,27 @@
  * - a bare base64 segment,
  * - an already-decoded JSON string (passed straight to `JSON.parse`).
  *
- * Only `node:zlib` is used — no third-party dependency.
+ * Decompression uses `fflate` (a tiny, dependency-free inflate) rather than
+ * `node:zlib` so the importer works in browsers as well as Node — this module
+ * is reachable from the package's root barrel and must stay universal.
  *
  * @packageDocumentation
  */
-import { gunzipSync } from "node:zlib";
+import { gunzipSync } from "fflate";
+
+/**
+ * Universal base64 → bytes. Node decodes via Buffer; browsers via atob.
+ * (`Uint8Array.fromBase64` is still too new to rely on.)
+ */
+function base64ToBytes(b64: string): Uint8Array {
+  if (typeof Buffer !== "undefined") {
+    return new Uint8Array(Buffer.from(b64, "base64"));
+  }
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
 
 /** The base64 prefix every ListForge gzip payload begins with. */
 const GZIP_BASE64_PREFIX = "H4sIA";
@@ -70,8 +86,8 @@ export function decodeListForge(input: string): unknown {
 
   let json: string;
   try {
-    const bytes = Buffer.from(segment, "base64");
-    json = gunzipSync(bytes).toString("utf8");
+    const bytes = base64ToBytes(segment);
+    json = new TextDecoder().decode(gunzipSync(bytes));
   } catch (cause) {
     throw new Error("decodeListForge: failed to gunzip base64 payload", {
       cause,

--- a/tools/src/import/import-roster.ts
+++ b/tools/src/import/import-roster.ts
@@ -16,6 +16,7 @@ import { selectAdapter } from "./adapter.js";
 import { decodeListForge } from "./decode.js";
 import { gwAdapter } from "./gw.js";
 import { listForgeAdapter } from "./listforge.js";
+import { listForgeTextAdapter } from "./listforge-text.js";
 import { newRecruitJsonAdapter } from "./newrecruit-json.js";
 import { newRecruitSimpleAdapter } from "./newrecruit-simple.js";
 import {
@@ -32,12 +33,14 @@ import type { Roster, RosterFormat } from "./types.js";
  * NewRecruit-JSON runs ahead of ListForge because both recognise a
  * `roster.forces` BattleScribe payload, and the NewRecruit signature is more
  * specific (`xmlns: rosterSchema` or `generatedBy: newrecruit.eu`). The text
- * adapters (`gw` / `wtc-compact` / `wtc-full` / `simple`) only match strings and
- * disambiguate among themselves via structural cues, so their order amongst
- * each other doesn't matter; wtc-full goes before wtc-compact because its
- * matcher is the more specific of the two. GW shares the WTC summary header but
- * carries `•` bullets and no `N with` lines, so it stays disjoint from both wtc
- * matchers. Rosterizer rides at the top of the JSON dispatch — its `rulebook` +
+ * adapters (`gw` / `wtc-compact` / `wtc-full` / `simple` / `listforge-text`)
+ * only match strings and disambiguate among themselves via structural cues, so
+ * their order amongst each other doesn't matter; wtc-full goes before
+ * wtc-compact because its matcher is the more specific of the two. GW shares
+ * the WTC summary header but carries `•` bullets and no `N with` lines, so it
+ * stays disjoint from both wtc matchers; listforge-text requires the
+ * `name - faction - detachment (N Points)` first line none of the others
+ * accept. Rosterizer rides at the top of the JSON dispatch — its `rulebook` +
  * `snapshot` signature is structurally distinct from the BattleScribe
  * `roster.forces` shape.
  */
@@ -48,6 +51,7 @@ const ADAPTERS: readonly FormatAdapter[] = [
   newRecruitWtcFullAdapter,
   newRecruitWtcCompactAdapter,
   newRecruitSimpleAdapter,
+  listForgeTextAdapter,
   listForgeAdapter,
 ];
 

--- a/tools/src/import/index.ts
+++ b/tools/src/import/index.ts
@@ -25,6 +25,7 @@ export type {
 export { decodeListForge } from "./decode.js";
 export { resolve } from "./resolve.js";
 export { listForgeAdapter } from "./listforge.js";
+export { listForgeTextAdapter } from "./listforge-text.js";
 export { newRecruitJsonAdapter } from "./newrecruit-json.js";
 export { newRecruitSimpleAdapter } from "./newrecruit-simple.js";
 export {

--- a/tools/src/import/listforge-text.ts
+++ b/tools/src/import/listforge-text.ts
@@ -1,0 +1,281 @@
+/**
+ * ListForge plain-text adapter: lower ListForge's copy-paste text export to a
+ * {@link ParsedRoster}.
+ *
+ * This is the bullet-list text users copy out of the ListForge app (distinct
+ * from the base64+gzip share-JSON the `listforge` adapter handles). Shape:
+ *
+ * ```
+ * all gas no breaks - Chaos Daemons - Daemonic Incursion (1995 Points)
+ *
+ * Epic Hero:
+ * Rotigus (250 pts)
+ *   • Gnarlrod
+ *   • Streams of brackish filth
+ *
+ * Battleline:
+ * Bloodletters (110 pts)
+ *   • Bloodreaper
+ *     • Hellblade
+ *   • Daemonic Icon
+ *   • 9x Bloodletter
+ *     • 9x Hellblade
+ * ```
+ *
+ * - The first non-blank line is `<list name> - <faction> - <detachment>
+ *   (<N> Points)`. A list name containing ` - ` breaks the split — a documented
+ *   ListForge limitation, not ours.
+ * - Sections are mixed-case battlefield-role lines ending with `:`
+ *   (`Epic Hero:`, `Character:`, `Battleline:`, …). Units under `Epic Hero:` or
+ *   `Character:` are characters.
+ * - Bullet classification mirrors the GW adapter: a top-level bullet with
+ *   deeper children is a **model group** (its `Nx` count — implicitly 1 —
+ *   adds to the model count); without children it's **wargear**. Child-bullet
+ *   `Nx` counts are already squad-wide totals; a child without a count is one
+ *   item (`• Hellblade` under a lone Bloodreaper).
+ * - `E: <name>` is the enhancement annotation (ListForge reports no points for
+ *   it, so `enhancement_points` stays null and unit points stay as displayed).
+ *   A bare `Warlord` bullet flags the warlord.
+ *
+ * **Disjointness**: the `(N Points)` first-line suffix is unique to this
+ * format — newrecruit-simple's first line ends `- [N pts]`, the GW export
+ * opens with a `++++` fence, and the WTC formats carry `N with` lines or no
+ * bullets at all.
+ *
+ * @packageDocumentation
+ */
+import type { FormatAdapter } from "./adapter.js";
+import type { ParsedRoster, ParsedUnit, ParsedWargear } from "./types.js";
+import { inferBattleSizeRaw } from "./newrecruit-text.js";
+
+const FIRST_LINE = /^(.+)\s\(\s*(\d+)\s*Points?\s*\)\s*$/i;
+const SECTION_HEADER = /^[A-Za-z][A-Za-z0-9 /&'-]*:$/;
+const UNIT_HEADER = /^(.+?)\s*\(\s*(\d+)\s*pts?\s*\)\s*$/i;
+const BULLET_LINE = /^(\s*)•\s*(.+?)\s*$/u;
+const NX_PREFIX = /^(\d+)x\s+(.+)$/;
+const BULLET = /^[\t ]*•/mu;
+const WITH_LINE = /^[\t ]*\d+\s+with\b/m;
+
+const ENHANCEMENT_PREFIX = "E: ";
+const WARLORD_MARKER = "Warlord";
+const CHARACTER_SECTIONS = new Set(["epic hero", "character"]);
+
+/** Accept plain text whose first non-blank line is the ListForge
+ * `name - faction - detachment (N Points)` header, with `•` bullets and no
+ * WTC `N with` lines. */
+function isListForgeText(decoded: unknown): string | null {
+  if (typeof decoded !== "string") return null;
+  const firstNonBlank = decoded
+    .split(/\r?\n/)
+    .find((l) => l.trim().length > 0);
+  if (!firstNonBlank) return null;
+  const first = FIRST_LINE.exec(firstNonBlank.trim());
+  if (!first || first[1].split(" - ").length < 3) return null;
+  if (!BULLET.test(decoded)) return null;
+  if (WITH_LINE.test(decoded)) return null;
+  return decoded;
+}
+
+interface Header {
+  name: string;
+  faction_raw_name: string | null;
+  detachment_raw_name: string | null;
+  total_reported: number | null;
+}
+
+function parseFirstLine(line: string): Header | null {
+  const m = FIRST_LINE.exec(line.trim());
+  if (!m) return null;
+  const parts = m[1].split(" - ").map((s) => s.trim()).filter(Boolean);
+  if (parts.length < 3) return null;
+  // `<list name> - <faction> - <detachment>`; the name is everything before
+  // the trailing two segments so faction names with hyphens stay intact only
+  // when ListForge itself doesn't insert ` - ` (it doesn't).
+  return {
+    name: parts.slice(0, parts.length - 2).join(" - "),
+    faction_raw_name: parts[parts.length - 2],
+    detachment_raw_name: parts[parts.length - 1],
+    total_reported: Number.parseInt(m[2], 10),
+  };
+}
+
+interface Bullet {
+  indent: number;
+  count: number | null;
+  text: string;
+}
+
+interface UnitAcc {
+  raw_name: string;
+  displayed_pts: number | null;
+  is_character: boolean;
+  bullets: Bullet[];
+}
+
+function finishUnit(acc: UnitAcc): ParsedUnit {
+  const topIndent = acc.bullets.length
+    ? Math.min(...acc.bullets.map((b) => b.indent))
+    : 0;
+
+  const wargear = new Map<string, number>();
+  let model_count = 0;
+  let is_warlord = false;
+  let enhancement_raw_name: string | null = null;
+
+  const addWargear = (raw_name: string, count: number): void => {
+    wargear.set(raw_name, (wargear.get(raw_name) ?? 0) + count);
+  };
+
+  for (let i = 0; i < acc.bullets.length; i += 1) {
+    const b = acc.bullets[i];
+
+    // Child bullet: a model group's weapon. ListForge child counts are
+    // squad-wide totals; a count-less child is a single item.
+    if (b.indent > topIndent) {
+      addWargear(b.text, b.count ?? 1);
+      continue;
+    }
+
+    // Top-level annotations.
+    if (b.count === null) {
+      if (b.text === WARLORD_MARKER) {
+        is_warlord = true;
+        continue;
+      }
+      if (b.text.startsWith(ENHANCEMENT_PREFIX)) {
+        if (enhancement_raw_name === null) {
+          enhancement_raw_name = b.text.slice(ENHANCEMENT_PREFIX.length).trim();
+        }
+        continue;
+      }
+    }
+
+    // Top-level entry: a model group when it has child bullets beneath it,
+    // otherwise plain wargear. Either way a missing `Nx` count means 1.
+    const next = acc.bullets[i + 1];
+    if (next && next.indent > b.indent) {
+      model_count += b.count ?? 1;
+    } else {
+      addWargear(b.text, b.count ?? 1);
+    }
+  }
+
+  if (model_count === 0) model_count = 1;
+
+  return {
+    raw_name: acc.raw_name,
+    is_character: acc.is_character,
+    model_count,
+    points: acc.displayed_pts,
+    is_warlord,
+    enhancement_raw_name,
+    // ListForge's text export reports no enhancement cost, so the unit's
+    // displayed points stay as-is and no enhancement points are claimed.
+    enhancement_points: null,
+    wargear: [...wargear].map(
+      ([raw_name, count]): ParsedWargear => ({ raw_name, count }),
+    ),
+  };
+}
+
+export const listForgeTextAdapter: FormatAdapter = {
+  id: "listforge-text",
+
+  matches(decoded: unknown): boolean {
+    return isListForgeText(decoded) !== null;
+  },
+
+  parse(decoded: unknown): ParsedRoster {
+    const text = isListForgeText(decoded);
+    if (text === null) {
+      throw new Error("listforge-text: input is not a ListForge text export");
+    }
+
+    const lines = text.split(/\r?\n/);
+    let header: Header | null = null;
+    const units: ParsedUnit[] = [];
+    let current: UnitAcc | null = null;
+    let sectionIsCharacter = false;
+
+    const finalize = (): void => {
+      if (current) {
+        units.push(finishUnit(current));
+        current = null;
+      }
+    };
+
+    for (const raw of lines) {
+      const line = raw.trim();
+      if (!line) continue;
+
+      if (!header) {
+        header = parseFirstLine(line);
+        if (header) continue;
+      }
+
+      const bulletMatch = BULLET_LINE.exec(raw);
+      if (bulletMatch) {
+        if (current) {
+          const rest = bulletMatch[2];
+          const nx = NX_PREFIX.exec(rest);
+          current.bullets.push({
+            indent: bulletMatch[1].length,
+            count: nx ? Number.parseInt(nx[1], 10) : null,
+            text: (nx ? nx[2] : rest).trim(),
+          });
+        }
+        continue;
+      }
+
+      if (SECTION_HEADER.test(line)) {
+        finalize();
+        sectionIsCharacter = CHARACTER_SECTIONS.has(
+          line.slice(0, -1).trim().toLowerCase(),
+        );
+        continue;
+      }
+
+      const unitMatch = UNIT_HEADER.exec(line);
+      if (unitMatch) {
+        finalize();
+        current = {
+          raw_name: unitMatch[1].trim(),
+          displayed_pts: Number.parseInt(unitMatch[2], 10),
+          is_character: sectionIsCharacter,
+          bullets: [],
+        };
+      }
+    }
+    finalize();
+
+    if (!header) {
+      throw new Error("listforge-text: missing ListForge header line");
+    }
+
+    let total_computed = 0;
+    for (const u of units) total_computed += u.points ?? 0;
+
+    // Like the GW export, ListForge text reports only the army total — use it
+    // as the declared limit so battle-size inference stays round-trippable.
+    const declared_limit = header.total_reported;
+
+    return {
+      name: header.name,
+      generated_by: "List Forge",
+      faction_raw_name: header.faction_raw_name,
+      detachment_raw_name: header.detachment_raw_name,
+      battle_size_raw: inferBattleSizeRaw(declared_limit),
+      declared_limit,
+      total_reported: header.total_reported,
+      total_computed,
+      units,
+      multi_force: false,
+    };
+  },
+};
+
+// Internals re-exported for unit tests.
+export const _internals = {
+  isListForgeText,
+  parseFirstLine,
+};

--- a/tools/src/import/newrecruit-simple.ts
+++ b/tools/src/import/newrecruit-simple.ts
@@ -28,12 +28,16 @@ import type { FormatAdapter } from "./adapter.js";
 import type { ParsedRoster, ParsedUnit, ParsedWargear } from "./types.js";
 import { classifyWargearList, splitWargearList } from "./newrecruit-text.js";
 
-const FIRST_LINE = /^(.+)\s-\s\[\s*(\d+)\s*pts?\s*\]\s*$/i;
-const ROSTER_HEADER = /^#\s*\+\+\s*Army Roster\s*\+\+\s*\[\s*(\d+)\s*pts?\s*\]\s*$/i;
-const SECTION_HEADER = /^##\s*(.+?)(?:\s*\[\s*(\d+)\s*pts?\s*\])?\s*$/;
-const UNIT_LINE = /^(.+?)\s*\[\s*(\d+)\s*pts?\s*\](?:\s*:\s*(.*))?$/i;
+// Point brackets may carry comma-separated faction resources after the pts
+// figure (e.g. `[4485pts, 29Cabal Points]`); the tail is recognized and
+// discarded — only the pts figure is consumed.
+const FIRST_LINE = /^(.+)\s-\s\[\s*(\d+)\s*pts?\s*(?:,[^\]]*)?\]\s*$/i;
+const ROSTER_HEADER =
+  /^#\s*\+\+\s*Army Roster\s*\+\+\s*\[\s*(\d+)\s*pts?\s*(?:,[^\]]*)?\]\s*$/i;
+const SECTION_HEADER = /^##\s*(.+?)(?:\s*\[\s*(\d+)\s*pts?\s*(?:,[^\]]*)?\])?\s*$/;
+const UNIT_LINE = /^(.+?)\s*\[\s*(\d+)\s*pts?\s*(?:,[^\]]*)?\](?:\s*:\s*(.*))?$/i;
 const BULLET =
-  /^\s*•\s*(\d+)x\s+(.+?)(?:\s*\[\s*(\d+)\s*pts?\s*\])?(?:\s*:\s*(.*))?\s*$/u;
+  /^\s*•\s*(\d+)x\s+(.+?)(?:\s*\[\s*(\d+)\s*pts?\s*(?:,[^\]]*)?\])?(?:\s*:\s*(.*))?\s*$/u;
 
 interface UnitBuilder {
   raw_name: string;
@@ -119,7 +123,12 @@ export const newRecruitSimpleAdapter: FormatAdapter = {
     const firstNonBlank = lines.find((l) => l.trim().length > 0);
     if (!firstNonBlank) return false;
     if (!FIRST_LINE.test(firstNonBlank)) return false;
-    return /^#\s*\+\+\s*Army Roster\s*\+\+/m.test(decoded);
+    // Some exports omit the `# ++ Army Roster ++` line and open straight with
+    // a `## Section` heading — accept either marker.
+    return (
+      /^#\s*\+\+\s*Army Roster\s*\+\+/m.test(decoded) ||
+      /^##\s+/m.test(decoded)
+    );
   },
 
   parse(decoded: unknown): ParsedRoster {
@@ -184,14 +193,20 @@ export const newRecruitSimpleAdapter: FormatAdapter = {
       }
 
       if (section === "configuration") {
-        const idx = line.indexOf(":");
-        if (idx > 0) {
-          const key = line.slice(0, idx).trim().toLowerCase();
-          const value = line.slice(idx + 1).trim();
-          if (key === "battle size") battle_size_raw = value;
-          else if (key === "detachment") detachment_raw_name = value;
+        // Some exports list units directly after Configuration with no units
+        // section heading; a `Name [N pts]` line ends the configuration block.
+        if (UNIT_LINE.test(line)) {
+          section = "units";
+        } else {
+          const idx = line.indexOf(":");
+          if (idx > 0) {
+            const key = line.slice(0, idx).trim().toLowerCase();
+            const value = line.slice(idx + 1).trim();
+            if (key === "battle size") battle_size_raw = value;
+            else if (key === "detachment") detachment_raw_name = value;
+          }
+          continue;
         }
-        continue;
       }
 
       // Unit section. A bullet line extends the *current* unit.

--- a/tools/src/import/types.ts
+++ b/tools/src/import/types.ts
@@ -88,6 +88,7 @@ export interface RosterUnit {
  * extend this union; `roster.schema.json` keeps the canonical enum. */
 export type RosterFormat =
   | "listforge"
+  | "listforge-text"
   | "newrecruit-json"
   | "newrecruit-wtc-compact"
   | "newrecruit-wtc-full"

--- a/tools/src/index.ts
+++ b/tools/src/index.ts
@@ -55,14 +55,10 @@ export type {
 // module and pinned by the `conformance/scoring` corpus.
 export * from "./scoring/index.js";
 
-// Schema access + AJV validation (secondary: this package also validates data
-// against the canonical JSON Schemas).
-export {
-  createValidator,
-  findSchemaFiles,
-  listSchemaIds,
-  SCHEMAS_ROOT,
-} from "./schema-loader.js";
+// Schema access + AJV validation lives behind the `./validate` subpath export
+// (`@alpaca-software/40kdc-data/validate`), NOT the root barrel: it reads
+// schema files from disk at module load (node:fs/node:url), which breaks
+// browser bundles. The root barrel stays universal (Node + browser).
 
 // Army-list importer (ListForge → resolved 40kdc roster). Types are curated
 // rather than re-exported wholesale to avoid name clashes with generated types

--- a/tools/test/conformance.test.ts
+++ b/tools/test/conformance.test.ts
@@ -87,6 +87,7 @@ function expectedFormatFor(filename: string): RosterFormat {
   if (filename === "input.json") return "listforge";
   if (filename === "input.rosterizer.json") return "rosterizer";
   if (filename === "input.gw.txt") return "gw";
+  if (filename === "input.listforge-text.txt") return "listforge-text";
   const match = /^input\.(newrecruit-[a-z-]+)\.[a-z]+$/.exec(filename);
   if (!match) throw new Error(`unrecognised input fixture filename: ${filename}`);
   return match[1] as RosterFormat;
@@ -142,7 +143,8 @@ describe("conformance corpus (ties out with the Rust crate)", () => {
         const isCanonical =
           filename === "input.json" ||
           filename === "input.newrecruit-json.json" ||
-          filename === "input.gw.txt";
+          filename === "input.gw.txt" ||
+          filename === "input.listforge-text.txt";
         if (isCanonical) {
           // Canonical seed must reproduce the golden exactly.
           expect(
@@ -175,6 +177,8 @@ describe("conformance corpus (ties out with the Rust crate)", () => {
         decoded = readJson(join(caseDir, "input.newrecruit-json.json"));
       } else if (dirEntries.includes("input.gw.txt")) {
         decoded = readText(join(caseDir, "input.gw.txt"));
+      } else if (dirEntries.includes("input.listforge-text.txt")) {
+        decoded = readText(join(caseDir, "input.listforge-text.txt"));
       } else {
         throw new Error(`roster/${entry.name}: no canonical seed`);
       }
@@ -199,7 +203,8 @@ describe("conformance corpus (ties out with the Rust crate)", () => {
       const seed =
         dirEntries.find((n) => n === "input.json") ??
         dirEntries.find((n) => n === "input.newrecruit-json.json") ??
-        dirEntries.find((n) => n === "input.gw.txt");
+        dirEntries.find((n) => n === "input.gw.txt") ??
+        dirEntries.find((n) => n === "input.listforge-text.txt");
       if (!seed) throw new Error(`no canonical input in roster/${entry.name}`);
       const seedPath = join(caseDir, seed);
       const roster = importRoster(

--- a/tools/test/import/listforge-text.test.ts
+++ b/tools/test/import/listforge-text.test.ts
@@ -1,0 +1,177 @@
+/**
+ * ListForge plain-text adapter unit tests.
+ *
+ * ListForge's copy-paste export: a `name - faction - detachment (N Points)`
+ * first line, mixed-case role sections ending with `:`, units as
+ * `Name (N pts)` headers, and indented `•` bullets for model groups, wargear,
+ * the `E: <name>` enhancement annotation, and the bare `Warlord` marker.
+ * These tests pin the parse and the disjointness from the other text matchers.
+ */
+import { describe, it, expect } from "vitest";
+import { Dataset } from "../../src/data/dataset.js";
+import { tryImportRoster } from "../../src/import/import-roster.js";
+import { listForgeTextAdapter } from "../../src/import/listforge-text.js";
+import { gwAdapter } from "../../src/import/gw.js";
+import { newRecruitSimpleAdapter } from "../../src/import/newrecruit-simple.js";
+
+const ds = Dataset.embedded();
+
+// Condensed from the reference Chaos Daemons export.
+const SAMPLE = `all gas no breaks - Chaos Daemons - Daemonic Incursion (1995 Points)
+
+
+Epic Hero:
+Rotigus (250 pts)
+  • Gnarlrod
+  • Streams of brackish filth
+
+
+Character:
+Great Unclean One (295 pts)
+  • Putrid vomit
+  • Bileblade
+  • Bilesword
+  • E: The Endless Gift
+  • Warlord
+
+Bloodmaster (65 pts)
+  • Blade of blood
+
+
+Battleline:
+Bloodletters (110 pts)
+  • Bloodreaper
+    • Hellblade
+  • Instrument of Chaos
+  • Daemonic Icon
+  • 9x Bloodletter
+    • 9x Hellblade
+
+
+Beast:
+Flesh Hounds (75 pts)
+  • Gore Hound
+    • Burning maw
+    • Collar of Khorne
+    • Gore-drenched fangs
+  • 4x Flesh Hound
+    • 4x Collar of Khorne
+    • 4x Gore-drenched fangs
+`;
+
+describe("listForgeTextAdapter.matches", () => {
+  it("recognises the ListForge text export", () => {
+    expect(listForgeTextAdapter.matches(SAMPLE)).toBe(true);
+  });
+
+  it("rejects non-string payloads and other text formats", () => {
+    expect(listForgeTextAdapter.matches({ roster: {} })).toBe(false);
+    // newrecruit-simple first line ends `- [N pts]`, not `(N Points)`.
+    expect(
+      listForgeTextAdapter.matches(
+        "Chaos - Chaos Knights - List - [2000 pts]\n\n# ++ Army Roster ++ [2000 pts]\nUnit [5 pts]:\n• 1x Model: Gun",
+      ),
+    ).toBe(false);
+    // A GW export's first non-blank line is the `++++` fence.
+    expect(
+      listForgeTextAdapter.matches(
+        "++++\n+ FACTION KEYWORD: Chaos - Chaos Knights\n++++\nUnit (5 pts)\n• 1x Gun",
+      ),
+    ).toBe(false);
+  });
+
+  it("requires bullets and refuses WTC `N with` bodies", () => {
+    const noBullets = "name - Faction - Detachment (1000 Points)\nUnit (50 pts)";
+    expect(listForgeTextAdapter.matches(noBullets)).toBe(false);
+    const withLines =
+      "name - Faction - Detachment (1000 Points)\nUnit (50 pts)\n  • Gun\n1 with Sword";
+    expect(listForgeTextAdapter.matches(withLines)).toBe(false);
+  });
+
+  it("stays disjoint from the other text matchers on its own sample", () => {
+    expect(gwAdapter.matches(SAMPLE)).toBe(false);
+    expect(newRecruitSimpleAdapter.matches(SAMPLE)).toBe(false);
+  });
+});
+
+describe("listForgeTextAdapter via tryImportRoster", () => {
+  it("auto-detects the format and resolves against the dataset", () => {
+    const result = tryImportRoster(SAMPLE, { dataset: ds });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.format).toBe("listforge-text");
+      expect(result.roster.faction_id).toBe("chaos-daemons");
+    }
+  });
+});
+
+describe("listForgeTextAdapter.parse", () => {
+  const parsed = listForgeTextAdapter.parse(SAMPLE);
+
+  it("reads name, faction, detachment, and points from the first line", () => {
+    expect(parsed.name).toBe("all gas no breaks");
+    expect(parsed.faction_raw_name).toBe("Chaos Daemons");
+    expect(parsed.detachment_raw_name).toBe("Daemonic Incursion");
+    expect(parsed.total_reported).toBe(1995);
+    // ListForge reports only the army total — it doubles as the limit.
+    expect(parsed.declared_limit).toBe(1995);
+  });
+
+  it("captures units in declaration order", () => {
+    expect(parsed.units.map((u) => u.raw_name)).toEqual([
+      "Rotigus",
+      "Great Unclean One",
+      "Bloodmaster",
+      "Bloodletters",
+      "Flesh Hounds",
+    ]);
+  });
+
+  it("flags characters from the Epic Hero / Character sections", () => {
+    const flags = Object.fromEntries(
+      parsed.units.map((u) => [u.raw_name, u.is_character]),
+    );
+    expect(flags["Rotigus"]).toBe(true);
+    expect(flags["Great Unclean One"]).toBe(true);
+    expect(flags["Bloodmaster"]).toBe(true);
+    expect(flags["Bloodletters"]).toBe(false);
+    expect(flags["Flesh Hounds"]).toBe(false);
+  });
+
+  it("reads the E: enhancement annotation without claiming points for it", () => {
+    const guo = parsed.units.find((u) => u.raw_name === "Great Unclean One")!;
+    expect(guo.enhancement_raw_name).toBe("The Endless Gift");
+    expect(guo.enhancement_points).toBeNull();
+    expect(guo.points).toBe(295); // displayed points stay as-is
+    expect(guo.is_warlord).toBe(true);
+  });
+
+  it("derives model counts from bulleted model groups", () => {
+    const bloodletters = parsed.units.find((u) => u.raw_name === "Bloodletters")!;
+    expect(bloodletters.model_count).toBe(10); // Bloodreaper + 9x Bloodletter
+    const hounds = parsed.units.find((u) => u.raw_name === "Flesh Hounds")!;
+    expect(hounds.model_count).toBe(5); // Gore Hound + 4x Flesh Hound
+    const rotigus = parsed.units.find((u) => u.raw_name === "Rotigus")!;
+    expect(rotigus.model_count).toBe(1); // wargear-only bullets
+  });
+
+  it("aggregates squad-wide wargear from child bullets and leaf bullets", () => {
+    const bloodletters = parsed.units.find((u) => u.raw_name === "Bloodletters")!;
+    const gear = Object.fromEntries(
+      bloodletters.wargear.map((w) => [w.raw_name, w.count]),
+    );
+    expect(gear["Hellblade"]).toBe(10); // 1 (Bloodreaper's) + 9 (squad line)
+    expect(gear["Instrument of Chaos"]).toBe(1);
+    expect(gear["Daemonic Icon"]).toBe(1);
+  });
+
+  it("sums total_computed from unit points", () => {
+    expect(parsed.total_computed).toBe(250 + 295 + 65 + 110 + 75);
+  });
+
+  it("does not leak any prose fields", () => {
+    const json = JSON.stringify(parsed);
+    expect(json.includes("description")).toBe(false);
+    expect(json.includes("rules")).toBe(false);
+  });
+});

--- a/tools/test/import/newrecruit-simple.test.ts
+++ b/tools/test/import/newrecruit-simple.test.ts
@@ -95,3 +95,61 @@ describe("newRecruitSimpleAdapter", () => {
     expect(JSON.stringify(parsed)).not.toMatch(/description/i);
   });
 });
+
+describe("newRecruitSimpleAdapter edge cases", () => {
+  it("parses points brackets carrying comma-separated faction resources", () => {
+    const cabal = `Chaos - Thousand Sons - Tester - [4485pts, 29Cabal Points]
+
+# ++ Army Roster ++ [4485pts, 29Cabal Points]
+## Epic Hero [895pts, 13Cabal Points]
+Ahriman [140pts, 3Cabal Points]: Black Staff of Ahriman, Inferno bolt pistol
+`;
+    expect(newRecruitSimpleAdapter.matches(cabal)).toBe(true);
+    const parsed = newRecruitSimpleAdapter.parse(cabal);
+    expect(parsed.declared_limit).toBe(4485);
+    expect(parsed.total_reported).toBe(4485);
+    expect(parsed.units.length).toBe(1);
+    expect(parsed.units[0].raw_name).toBe("Ahriman");
+    expect(parsed.units[0].points).toBe(140);
+  });
+
+  it("matches exports that omit the Army Roster line but carry ## sections", () => {
+    const headerless = `Chaos - World Eaters - Proxy List - [2000pts]
+
+## Epic Hero [675pts]
+Angron [435pts]: Samni'arius and Spinegrinder, Warlord
+`;
+    expect(newRecruitSimpleAdapter.matches(headerless)).toBe(true);
+    const parsed = newRecruitSimpleAdapter.parse(headerless);
+    expect(parsed.faction_raw_name).toBe("World Eaters");
+    expect(parsed.total_reported).toBeNull();
+    expect(parsed.units.length).toBe(1);
+    expect(parsed.units[0].is_warlord).toBe(true);
+  });
+
+  it("treats a unit line directly after Configuration as ending that section", () => {
+    const noUnitsHeader = `Xenos - T'au Empire - Base Tau - [2000pts]
+
+# ++ Army Roster ++ [2000pts]
+## Configuration
+Battle Size: Strike Force (2000 Point limit)
+Detachment: Auxiliary Cadre
+Show/Hide Options: Legends are visible
+
+Broadside Battlesuits [90pts]:
+• 1x Broadside Shas'vre: Crushing bulk, 2x Shield Drone, Heavy rail rifle
+Broadside Battlesuits [90pts]:
+• 1x Broadside Shas'vre: Crushing bulk, 2x Shield Drone, Heavy rail rifle
+`;
+    const parsed = newRecruitSimpleAdapter.parse(noUnitsHeader);
+    expect(parsed.detachment_raw_name).toBe("Auxiliary Cadre");
+    expect(parsed.units.length).toBe(2);
+    expect(parsed.units[0].raw_name).toBe("Broadside Battlesuits");
+    expect(parsed.units[0].model_count).toBe(1);
+    const gear = Object.fromEntries(
+      parsed.units[0].wargear.map((w) => [w.raw_name, w.count]),
+    );
+    expect(gear["Shield Drone"]).toBe(2);
+    expect(gear["Heavy rail rifle"]).toBe(1);
+  });
+});


### PR DESCRIPTION
Adds the missing omni-importer coverage that army-assist's 11e migration surfaced: the ListForge plain bullet-text export (the format users actually paste) had no adapter, and three real-world NewRecruit-simple exports defeated the existing matcher.

## listforge-text (new format, all three implementations)
- `name - faction - detachment (N Points)` header, mixed-case role sections, GW-style bullet classification (model groups vs wargear vs `E:`/`Warlord` annotations). Count-less child bullets are single items; enhancement points are never claimed (ListForge doesn't report them).
- New conformance case `cd-daemonic-incursion` seeded from the text input; goldens generated by the TS oracle, reproduced byte-for-byte by Rust and Python. Parity green on all three pairs.
- Rust note: the registry's extra `GwHeaderlessAdapter` fallback also accepts this format, so registry order decides there; the disjointness test asserts the order-decided winner for that one fixture.

## newrecruit-simple fixes
- Points brackets with faction resources (`[4485pts, 29Cabal Points]`) parse; the tail is discarded.
- Exports that omit the `# ++ Army Roster ++` line but carry `## Section` headings now match.
- A `Name [N pts]` line directly after Configuration ends that section instead of being swallowed as a config key (previously produced zero-unit rosters).

## Browser compatibility (root barrel)
- `decodeListForge` drops `node:zlib`/`Buffer` for `fflate` + `atob`/`TextDecoder` — `tryImportRoster` now bundles in Vite/browser targets.
- Schema/AJV validation moves off the root barrel to a new `./validate` subpath export; it reads schema files from disk at module load and was breaking browser builds. Node tooling imports `@alpaca-software/40kdc-data/validate`.

Versions bumped in lockstep to 0.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)