### PR TITLE
fix: strip BCP summary preamble in the headerless GW importer

### DIFF
--- a/crates/wh40kdc/Cargo.toml
+++ b/crates/wh40kdc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wh40kdc"
-version = "1.0.18"
+version = "1.0.19"
 description = "Warhammer 40K dataset for the 40kdc-data schema layer: generated types, an embedded dataset behind a linked typed API, plus ListForge + NewRecruit roster importers and exporters."
 readme = "README.md"
 keywords = ["warhammer", "40k", "wargaming", "schema", "serde"]

--- a/go/version.go
+++ b/go/version.go
@@ -5,4 +5,4 @@ package wh40kdc
 
 // Version is the package version, kept in lockstep with tools/package.json,
 // crates/wh40kdc/Cargo.toml, and python .../_version.py (CI fails on drift).
-const Version = "1.0.18"
+const Version = "1.0.19"

--- a/python/src/wh40kdc/_version.py
+++ b/python/src/wh40kdc/_version.py
@@ -4,4 +4,4 @@ Kept in lockstep with tools/package.json and crates/wh40kdc/Cargo.toml;
 CI hard-fails on mismatch.
 """
 
-__version__ = "1.0.18"
+__version__ = "1.0.19"

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alpaca-software/40kdc-data",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "type": "module",
   "description": "The 40kdc Warhammer 40K dataset behind a linked, typed API — find units, follow them to their weapons, abilities, phases, and factions. Also validates data against the canonical JSON Schemas.",
   "keywords": [

--- a/tools/src/import/gw-headerless.ts
+++ b/tools/src/import/gw-headerless.ts
@@ -92,13 +92,46 @@ function parsePts(raw: string): number | null {
   return Number.isNaN(n) ? null : n;
 }
 
+/** A line of only `+` characters — the BCP summary block's fence. */
+const RE_PLUS_FENCE = /^\++$/;
+/** A line inside that block identifying it as BCP's (not GW's own `+ …` fence). */
+const RE_BCP_SUMMARY_MARKER = /^\s*(?:Player Name|Team Name|Factions Used|Army Points)\s*:/im;
+
+/**
+ * BCP prepends a `++…++`-fenced summary block (`Player Name:` / `Factions Used:`
+ * / `Army Points: N` / …) to text-type lists. It is BCP metadata, not part of the
+ * pasted roster, and it derails the body grammar: the fence line gets consumed as
+ * the roster title, so the *real* title line (`House Rosecairn (1995 points)`)
+ * becomes a phantom unit and its points double the computed total. Strip the
+ * leading block when present. Only a block whose fence pair wraps a BCP marker is
+ * removed, so a framed GW export's own `+ FACTION KEYWORD:` fence is left intact.
+ */
+function stripBcpSummary(text: string): string {
+  const lines = text.split(/\r?\n/);
+  let open = 0;
+  while (open < lines.length && lines[open].trim() === "") open += 1;
+  if (open >= lines.length || !RE_PLUS_FENCE.test(lines[open].trim())) return text;
+  let close = -1;
+  for (let j = open + 1; j < lines.length; j += 1) {
+    if (RE_PLUS_FENCE.test(lines[j].trim())) {
+      close = j;
+      break;
+    }
+  }
+  if (close === -1) return text;
+  const block = lines.slice(open + 1, close).join("\n");
+  if (!RE_BCP_SUMMARY_MARKER.test(block)) return text;
+  return lines.slice(close + 1).join("\n");
+}
+
 /** Accept bullet-bearing plain text that no framed adapter claims. */
 function headerlessText(decoded: unknown): string | null {
   if (typeof decoded !== "string") return null;
-  if (!RE_BULLET_ANYWHERE.test(decoded)) return null; // need a bullet
-  if (decoded.includes("+ FACTION KEYWORD:")) return null; // framed GW → gwAdapter
-  if (RE_WITH_LINE.test(decoded)) return null; // WTC-full
-  const lines = decoded.split(/\r?\n/);
+  const text = stripBcpSummary(decoded);
+  if (!RE_BULLET_ANYWHERE.test(text)) return null; // need a bullet
+  if (text.includes("+ FACTION KEYWORD:")) return null; // framed GW → gwAdapter
+  if (RE_WITH_LINE.test(text)) return null; // WTC-full
+  const lines = text.split(/\r?\n/);
   // ListForge-text's `name - faction - detachment (N Points)` header → defer to
   // listForgeTextAdapter (registered ahead of us). Mirrors its own matcher so
   // the two stay disjoint, per the importer's single-match invariant.
@@ -115,7 +148,7 @@ function headerlessText(decoded: unknown): string | null {
     return null;
   }
   // Require a `Name (N pts|Points)` line somewhere — the unit/title signature.
-  return lines.some((l) => RE_PTS_LINE.test(l.trim())) ? decoded : null;
+  return lines.some((l) => RE_PTS_LINE.test(l.trim())) ? text : null;
 }
 
 interface Bullet {

--- a/tools/test/import/gw-headerless.test.ts
+++ b/tools/test/import/gw-headerless.test.ts
@@ -193,3 +193,51 @@ describe("gwHeaderlessAdapter via tryImportRoster", () => {
     expect(roster.units.some((u) => u.ref.id === "kharn-the-betrayer")).toBe(true);
   });
 });
+
+// BCP prepends a `++…++` summary block (Player Name / Factions Used / Army Points
+// / …) to text-type lists. Regression: its fence line was consumed as the roster
+// title, so the real title line ("Ding dong (1995 Points)") became a phantom unit
+// whose points doubled the computed total (a 1995pt list read as 3990). The block
+// must be stripped so the body parses as if pasted straight from the GW app.
+const BCP_WRAPPED = `++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Player Name:
+Team Name: Example Team
+Factions Used: World Eaters
+Disposition Used: Purge the Foe
+Detachment Used: Berzerker Warband
+Army Upgrades and Enhancements (list on which model):
+Master of Executions: Berzerker Glaive
+Army Points: 375
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+${GW_APP}`;
+
+describe("gwHeaderlessAdapter — BCP summary preamble", () => {
+  it("matches despite the leading BCP `++…++` block", () => {
+    expect(gwHeaderlessAdapter.matches(BCP_WRAPPED)).toBe(true);
+  });
+
+  it("strips the block: real title isn't a unit and points aren't doubled", () => {
+    const p = gwHeaderlessAdapter.parse(BCP_WRAPPED);
+    // Title consumed (not left as a phantom unit), faction read from the body.
+    expect(p.name).toBe("Ding dong");
+    expect(p.faction_raw_name).toBe("World Eaters");
+    expect(p.units).toHaveLength(3);
+    expect(p.units.some((u) => u.raw_name === "Ding dong")).toBe(false);
+    // 375 (Khârn 100 + MoE 95 + Berzerkers 180), NOT 375 + 1995.
+    expect(p.total_computed).toBe(375);
+    // Parsing the wrapped and unwrapped text yields the same units + total.
+    const plain = gwHeaderlessAdapter.parse(GW_APP);
+    expect(p.units.map((u) => u.raw_name)).toEqual(plain.units.map((u) => u.raw_name));
+    expect(p.total_computed).toBe(plain.total_computed);
+  });
+
+  it("resolves through tryImportRoster like the unwrapped export", () => {
+    const result = tryImportRoster(BCP_WRAPPED, { dataset: ds });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.format).toBe("gw");
+    expect(result.roster.faction_id).toBe("world-eaters");
+    expect(result.roster.units.length).toBe(3);
+  });
+});


### PR DESCRIPTION
## Why

BCP prepends a `++…++` summary block (`Player Name:` / `Factions Used:` / `Army Points: N` / …) to text-type army lists. The headerless GW importer consumed that fence line as the roster **title**, so the real title line (e.g. `House Rosecairn (1995 points)`) fell through to the unit branch and became a phantom 1-model unit — and its points were then added to the real units, **doubling the computed total** (a 1995 pt list imported as 3990).

## Fix

`stripBcpSummary()` removes a leading `+`-fenced block **only when its fence pair wraps a BCP marker** (`Player Name` / `Team Name` / `Factions Used` / `Army Points`), so a framed `+ FACTION KEYWORD:` export is untouched and still routes to `gwAdapter`.

Verified against a real captured list: `3990 → 1995`, no phantom household unit, all units resolve, and faction now resolves (was null). New regression test in `gw-headerless.test.ts`; full tools suite green (1169 tests). Version lockstep bumped to `1.0.19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)