### PR TITLE
Fix legion-ability leak on the shared Defiler datasheet

### DIFF
--- a/data/core/chaos-space-marines/units.json
+++ b/data/core/chaos-space-marines/units.json
@@ -1554,13 +1554,9 @@
       "twin-lascannon"
     ],
     "ability_ids": [
-      "barrage-of-filth",
       "daemonforge",
-      "deadly-demise-d3",
-      "destroyer-of-futures",
-      "feel-no-pain-6",
-      "scuttling-walker",
-      "unleash-wrath"
+      "deadly-demise-d6",
+      "scuttling-walker"
     ],
     "game_version": {
       "edition": "11th",

--- a/data/core/death-guard/units.json
+++ b/data/core/death-guard/units.json
@@ -122,12 +122,8 @@
     ],
     "ability_ids": [
       "barrage-of-filth",
-      "daemonforge",
-      "deadly-demise-d3",
-      "destroyer-of-futures",
-      "feel-no-pain-6",
-      "scuttling-walker",
-      "unleash-wrath"
+      "deadly-demise-d6",
+      "scuttling-walker"
     ],
     "game_version": {
       "edition": "11th",

--- a/data/core/thousand-sons/units.json
+++ b/data/core/thousand-sons/units.json
@@ -1180,13 +1180,10 @@
       "twin-lascannon"
     ],
     "ability_ids": [
-      "barrage-of-filth",
-      "daemonforge",
-      "deadly-demise-d3",
+      "deadly-demise-d6",
       "destroyer-of-futures",
       "feel-no-pain-6",
-      "scuttling-walker",
-      "unleash-wrath"
+      "scuttling-walker"
     ],
     "game_version": {
       "edition": "11th",

--- a/data/enrichment/chaos-space-marines/abilities.json
+++ b/data/enrichment/chaos-space-marines/abilities.json
@@ -1208,7 +1208,8 @@
       "duration": "permanent"
     },
     "unit_ids": [
-      "chaos-land-raider"
+      "chaos-land-raider",
+      "defiler"
     ],
     "ability_type": "core",
     "behavior": "reactive"
@@ -2286,9 +2287,7 @@
       "range": "unit",
       "duration": "phase"
     },
-    "unit_ids": [
-      "defiler"
-    ],
+    "unit_ids": [],
     "ability_type": "unit",
     "behavior": "passive"
   },
@@ -2312,9 +2311,7 @@
       "range": "unit",
       "duration": "permanent"
     },
-    "unit_ids": [
-      "defiler"
-    ],
+    "unit_ids": [],
     "ability_type": "core",
     "behavior": "passive"
   },
@@ -2341,9 +2338,7 @@
       "range": "aura-9",
       "duration": "permanent"
     },
-    "unit_ids": [
-      "defiler"
-    ],
+    "unit_ids": [],
     "ability_type": "unit",
     "behavior": "passive"
   },
@@ -2367,9 +2362,7 @@
       "range": "aura-12",
       "duration": "permanent"
     },
-    "unit_ids": [
-      "defiler"
-    ],
+    "unit_ids": [],
     "ability_type": "unit",
     "behavior": "passive"
   },

--- a/data/enrichment/death-guard/abilities.json
+++ b/data/enrichment/death-guard/abilities.json
@@ -138,9 +138,7 @@
       "range": "aura-6",
       "duration": "permanent"
     },
-    "unit_ids": [
-      "defiler"
-    ],
+    "unit_ids": [],
     "ability_type": "core",
     "behavior": "reactive"
   },
@@ -162,9 +160,7 @@
       "range": "unit",
       "duration": "permanent"
     },
-    "unit_ids": [
-      "defiler"
-    ],
+    "unit_ids": [],
     "ability_type": "unit",
     "behavior": "passive",
     "community_notes": "auto-generated stub \u2014 needs manual authoring (source: 10e Datasheets_abilities; rules text omitted for IP)"
@@ -252,9 +248,7 @@
       "range": "unit",
       "duration": "permanent"
     },
-    "unit_ids": [
-      "defiler"
-    ],
+    "unit_ids": [],
     "ability_type": "core",
     "behavior": "passive"
   },
@@ -281,9 +275,7 @@
       "range": "aura-9",
       "duration": "permanent"
     },
-    "unit_ids": [
-      "defiler"
-    ],
+    "unit_ids": [],
     "ability_type": "unit",
     "behavior": "passive"
   },
@@ -307,9 +299,7 @@
       "range": "aura-12",
       "duration": "permanent"
     },
-    "unit_ids": [
-      "defiler"
-    ],
+    "unit_ids": [],
     "ability_type": "unit",
     "behavior": "passive"
   },

--- a/data/enrichment/thousand-sons/abilities.json
+++ b/data/enrichment/thousand-sons/abilities.json
@@ -1756,9 +1756,7 @@
       "range": "unit",
       "duration": "permanent"
     },
-    "unit_ids": [
-      "defiler"
-    ],
+    "unit_ids": [],
     "ability_type": "unit",
     "behavior": "passive",
     "community_notes": "auto-generated stub — needs manual authoring (source: 10e Datasheets_abilities; rules text omitted for IP)"
@@ -1820,9 +1818,7 @@
       "range": "unit",
       "duration": "phase"
     },
-    "unit_ids": [
-      "defiler"
-    ],
+    "unit_ids": [],
     "ability_type": "unit",
     "behavior": "passive"
   },
@@ -1901,9 +1897,7 @@
       "range": "aura-12",
       "duration": "permanent"
     },
-    "unit_ids": [
-      "defiler"
-    ],
+    "unit_ids": [],
     "ability_type": "unit",
     "behavior": "passive"
   },


### PR DESCRIPTION
## What

The **CSM / Death Guard / Thousand Sons** Defiler copies all carry the **union** of every legion's Defiler abilities (`barrage-of-filth`, `daemonforge`, `destroyer-of-futures`, `feel-no-pain-6`, `unleash-wrath`) and `deadly-demise-d3` instead of `d6`. Per the official 11e datasheets, each legion's Defiler has only its own kit:

| Legion | ability_ids |
|---|---|
| CSM | `daemonforge`, `deadly-demise-d6`, `scuttling-walker` |
| Death Guard | `barrage-of-filth`, `deadly-demise-d6`, `scuttling-walker` |
| Thousand Sons | `deadly-demise-d6`, `destroyer-of-futures`, `feel-no-pain-6`, `scuttling-walker` |
| World Eaters | already correct upstream — untouched |

Notably the DG/TS **enrichment** files already list the Defiler under `deadly-demise-d6`, contradicting their own units.json `d3` — this PR aligns both sides.

## Changes

- `data/core/{chaos-space-marines,death-guard,thousand-sons}/units.json`: Defiler `ability_ids` per the table above
- `data/enrichment/*/abilities.json`: `defiler` removed from the leaked entries' `unit_ids` (entries kept with empty `unit_ids` rather than deleted) and added to CSM's `deadly-demise-d6`

## Validation

`cd tools && npm run codegen:data && npm run validate` — 3378/3378 referential-integrity checks pass.

Found while consuming the dataset downstream (Death Guard players saw Daemonforge and Destroyer of Futures on their Defiler). Companion to #72 / #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)