### PR TITLE
Link More Dakka on Big Mek in Mega Armour

### DIFF
--- a/data/core/orks/units.json
+++ b/data/core/orks/units.json
@@ -2285,7 +2285,8 @@
       "fix-dat-armour-up",
       "grot-oiler",
       "kustom-force-field",
-      "leader"
+      "leader",
+      "more-dakka"
     ],
     "game_version": {
       "edition": "11th",

--- a/data/enrichment/orks/abilities.json
+++ b/data/enrichment/orks/abilities.json
@@ -595,7 +595,8 @@
       "duration": "permanent"
     },
     "unit_ids": [
-      "big-mek"
+      "big-mek",
+      "big-mek-in-mega-armour"
     ],
     "ability_type": "unit",
     "behavior": "passive"


### PR DESCRIPTION
## What

`big-mek-in-mega-armour` is missing the `more-dakka` ability that the base `big-mek` datasheet carries. Per the official 11e datasheet, the Mega Armour variant has More Dakka as well.

## Changes

- `data/core/orks/units.json`: add `more-dakka` to `big-mek-in-mega-armour`'s `ability_ids`
- `data/enrichment/orks/abilities.json`: add `big-mek-in-mega-armour` to the `more-dakka` ability's `unit_ids`

## Validation

`cd tools && npm run codegen:data && npm run validate` — all 3378 referential-integrity checks pass.

Found while consuming this dataset in a downstream army builder (the variant rendered without the ability its printed card has).

🤖 Generated with [Claude Code](https://claude.com/claude-code)