### PR TITLE
feat: flag layouts needing review in the editor

### DIFF
--- a/examples/layout-editor/package.json
+++ b/examples/layout-editor/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "test": "vitest run"
   },
   "dependencies": {
     "@alpaca-software/40kdc-data": "*"
@@ -20,6 +21,7 @@
     "svelte-check": "^4.0.0",
     "tslib": "^2.6.0",
     "typescript": "^5.6.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^2.1.9"
   }
 }

--- a/examples/layout-editor/src/App.svelte
+++ b/examples/layout-editor/src/App.svelte
@@ -16,6 +16,7 @@
     addKeystone,
     removeKeystone,
     keystoneDisplays,
+    layoutWarnings,
     setParentArea,
     snapToAreaCenter,
     snapFeatureToAreaCorner,
@@ -85,6 +86,12 @@
     selectedPiece ? boardCentroid(layout, selectedPiece) : { x: 0, y: 0 },
   );
   const markers = $derived(objectiveMarkers(layout));
+  // "Needs review" warnings for the working layout: overlapping pieces + off-grid
+  // keystones. The banner lists them; the board dims every piece one names.
+  const warnings = $derived(layoutWarnings(layout));
+  const warnPieceIds = $derived(
+    new Set(warnings.flatMap((w) => w.pieceIds).filter((id): id is string => !!id)),
+  );
   // The selected piece's keystones with live derived distances (inspector list).
   const selectedKeystones = $derived(
     selectedPiece ? keystoneDisplays(layout).filter((d) => d.pieceId === selectedPiece.id) : [],
@@ -382,10 +389,21 @@
         {markers}
         {showKeystones}
         {keystoneFacing}
+        {warnPieceIds}
         onselect={(id) => (selectedId = id)}
         {onmove}
         {onorient}
       />
+      {#if warnings.length > 0}
+        <div class="warnings" role="status">
+          <span class="warn-head">⚠ {warnings.length} to review</span>
+          <ul>
+            {#each warnings as w, i (i)}
+              <li class="warn {w.kind}">{w.message}</li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
       <p class="status">
         {layout.pieces.length} pieces · drag to move · rotate/flip handles on the selected piece
         {#if symmetric}· edits mirror across the centre{/if}
@@ -518,6 +536,36 @@
     font-size: 0.78rem;
     margin: 0.4rem 0 0;
     flex: 0 0 auto;
+  }
+  .warnings {
+    flex: 0 0 auto;
+    margin: 0.5rem 0 0;
+    padding: 0.5rem 0.7rem;
+    border: 1px solid oklch(0.6 0.14 70);
+    border-left-width: 3px;
+    border-radius: 4px;
+    background: oklch(0.7 0.13 70 / 0.12);
+    font-size: 0.78rem;
+    max-height: 8.5rem;
+    overflow-y: auto;
+  }
+  .warn-head {
+    font-weight: 600;
+    color: oklch(0.7 0.14 70);
+  }
+  .warnings ul {
+    margin: 0.35rem 0 0;
+    padding-left: 1.1rem;
+  }
+  .warnings li {
+    margin: 0.1rem 0;
+    color: var(--text-dim);
+  }
+  .warnings li.collision::marker {
+    content: "⤫ ";
+  }
+  .warnings li.keystone-not-round::marker {
+    content: "⌖ ";
   }
   select.ctrl,
   .export textarea {

--- a/examples/layout-editor/src/lib/Board.svelte
+++ b/examples/layout-editor/src/lib/Board.svelte
@@ -36,6 +36,8 @@
     showKeystones?: boolean;
     /** Rotate keystone labels to face the player whose board half holds the piece — always an axis-aligned top/bottom or left/right split (needs `divider`). */
     keystoneFacing?: boolean;
+    /** Resolved ids of pieces named by a "needs review" warning, outlined on the board. */
+    warnPieceIds?: Set<string>;
     onselect: (id: string | null) => void;
     onmove: (id: string, position: Vec2) => void;
     onorient: (id: string, patch: { rotation_degrees?: number; mirror?: Mirror }) => void;
@@ -51,6 +53,7 @@
     markers,
     showKeystones = true,
     keystoneFacing = false,
+    warnPieceIds = new Set<string>(),
     onselect,
     onmove,
     onorient,
@@ -295,7 +298,9 @@
         points={pts(p)}
         class="piece {p.piece_type} {tplCat} {p.id === selectedId ? 'selected' : ''} {p.id === twinId
           ? 'twin'
-          : ''} {ep && isGroundBlocked(ep) ? 'blocked' : ''}"
+          : ''} {ep && isGroundBlocked(ep) ? 'blocked' : ''} {p.id && warnPieceIds.has(p.id)
+          ? 'needs-review'
+          : ''}"
         role="button"
         tabindex="0"
         aria-label={p.name ?? p.id ?? "piece"}
@@ -508,6 +513,14 @@
     stroke: oklch(0.48 0.15 195);
     stroke-width: 0.36;
   }
+  /* "Needs review" pieces (overlap / off-grid keystone): red dashed outline,
+     placed after .selected/.twin so it wins when a flagged piece is also
+     selected. */
+  .piece.needs-review {
+    stroke: oklch(0.58 0.21 25);
+    stroke-width: 0.5;
+    stroke-dasharray: 0.7 0.4;
+  }
   .upper {
     fill: none;
     stroke: oklch(0.4 0.02 255);
@@ -524,25 +537,28 @@
   .ind {
     pointer-events: none;
   }
+  /* Pinning-panel edge/vertex highlight: magenta (hue 330), deliberately clear of
+     the teal (195) used by selected/twin outlines and measure guides — teal on
+     teal made the pinned feature nearly impossible to pick out. */
   .ind.hover {
-    fill: oklch(0.52 0.14 195);
-    opacity: 0.7;
+    fill: oklch(0.64 0.26 330);
+    opacity: 0.95;
   }
   .ind.active {
-    fill: oklch(0.42 0.15 195);
+    fill: oklch(0.55 0.27 330);
   }
   .ind-edge {
     pointer-events: none;
     fill: none;
   }
   .ind-edge.hover {
-    stroke: oklch(0.52 0.14 195);
-    stroke-width: 0.4;
-    opacity: 0.7;
+    stroke: oklch(0.64 0.26 330);
+    stroke-width: 0.55;
+    opacity: 0.95;
   }
   .ind-edge.active {
-    stroke: oklch(0.42 0.15 195);
-    stroke-width: 0.4;
+    stroke: oklch(0.55 0.27 330);
+    stroke-width: 0.55;
   }
   .measure {
     stroke: oklch(0.4 0.15 195);

--- a/examples/layout-editor/src/lib/Library.svelte
+++ b/examples/layout-editor/src/lib/Library.svelte
@@ -5,6 +5,7 @@
     pairKey,
     canonicalMatchupId,
     libraryIndex,
+    layoutWarningsFor,
     type LibraryEntry,
   } from "./model.js";
   import LayoutThumb from "./LayoutThumb.svelte";
@@ -68,6 +69,33 @@
     index ? [...index.cells.values()].reduce((n, c) => n + c.byVariant.size, 0) : 0,
   );
 
+  /** Whether a library layout has any "needs review" warning (memoized in the model). */
+  function needsReview(id: string): boolean {
+    return layoutWarningsFor(id).length > 0;
+  }
+  /** Multi-line tooltip listing a layout's warnings. */
+  function reviewTitle(id: string): string {
+    const w = layoutWarningsFor(id);
+    return w.length ? `${w.length} to review:\n${w.map((x) => `• ${x.message}`).join("\n")}` : "";
+  }
+  /** Count of distinct layouts in the grid that need review (for the header). */
+  const flaggedCount = $derived.by(() => {
+    if (!index) return 0;
+    const seen = new Set<string>();
+    let n = 0;
+    const bump = (e: LibraryEntry): void => {
+      if (seen.has(e.id)) return;
+      seen.add(e.id);
+      if (needsReview(e.id)) n++;
+    };
+    for (const cell of index.cells.values()) {
+      for (const list of cell.byVariant.values()) list.forEach(bump);
+      cell.unnumbered.forEach(bump);
+    }
+    index.unassigned.forEach(bump);
+    return n;
+  });
+
   function pick(id: string): void {
     open = false;
     onpick(id);
@@ -89,6 +117,11 @@
     <header>
       <h2>Layout Library</h2>
       <span class="coverage">{filled} / 45 slots</span>
+      {#if flaggedCount > 0}
+        <span class="review-count" title="Layouts with overlapping pieces or off-grid keystones">
+          ⚠ {flaggedCount} to review
+        </span>
+      {/if}
       <span class="spacer"></span>
       <button type="button" class="blank" onclick={blank}>＋ Blank layout</button>
       <button type="button" class="close" aria-label="Close" onclick={() => (open = false)}>×</button>
@@ -123,6 +156,7 @@
                       onclick={() => pick(e.id)}
                     >
                       <span class="num">{v}</span>
+                      {#if needsReview(e.id)}<span class="review-badge" title={reviewTitle(e.id)}>⚠</span>{/if}
                       <LayoutThumb layoutId={e.id} patternId={e.deploymentPatternId} />
                       <span class="name">{e.name}</span>
                     </button>
@@ -138,6 +172,7 @@
                     onclick={() => pick(e.id)}
                   >
                     <span class="num">{v}</span>
+                    {#if needsReview(e.id)}<span class="review-badge" title={reviewTitle(e.id)}>⚠</span>{/if}
                     <LayoutThumb layoutId={e.id} patternId={e.deploymentPatternId} />
                     <span class="name">{e.name}</span>
                   </button>
@@ -168,6 +203,7 @@
                 title={e.name}
                 onclick={() => pick(e.id)}
               >
+                {#if needsReview(e.id)}<span class="review-badge" title={reviewTitle(e.id)}>⚠</span>{/if}
                 <LayoutThumb layoutId={e.id} patternId={e.deploymentPatternId} />
                 <span class="name">{e.name}</span>
               </button>
@@ -222,6 +258,11 @@
   .coverage {
     color: var(--text-mute);
     font-size: 0.85rem;
+  }
+  .review-count {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: oklch(0.72 0.16 70);
   }
   .spacer {
     flex: 1 1 auto;
@@ -336,6 +377,17 @@
     font-size: 0.68rem;
     color: var(--text-mute);
     z-index: 1;
+  }
+  .slot .review-badge {
+    position: absolute;
+    top: 0.15rem;
+    right: 0.25rem;
+    z-index: 1;
+    font-size: 0.8rem;
+    line-height: 1;
+    color: oklch(0.72 0.16 70);
+    text-shadow: 0 0 2px rgba(0, 0, 0, 0.6);
+    pointer-events: none;
   }
   .slot .name {
     font-size: 0.7rem;

--- a/examples/layout-editor/src/lib/model.test.ts
+++ b/examples/layout-editor/src/lib/model.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { layoutWarnings, isRoundKeystone, type EditLayout, type EditPiece } from "./model.js";
+
+/** A rectangle piece placed centroid-at-`position` (inline footprint, no catalog dep). */
+function rect(
+  id: string,
+  width: number,
+  height: number,
+  position: { x: number; y: number },
+  extra: Partial<EditPiece> = {},
+): EditPiece {
+  return {
+    id,
+    piece_type: "area",
+    footprint: { type: "rectangle", width, height },
+    position,
+    rotation_degrees: 0,
+    mirror: "none",
+    ...extra,
+  };
+}
+
+function layout(pieces: EditPiece[]): EditLayout {
+  return { id: "test", name: "Test", pieces };
+}
+
+describe("isRoundKeystone", () => {
+  it("accepts clean quarter-inch marks", () => {
+    for (const n of [16.25, 17.5, 16.0, 3, 21.0, 6.01]) {
+      expect(isRoundKeystone(n)).toBe(true);
+    }
+  });
+  it("rejects off-grid values (rounding errors)", () => {
+    for (const n of [15.92, 21.12, 16.13]) {
+      expect(isRoundKeystone(n)).toBe(false);
+    }
+  });
+});
+
+describe("collision warnings", () => {
+  it("does not flag edge-abutting areas", () => {
+    // Two 10×10 areas sharing the x=10 edge: centroids at (5,5) and (15,5).
+    const l = layout([rect("a", 10, 10, { x: 5, y: 5 }), rect("b", 10, 10, { x: 15, y: 5 })]);
+    expect(layoutWarnings(l).filter((w) => w.kind === "collision")).toHaveLength(0);
+  });
+
+  it("flags two overlapping areas", () => {
+    // Second area shifted so it overlaps the first by a 3×10 strip.
+    const l = layout([rect("a", 10, 10, { x: 5, y: 5 }), rect("b", 10, 10, { x: 12, y: 5 })]);
+    const cols = layoutWarnings(l).filter((w) => w.kind === "collision");
+    expect(cols).toHaveLength(1);
+    expect(cols[0].pieceIds).toEqual(expect.arrayContaining(["a", "b"]));
+    expect(cols[0].message).toContain("overlaps");
+  });
+
+  it("does not flag a feature sitting on its own parent area", () => {
+    // Feature parented to area "a", centred on it (local origin = area centroid):
+    // it overlaps the area, but they are one family, so no warning.
+    const area = rect("a", 20, 20, { x: 30, y: 22 });
+    const feat = rect("f", 4, 4, { x: 0, y: 0 }, { piece_type: "feature", parent_area_id: "a" });
+    expect(layoutWarnings(layout([area, feat])).filter((w) => w.kind === "collision")).toHaveLength(0);
+  });
+
+  it("does not flag a feature spanning onto a linked (same link_group) area", () => {
+    // Two baseplates that interlock as one logical area (shared link_group), like
+    // the Take-and-Hold centre trapezoid pair. A ruin on one legitimately spans
+    // onto its linked partner, so it must not warn.
+    const a = rect("a", 10, 10, { x: 6, y: 6 }, { link_group: "Center" });
+    const b = rect("b", 10, 10, { x: 15, y: 6 }, { link_group: "Center" });
+    // a's centroid (6,6); local (5,0) → board (11,6), straddling a and b.
+    const f = rect("f", 4, 4, { x: 5, y: 0 }, { piece_type: "feature", parent_area_id: "a" });
+    expect(layoutWarnings(layout([a, b, f])).filter((w) => w.kind === "collision")).toHaveLength(0);
+  });
+
+  it("flags a feature that overlaps a different (non-parent) area", () => {
+    // area "a" at left; area "b" at right; feature parented to "a" but placed far
+    // enough (area-local) that it lands on top of "b" — the "flew across" bug.
+    const a = rect("a", 10, 10, { x: 6, y: 6 });
+    const b = rect("b", 10, 10, { x: 30, y: 6 });
+    // a's centroid is (6,6); local (24,0) → board (30,6), centred on b.
+    const f = rect("f", 4, 4, { x: 24, y: 0 }, { piece_type: "feature", parent_area_id: "a" });
+    const cols = layoutWarnings(layout([a, b, f])).filter((w) => w.kind === "collision");
+    expect(cols.length).toBeGreaterThanOrEqual(1);
+    expect(cols.some((w) => w.pieceIds.includes("f") && w.pieceIds.includes("b"))).toBe(true);
+  });
+});
+
+describe("keystone-not-round warnings", () => {
+  function withLeftKeystone(minX: number): EditLayout {
+    // Rectangle width 8 → min-x = position.x - 4. Left-edge keystone reads min-x.
+    const p = rect("k", 8, 8, { x: minX + 4, y: 10 }, {
+      keystones: [{ edge: "left", ref: { kind: "face", side: "min-x" } }],
+    });
+    return layout([p]);
+  }
+
+  it("does not flag a clean 16.25″ keystone", () => {
+    const ks = layoutWarnings(withLeftKeystone(16.25)).filter((w) => w.kind === "keystone-not-round");
+    expect(ks).toHaveLength(0);
+  });
+
+  it("flags an off-grid 15.92″ keystone", () => {
+    const ks = layoutWarnings(withLeftKeystone(15.92)).filter((w) => w.kind === "keystone-not-round");
+    expect(ks).toHaveLength(1);
+    expect(ks[0].message).toContain("15.92");
+    expect(ks[0].pieceIds).toEqual(["k"]);
+  });
+});

--- a/examples/layout-editor/src/lib/model.ts
+++ b/examples/layout-editor/src/lib/model.ts
@@ -1148,6 +1148,280 @@ export function keystoneDisplays(layout: EditLayout): KeystoneDisplay[] {
   }));
 }
 
+// ── layout warnings ("needs review" flag) ─────────────────────────────────────
+// Advisory, editor-side checks that surface layouts a human should look at: two
+// pieces that overlap when they shouldn't (a feature mirrored onto the wrong side
+// "flies across the map"), and keystone distances that aren't clean ¼″ increments
+// (a symptom of a coordinate that's slightly off — 15.92″ where the card says
+// 16.25″). These are hints, never a gate: some overlaps/near-values are genuine, so
+// false positives are tolerable and nothing here blocks saving or loading.
+
+/** The kind of problem a {@link LayoutWarning} reports. */
+export type LayoutWarningKind = "collision" | "keystone-not-round";
+
+export interface LayoutWarning {
+  kind: LayoutWarningKind;
+  /** Human-readable summary for the banner/tooltip. */
+  message: string;
+  /** Resolved id(s) of the offending piece(s), for on-board highlighting (may be null when a piece has no id). */
+  pieceIds: (string | null)[];
+}
+
+/** Card measurements are clean quarter-inch increments; anything off by more than
+ *  this (in inches) is treated as a data-entry rounding error worth reviewing. */
+const KEYSTONE_INCREMENT = 0.25;
+const KEYSTONE_ROUND_TOL = 0.03;
+/** Minimum overlap area (in²) that counts as a collision. Edge-abutting pieces
+ *  share vertices exactly and overlap by ~0, so they never trip this; a real
+ *  overlap — even a small ruin nub onto a neighbouring baseplate — clears it. */
+const COLLISION_MIN_AREA = 0.25;
+
+const nearestIncrement = (n: number): number =>
+  Math.round(n / KEYSTONE_INCREMENT) * KEYSTONE_INCREMENT;
+
+/** Whether a keystone distance sits on (or within tolerance of) a clean ¼″ mark. */
+export function isRoundKeystone(distance: number): boolean {
+  return Math.abs(distance - nearestIncrement(distance)) <= KEYSTONE_ROUND_TOL;
+}
+
+const pieceLabel = (p: ResolvedPiece): string => p.name ?? p.id ?? "piece";
+
+/** Signed polygon area (shoelace); sign encodes winding. */
+function signedArea(poly: Vec2[]): number {
+  let a = 0;
+  for (let i = 0; i < poly.length; i++) {
+    const p = poly[i];
+    const q = poly[(i + 1) % poly.length];
+    a += p.x * q.y - q.x * p.y;
+  }
+  return a / 2;
+}
+
+/** Whether two polygons' axis-aligned bounding boxes overlap (cheap pre-filter). */
+function bboxOverlap(a: Vec2[], b: Vec2[]): boolean {
+  const ba = bbox(a);
+  const bb = bbox(b);
+  return ba.minX <= bb.maxX && bb.minX <= ba.maxX && ba.minY <= bb.maxY && bb.minY <= ba.maxY;
+}
+
+/** Barycentric-sign point-in-triangle (boundary counts as inside). */
+function inTriangle(p: Vec2, a: Vec2, b: Vec2, c: Vec2): boolean {
+  const s = (u: Vec2, v: Vec2, w: Vec2): number =>
+    (u.x - w.x) * (v.y - w.y) - (v.x - w.x) * (u.y - w.y);
+  const d1 = s(p, a, b);
+  const d2 = s(p, b, c);
+  const d3 = s(p, c, a);
+  const hasNeg = d1 < 0 || d2 < 0 || d3 < 0;
+  const hasPos = d1 > 0 || d2 > 0 || d3 > 0;
+  return !(hasNeg && hasPos);
+}
+
+/**
+ * Ear-clipping triangulation of a simple polygon (handles the concave L-shaped
+ * ruins). Returns CCW triangles; degenerate input yields no triangles rather than
+ * throwing — a warning check must never crash the editor.
+ */
+function triangulate(poly: Vec2[]): [Vec2, Vec2, Vec2][] {
+  const n = poly.length;
+  if (n < 3) return [];
+  // Normalise to CCW so the convex-vertex test below is orientation-independent.
+  const verts = signedArea(poly) < 0 ? poly.slice().reverse() : poly.slice();
+  const idx = verts.map((_, i) => i);
+  const tris: [Vec2, Vec2, Vec2][] = [];
+  let guard = n * n + 16;
+  while (idx.length > 3 && guard-- > 0) {
+    let clipped = false;
+    for (let k = 0; k < idx.length; k++) {
+      const a = verts[idx[(k - 1 + idx.length) % idx.length]];
+      const b = verts[idx[k]];
+      const c = verts[idx[(k + 1) % idx.length]];
+      // Convex (ear tip) in CCW winding: cross > 0.
+      const cross = (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+      if (cross <= 0) continue;
+      let empty = true;
+      for (const j of idx) {
+        const v = verts[j];
+        if (v === a || v === b || v === c) continue;
+        if (inTriangle(v, a, b, c)) {
+          empty = false;
+          break;
+        }
+      }
+      if (!empty) continue;
+      tris.push([a, b, c]);
+      idx.splice(k, 1);
+      clipped = true;
+      break;
+    }
+    if (!clipped) break; // no ear found (self-intersecting / degenerate): bail
+  }
+  if (idx.length === 3) tris.push([verts[idx[0]], verts[idx[1]], verts[idx[2]]]);
+  return tris;
+}
+
+/** Intersection point of segment s→e with the infinite line a→b. */
+function lineIntersect(s: Vec2, e: Vec2, a: Vec2, b: Vec2): Vec2 {
+  const dc = { x: a.x - b.x, y: a.y - b.y };
+  const dp = { x: s.x - e.x, y: s.y - e.y };
+  const n1 = a.x * b.y - a.y * b.x;
+  const n2 = s.x * e.y - s.y * e.x;
+  const denom = dc.x * dp.y - dc.y * dp.x;
+  return { x: (n1 * dp.x - n2 * dc.x) / denom, y: (n1 * dp.y - n2 * dc.y) / denom };
+}
+
+/** Clip convex polygon `subject` by convex polygon `clip` (both CCW) — Sutherland–Hodgman. */
+function clipConvex(subject: Vec2[], clip: Vec2[]): Vec2[] {
+  let output = subject;
+  for (let i = 0; i < clip.length && output.length > 0; i++) {
+    const a = clip[i];
+    const b = clip[(i + 1) % clip.length];
+    const inside = (p: Vec2): boolean =>
+      (b.x - a.x) * (p.y - a.y) - (b.y - a.y) * (p.x - a.x) >= 0;
+    const input = output;
+    output = [];
+    for (let j = 0; j < input.length; j++) {
+      const cur = input[j];
+      const prev = input[(j + input.length - 1) % input.length];
+      const curIn = inside(cur);
+      const prevIn = inside(prev);
+      if (curIn) {
+        if (!prevIn) output.push(lineIntersect(prev, cur, a, b));
+        output.push(cur);
+      } else if (prevIn) {
+        output.push(lineIntersect(prev, cur, a, b));
+      }
+    }
+  }
+  return output;
+}
+
+/** Exact overlap area of two (possibly concave) polygons, via triangulation + clipping. */
+function polygonOverlapArea(a: Vec2[], b: Vec2[]): number {
+  let area = 0;
+  for (const t1 of triangulate(a)) {
+    for (const t2 of triangulate(b)) {
+      const clipped = clipConvex(t1.slice(), t2);
+      if (clipped.length >= 3) area += Math.abs(signedArea(clipped));
+    }
+  }
+  return area;
+}
+
+/**
+ * Overlapping-piece warnings. Resolves the layout, then assigns every resolved
+ * piece a "collision group" keyed by the logical area it belongs to — an area and
+ * everything anchored to it (its parented features + its template's composed
+ * features), with linked areas (shared `link_group`) folded into one group. Pairs
+ * within a group are expected to overlap and are skipped:
+ *   - a ruin sits on its own baseplate (same area), and
+ *   - two linked baseplates interlock as one piece, so a ruin on one legitimately
+ *     spans onto its partner (the Take-and-Hold centre trapezoid pair).
+ * Every other pair with a real overlap area is flagged. Returns [] if the layout
+ * can't resolve mid-edit.
+ */
+function collisionWarnings(layout: EditLayout): LayoutWarning[] {
+  let resolved: ResolvedPiece[];
+  try {
+    resolved = resolve(layout);
+  } catch {
+    return [];
+  }
+  const pieces = layout.pieces ?? [];
+
+  // The governing-area id of each resolved piece: itself for a top-level piece,
+  // the parent for a parented feature, the templated area for a composed feature.
+  // Walk the resolver's emission contract (mirrored from keystones.ts): one slot
+  // per layout piece, plus a templated unparented piece's composed features after.
+  const linkByPieceId = new Map<string, string>();
+  for (const p of pieces) if (p.id && p.link_group) linkByPieceId.set(p.id, p.link_group);
+  const governingArea: (string | null)[] = new Array(resolved.length).fill(null);
+  let cursor = 0;
+  for (const p of pieces) {
+    const self = cursor;
+    cursor += 1;
+    if (p.parent_area_id) {
+      governingArea[self] = p.parent_area_id;
+    } else {
+      governingArea[self] = p.id ?? `#${self}`;
+      const fcount = p.template ? templateById(p.template)?.features?.length ?? 0 : 0;
+      for (let f = 1; f <= fcount; f++) governingArea[self + f] = p.id ?? `#${self}`;
+    }
+  }
+  // Pieces sharing a group key never collide-warn against each other.
+  const groupKey = (i: number): string => {
+    const aid = governingArea[i];
+    const link = aid ? linkByPieceId.get(aid) : undefined;
+    return link ? `lg:${link}` : `a:${aid ?? i}`;
+  };
+
+  const out: LayoutWarning[] = [];
+  for (let a = 0; a < resolved.length; a++) {
+    for (let b = a + 1; b < resolved.length; b++) {
+      if (groupKey(a) === groupKey(b)) continue;
+      const pa = resolved[a];
+      const pb = resolved[b];
+      if (!bboxOverlap(pa.vertices, pb.vertices)) continue;
+      const overlap = polygonOverlapArea(pa.vertices, pb.vertices);
+      if (overlap > COLLISION_MIN_AREA) {
+        out.push({
+          kind: "collision",
+          message: `${pieceLabel(pa)} overlaps ${pieceLabel(pb)} (${round2(overlap)} in²)`,
+          pieceIds: [pa.id, pb.id],
+        });
+      }
+    }
+  }
+  return out;
+}
+
+/** Non-round keystone warnings: every derived distance that isn't a clean ¼″ mark. */
+function keystoneRoundnessWarnings(layout: EditLayout): LayoutWarning[] {
+  const out: LayoutWarning[] = [];
+  for (const d of keystoneDisplays(layout)) {
+    if (d.distance == null || isRoundKeystone(d.distance)) continue;
+    const target = nearestIncrement(d.distance);
+    out.push({
+      kind: "keystone-not-round",
+      message: `${d.keystone.edge} keystone ${round2(d.distance)}″ (nearest ¼″ is ${round2(target)}″)`,
+      pieceIds: [d.pieceId],
+    });
+  }
+  return out;
+}
+
+/**
+ * Every "needs review" warning for a layout: overlapping pieces first, then
+ * off-grid keystones. Symmetric twins produce the same warning on both board
+ * halves, so identical messages are collapsed (their piece ids merged for the
+ * board highlight). Pure and cheap; components call it in a `$derived`.
+ */
+export function layoutWarnings(layout: EditLayout): LayoutWarning[] {
+  const raw = [...collisionWarnings(layout), ...keystoneRoundnessWarnings(layout)];
+  const byMessage = new Map<string, LayoutWarning>();
+  for (const w of raw) {
+    const key = `${w.kind}|${w.message}`;
+    const seen = byMessage.get(key);
+    if (seen) {
+      for (const id of w.pieceIds) if (!seen.pieceIds.includes(id)) seen.pieceIds.push(id);
+    } else {
+      byMessage.set(key, { ...w, pieceIds: [...w.pieceIds] });
+    }
+  }
+  return [...byMessage.values()];
+}
+
+/** Warnings for an embedded (library) layout by id. Memoized — the dataset is
+ *  immutable for the life of the build (same contract as {@link resolveEmbedded}). */
+const warningCache = new Map<string, LayoutWarning[]>();
+export function layoutWarningsFor(layoutId: string): LayoutWarning[] {
+  const hit = warningCache.get(layoutId);
+  if (hit) return hit;
+  const raw = ds.terrainLayouts.get(layoutId) as unknown as EditLayout | undefined;
+  const warnings = raw ? layoutWarnings(raw) : [];
+  warningCache.set(layoutId, warnings);
+  return warnings;
+}
+
 export type ObjectiveRole = "home" | "expansion" | "center";
 
 /** Every piece that forms the same objective as `p`: its link_group union, else just itself — each with its twin. */

--- a/examples/layout-editor/vitest.config.ts
+++ b/examples/layout-editor/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Tests run in Node, not the browser, so they import the real
+ * `@alpaca-software/40kdc-data` package directly — no `stubNodeOnlyModules`
+ * plugin (the schema-loader's `node:fs`/`node:url` access is fine in Node).
+ * Kept separate from `vite.config.ts` for exactly that reason.
+ */
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10129,7 +10129,7 @@
     },
     "tools": {
       "name": "@alpaca-software/40kdc-data",
-      "version": "1.0.16",
+      "version": "1.0.23",
       "license": "SEE LICENSE IN LICENSE-TOOLS",
       "dependencies": {
         "ajv": "^8.17.0",


### PR DESCRIPTION
## Why

Authors transcribe official GW terrain maps in the layout editor, and two classes of error currently ship silently:

1. **Overlapping pieces** — when a piece is mirrored/flipped, a parented feature can compose onto the wrong side and "fly across the map", landing on an unrelated baseplate. Nothing surfaced it.
2. **Non-round keystone numbers** — a keystone distance is derived purely from the resolved geometry (never stored). Official maps use clean ¼-inch increments (16.25″, 17.5″); a derived `15.92″` means a coordinate is slightly off.

This adds a **"needs review"** flag so a human can spot which layouts need fixing — matching the report that most of the Take-and-Hold set is currently off.

## What

- **Overlap detection** (`model.ts`): exact polygon-intersection area via ear-clip triangulation + Sutherland–Hodgman clipping, so concave ruin footprints are handled and edge-abutting baseplates (≈0 area) don't false-fire. It's **family- and `link_group`-aware**: a ruin on its own baseplate — or spanning onto a *linked* baseplate (the centre trapezoid pair) — is expected and not flagged; a piece overlapping an unrelated baseplate is.
- **Keystone roundness** (`model.ts`): flags any derived distance more than a hair off the nearest ¼″.
- **Surfacing**: a banner listing the issues with the offending pieces outlined in red on the board, plus ⚠ badges and a count in the library grid. All advisory — nothing blocks saving/loading.
- **Pinning-panel highlight recolor** (`Board.svelte`): the edge/vertex hover/active indicators moved from teal (hue 195) — which blended into the teal selection/twin/measure guides — to magenta (hue 330).
- **Tests**: adds a vitest harness to the editor (previously untested) covering overlap, the link-group exemption, and keystone roundness.

## Verification

- `npm run check` (0 errors) and `npm test` (9 passing) in `examples/layout-editor`.
- Production `build` succeeds; drove the built app headlessly at `/#edit`: banner renders "⚠ 2 to review", flagged pieces outline red on the board, recolored highlight ships in the bundle.
- Ran the check across all 46 embedded layouts: 22 flagged, and **only** Take-and-Hold layouts — the untouched missions come back clean.

Editor apps aren't in `just preflight`; verified with the app's own `check`/`test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)