### PR TITLE
feat: gate ambiguous points ladders in referential integrity

### DIFF
--- a/tools/src/integrity.ts
+++ b/tools/src/integrity.ts
@@ -148,6 +148,23 @@ interface AbilityLike {
  * the loadout, never to silence a fixable data gap.
  */
 export const KNOWN_LOADOUT_ORPHANS: ReadonlySet<string> = new Set<string>([]);
+
+/**
+ * Known, accepted ambiguous points ladders — a `<faction>/<unit_id>` whose
+ * `points` array gives one squad size two DIFFERENT costs inside a single
+ * army-ordinal band. The sole entry predates this check and is a real data bug,
+ * not resolvable from what this repo ships: the correct costs live in the GW
+ * MFM dump, so repairing it is an ingest fix, not a hand-edit.
+ *
+ * Fix the tiers and delete the entry. A listed unit that is no longer ambiguous
+ * is reported as stale so the list stays minimal. Do NOT add to this list to
+ * silence a fresh ingest regression — that is the case the gate exists for.
+ */
+export const KNOWN_AMBIGUOUS_POINTS: ReadonlySet<string> = new Set<string>([
+  // 3=85, 6=170, 6=110, 12=220 — two prices for 6 models. The stray 12-model
+  // tier also drives model_count.max to 12 on a datasheet that caps at 6.
+  "adeptus-astartes/wolf-guard-headtakers",
+]);
 interface WargearOptionLike {
   id?: string;
   replaces?: string[];
@@ -212,6 +229,11 @@ export async function checkReferentialIntegrity(dataRoot?: string): Promise<Vali
   const unitFiles = await glob("core/*/units.json", { cwd: root, absolute: true });
   unitFiles.sort();
 
+  // `<faction>/<unit_id>` keys for the ambiguous-points gate below: every unit
+  // actually examined, and the allowlisted ones found still ambiguous.
+  const pricedUnits = new Set<string>();
+  const seenAmbiguous = new Set<string>();
+
   for (const file of unitFiles) {
     const faction = basename(dirname(file));
     if (faction.startsWith("_")) continue; // scratch/example/report dirs
@@ -241,6 +263,58 @@ export async function checkReferentialIntegrity(dataRoot?: string): Promise<Vali
         errors: dupIds.map((id) => ({
           path: "/",
           message: `duplicate unit id "${id}" appears ${idCounts.get(id)}× in ${faction}/units.json — the linked API keys by id (first-wins), so the later entry is silently shadowed; keep exactly one`,
+        })),
+      });
+    }
+
+    // Within one army-ordinal band a squad size must resolve to exactly ONE
+    // price. Two tiers covering the same size with no distinct `unit_count_*`
+    // band to separate them leave the cost ambiguous: `baseUnitPoints` prices at
+    // the highest `models` threshold the squad reaches, so it silently takes
+    // whichever of the pair it lands on. Worse, a stray oversized tier drags the
+    // unit's legal maximum up with it (Wolf Guard Headtakers: a spurious
+    // 12-model tier put model_count.max at 12 on a 6-model datasheet).
+    //
+    // The points↔composition coverage check further down cannot catch this — it
+    // requires composition `tiers`, which 15 compositions still lack, and those
+    // are exactly the units an ingest is most likely to get wrong. Overlap, not
+    // equality, is the test so a range-priced tier (`models`..`models_max`)
+    // colliding with a single-size tier is caught too. An append-instead-of-
+    // replace ingest is the recurring cause, same as the duplicate-id check.
+    const band = (p: PointsTierLike) => `${p.unit_count_min ?? ""}:${p.unit_count_max ?? ""}`;
+    const lo = (p: PointsTierLike) => p.models ?? 0;
+    const hi = (p: PointsTierLike) => p.models_max ?? p.models ?? 0;
+    for (const u of units) {
+      const tiers = u.points ?? [];
+      if (!u.id || tiers.length < 2) continue;
+      const key = `${faction}/${u.id}`;
+      pricedUnits.add(key);
+      const clashes: string[] = [];
+      for (let i = 0; i < tiers.length; i++)
+        for (let j = i + 1; j < tiers.length; j++) {
+          const a = tiers[i];
+          const b = tiers[j];
+          if (band(a) !== band(b)) continue; // different army-ordinal bands never collide
+          if (lo(a) > hi(b) || lo(b) > hi(a)) continue;
+          // Same-cost overlap is redundant, not ambiguous — a single-size tier
+          // nested inside a range at the identical price (the kill-team shape)
+          // prices correctly whichever one wins. Only a cost CONFLICT is a bug.
+          if (a.cost === b.cost) continue;
+          const span = (p: PointsTierLike) => (hi(p) === lo(p) ? `${lo(p)}` : `${lo(p)}-${hi(p)}`);
+          clashes.push(`${span(a)} models @ ${a.cost}pts vs ${span(b)} models @ ${b.cost}pts`);
+        }
+      if (clashes.length === 0) continue;
+      if (KNOWN_AMBIGUOUS_POINTS.has(key)) {
+        seenAmbiguous.add(key);
+        continue;
+      }
+      result.failed++;
+      result.errors.push({
+        file,
+        index: 0,
+        errors: clashes.map((c) => ({
+          path: `/${u.id}`,
+          message: `unit "${u.id}": ambiguous points ladder — ${c}. Two tiers price the same squad size in the same army-ordinal band, so the cost a builder picks is arbitrary; give them distinct unit_count_min/unit_count_max bands, merge them into one models/models_max range, or drop the stale tier`,
         })),
       });
     }
