### PR TITLE
fix: correct swapped light/dense terrain colors

### DIFF
--- a/examples/_shared/LayoutDiagram.svelte
+++ b/examples/_shared/LayoutDiagram.svelte
@@ -128,9 +128,13 @@
     fill: oklch(0.74 0.14 75 / 0.5);
     stroke: oklch(0.74 0.15 75);
   }
-  .piece.feature.light {
+  .piece.feature.dense {
     fill: oklch(0.70 0.14 145 / 0.45);
     stroke: oklch(0.52 0.15 145);
+  }
+  .piece.feature.light {
+    fill: oklch(0.74 0.14 75 / 0.5);
+    stroke: oklch(0.74 0.15 75);
   }
   .obj-ring {
     fill: none;

--- a/examples/_shared/LayoutThumb.svelte
+++ b/examples/_shared/LayoutThumb.svelte
@@ -88,8 +88,12 @@
     fill: oklch(0.68 0.15 62 / 0.55);
     stroke: oklch(0.5 0.16 58);
   }
-  .piece.feature.light {
+  .piece.feature.dense {
     fill: oklch(0.70 0.14 145 / 0.45);
     stroke: oklch(0.52 0.15 145);
+  }
+  .piece.feature.light {
+    fill: oklch(0.68 0.15 62 / 0.55);
+    stroke: oklch(0.5 0.16 58);
   }
 </style>

--- a/examples/layout-editor/src/lib/Board.svelte
+++ b/examples/layout-editor/src/lib/Board.svelte
@@ -486,9 +486,13 @@
     fill: oklch(0.68 0.15 62 / 0.55);
     stroke: oklch(0.5 0.16 58);
   }
-  .piece.feature.light {
+  .piece.feature.dense {
     fill: oklch(0.62 0.15 145 / 0.45);
     stroke: oklch(0.45 0.16 145);
+  }
+  .piece.feature.light {
+    fill: oklch(0.68 0.15 62 / 0.55);
+    stroke: oklch(0.5 0.16 58);
   }
   .piece.blocked {
     stroke-dasharray: 0.5 0.4;


### PR DESCRIPTION
Dense terrain now renders green and light terrain renders yellow/tan, matching the GW applet.

Adds an explicit `.piece.feature.dense` CSS rule with the green colors and corrects `.piece.feature.light` to yellow/tan. The base `.piece.feature` fallback (used by exposed terrain) is unchanged.

Affected components: `LayoutDiagram.svelte`, `LayoutThumb.svelte`, `Board.svelte`.