### PR TITLE
Fix Wulfen death totem: default wargear + correct swap target

### DIFF
--- a/data/core/adeptus-astartes/unit-compositions.json
+++ b/data/core/adeptus-astartes/unit-compositions.json
@@ -8031,7 +8031,8 @@
           "diameter": 40
         },
         "default_weapon_ids": [
-          "wulfen-weapons"
+          "wulfen-weapons",
+          "death-totem"
         ]
       }
     ],

--- a/data/core/adeptus-astartes/units.json
+++ b/data/core/adeptus-astartes/units.json
@@ -11425,6 +11425,7 @@
       "wulfen-weapons"
     ],
     "ability_ids": [
+      "death-totem",
       "savage-frenzy"
     ],
     "game_version": {

--- a/data/core/adeptus-astartes/wargear-options.json
+++ b/data/core/adeptus-astartes/wargear-options.json
@@ -6778,7 +6778,7 @@
     },
     "is_free": true,
     "replaces": [
-      "wulfen-weapons"
+      "death-totem"
     ],
     "replacement": [
       "stormfrag-auto-launcher"

--- a/data/core/adeptus-astartes/wargear.json
+++ b/data/core/adeptus-astartes/wargear.json
@@ -135,5 +135,13 @@
       "edition": "10th",
       "dataslate": "2025-q3"
     }
+  },
+  {
+    "id": "death-totem",
+    "name": "death totem",
+    "game_version": {
+      "edition": "11th",
+      "dataslate": "launch"
+    }
   }
 ]

--- a/data/enrichment/adeptus-astartes/abilities.json
+++ b/data/enrichment/adeptus-astartes/abilities.json
@@ -11106,6 +11106,7 @@
       "duration": "permanent"
     },
     "unit_ids": [
+      "wulfen",
       "wulfen-with-storm-shields"
     ],
     "ability_type": "unit",


### PR DESCRIPTION
## What

Per the official 11e **Wulfen** datasheet, every model is equipped with wulfen weapons **and a death totem**, and the stormfrag auto-launcher wargear option replaces the **totem** — not the wulfen weapons. Currently:

- the base `wulfen` datasheet carries no death totem at all (the ability is only linked on `wulfen-with-storm-shields`), and
- `wulfen-wgo-mfm-1` has `replaces: ["wulfen-weapons"]`.

## Changes (all `adeptus-astartes`)

- `wargear.json`: add a `death-totem` wargear item (same shape as `storm-shield`)
- `unit-compositions.json`: `wulfen` model `default_weapon_ids` += `death-totem`
- `wargear-options.json`: `wulfen-wgo-mfm-1` now replaces `death-totem`
- `units.json`: `wulfen` `ability_ids` += `death-totem` — mirrors how `wulfen-with-storm-shields` already surfaces the totem's rule; happy to drop this hunk if you'd rather the rule ride the wargear item alone
- `data/enrichment/adeptus-astartes/abilities.json`: `death-totem` `unit_ids` += `wulfen`

## Validation

`cd tools && npm run codegen:data && npm run validate` — 3378/3378 referential-integrity checks pass.

Found while consuming the dataset downstream (companion to #72): the base Wulfen rendered without its totem, and taking the stormfrag decremented the wrong default item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)