@@ -706,6 +780,25 @@ export async function checkReferentialIntegrity(dataRoot?: string): Promise<Vali
       errors: stale.map((k) => ({
         path: "/KNOWN_LOADOUT_ORPHANS",
         message: `allowlist entry "${k}" is no longer an orphan — remove it`,
+      })),
+    });
+  }
+
+  // A fixed points ladder must drop its allowlist entry, so the list can't mask
+  // a later regression on the same unit. Only units actually scanned are
+  // eligible — a partial dataset (e.g. a fixture with one faction) never
+  // spuriously flags the rest.
+  const staleAmbiguous = [...KNOWN_AMBIGUOUS_POINTS].filter(
+    (k) => pricedUnits.has(k) && !seenAmbiguous.has(k),
+  );
+  if (staleAmbiguous.length > 0) {
+    result.failed++;
+    result.errors.push({
+      file: "tools/src/integrity.ts",
+      index: 0,
+      errors: staleAmbiguous.map((k) => ({
+        path: "/KNOWN_AMBIGUOUS_POINTS",
+        message: `allowlist entry "${k}" no longer has an ambiguous points ladder — remove it`,
       })),
     });
   }

--- a/tools/test/fixtures/integrity-points-ambiguous/core/world-eaters/units.json
+++ b/tools/test/fixtures/integrity-points-ambiguous/core/world-eaters/units.json
@@ -1,0 +1,43 @@
+[
+  {
+    "id": "ambiguous-flat",
+    "faction_keywords": ["World Eaters"],
+    "points": [
+      { "models": 3, "cost": 85 },
+      { "models": 6, "cost": 170 },
+      { "models": 6, "cost": 110 }
+    ]
+  },
+  {
+    "id": "ambiguous-range",
+    "faction_keywords": ["World Eaters"],
+    "points": [
+      { "models": 6, "models_max": 9, "cost": 235 },
+      { "models": 8, "cost": 250 }
+    ]
+  },
+  {
+    "id": "ordinal-banded",
+    "faction_keywords": ["World Eaters"],
+    "points": [
+      { "models": 5, "cost": 240, "unit_count_min": 1, "unit_count_max": 2 },
+      { "models": 5, "cost": 260, "unit_count_min": 3, "unit_count_max": null }
+    ]
+  },
+  {
+    "id": "same-cost-overlap",
+    "faction_keywords": ["World Eaters"],
+    "points": [
+      { "models": 3, "models_max": 16, "cost": 275 },
+      { "models": 10, "cost": 275 }
+    ]
+  },
+  {
+    "id": "clean-ladder",
+    "faction_keywords": ["World Eaters"],
+    "points": [
+      { "models": 5, "cost": 70 },
+      { "models": 6, "models_max": 8, "cost": 140 }
+    ]
+  }
+]

--- a/tools/test/fixtures/integrity-points-stale/core/adeptus-astartes/units.json
+++ b/tools/test/fixtures/integrity-points-stale/core/adeptus-astartes/units.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "wolf-guard-headtakers",
+    "points": [
+      { "models": 3, "cost": 85 },
+      { "models": 6, "cost": 170 }
+    ]
+  }
+]

--- a/tools/test/referential-integrity.test.ts
+++ b/tools/test/referential-integrity.test.ts
@@ -91,6 +91,43 @@ describe("referential integrity", () => {
     expect(messages.filter((m) => m.includes("drifted across factions"))).toEqual([]);
   });
 
+  it("flags an ambiguous points ladder, and spares legitimate ordinal bands", async () => {
+    const result = await checkReferentialIntegrity(resolve(FIXTURES, "integrity-points-ambiguous"));
+    const messages = result.errors.flatMap((e) => e.errors.map((x) => x.message));
+
+    // Two tiers priced at 6 models with no ordinal band to separate them.
+    expect(
+      messages.some(
+        (m) => m.includes('"ambiguous-flat"') && m.includes("6 models @ 170pts vs 6 models @ 110pts"),
+      ),
+    ).toBe(true);
+    // A range tier (6-9) swallowing a single-size tier (8) is equally ambiguous.
+    expect(
+      messages.some(
+        (m) => m.includes('"ambiguous-range"') && m.includes("6-9 models @ 235pts vs 8 models @ 250pts"),
+      ),
+    ).toBe(true);
+    // Same size, different army-ordinal band — this is 11e pricing, not a bug.
+    expect(messages.some((m) => m.includes('"ordinal-banded"'))).toBe(false);
+    // A single-size tier nested in a range at the SAME cost is redundant, not
+    // ambiguous — whichever wins prices identically, so it must not fire.
+    expect(messages.some((m) => m.includes('"same-cost-overlap"'))).toBe(false);
+    // Adjacent, non-overlapping tiers are fine.
+    expect(messages.some((m) => m.includes('"clean-ladder"'))).toBe(false);
+  });
+
+  it("reports a stale KNOWN_AMBIGUOUS_POINTS entry once its ladder is fixed", async () => {
+    const result = await checkReferentialIntegrity(resolve(FIXTURES, "integrity-points-stale"));
+    const messages = result.errors.flatMap((e) => e.errors.map((x) => x.message));
+    expect(
+      messages.some(
+        (m) =>
+          m.includes('"adeptus-astartes/wolf-guard-headtakers"') &&
+          m.includes("no longer has an ambiguous"),
+      ),
+    ).toBe(true);
+  });
+
   it("registers the chaos cult factions with bare-legion home keywords", () => {
     expect(FACTION_HOME_KEYWORD["world-eaters"]).toBe("World Eaters");
     expect(FACTION_HOME_KEYWORD["chaos-space-marines"]).toBe("Heretic Astartes");


### PR DESCRIPTION
## What

Adds a referential-integrity check: within a single army-ordinal band, a squad size must resolve to exactly one price. Two `points` tiers covering the same size with no distinct `unit_count_min`/`unit_count_max` to separate them are flagged.

## Why

Found while chasing a reported bug — **Wolf Guard Headtakers offers up to 12 models in list builders, but the datasheet caps at 6.**

The `max: 12` turned out to be a symptom, not the cause. The points ladder is:

```
{"models":3,  "cost":85}
{"models":6,  "cost":170}
{"models":6,  "cost":110}   <- same size, different price, no ordinal band
{"models":12, "cost":220}   <- where max=12 comes from
```

Both `model_count.max` and the composition's `models[0].max` are derived from that stray 12-model tier, so fixing the model count alone would leave a mispriced tier and an out-of-sync composition behind. Corroborating: the composition reads Headtaker max 12 + Hunting Wolf max 2 = 14, over the unit's own max of 12.

For contrast, `sword-brethren-squad` duplicates sizes legitimately — every tier there carries `unit_count_min`/`unit_count_max`. Headtakers carries none.

## Why the existing check missed it

`integrity.ts` already has the points<->composition coverage invariant (added after the Venatari 4-6 regression), but it bails when the composition has no `tiers`. Headtakers is one of only 4 `adeptus-astartes` compositions lacking `tiers` (15 repo-wide) — precisely the units an ingest is most likely to get wrong. `schemas/core/unit.schema.json` also has no `uniqueItems` on `points`, so duplicate tiers are schema-legal.

## Scope decisions

- **Overlap, not equality**, so a range-priced tier (`models`..`models_max`) colliding with a single-size tier is caught too.
- **Same-cost overlap is not flagged.** A single-size tier nested in a range at the identical price is redundant, not ambiguous — whichever wins prices the same. The kill-team datasheets (`indomitor`/`fortis`/`spectrus`) legitimately use that shape, and an initial stricter version false-flagged all three.
- Across the full dataset the check flags **exactly one unit**, the reported one.

## No data changes

The correct Headtakers costs live in the GW MFM dump, not in this repo, so repairing them is an ingest fix rather than a hand-edit. The unit is carried in `KNOWN_AMBIGUOUS_POINTS`, mirroring the existing `KNOWN_LOADOUT_ORPHANS` idiom — stale-entry detection included, so the entry cannot outlive the bug. That also keeps this PR clear of the four-language bundle regeneration.

**Open question for you:** the tier ladder was last written by `a92dbb2 feat: ingest MFM data_version 909`. If the dump does price Headtakers per army ordinal, the real fix may be teaching the ingest to emit `unit_count_*` here rather than editing the tiers — happy to follow up if you can confirm what the dump holds.

## Verification

`npm test` -> 1504 passed, 0 failed. `npm run validate` -> 18518 entities, 3576 integrity items, 0 failures. No `data/` or `schemas/` changes, so no generated-artifact drift.

Five new fixture cases cover: flat duplicate, range-vs-single overlap, legitimate ordinal bands, same-cost overlap, and clean adjacent tiers — plus a stale-allowlist test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ftWVtktasJ6DuametQ8tu