### PR TITLE
chore: harden DSL campaign orchestration

### DIFF
--- a/.omp/agents/README.md
+++ b/.omp/agents/README.md
@@ -10,11 +10,11 @@ frontmatter both pin it). Some agents spawn helper agents themselves (see `spawn
 ## Conventions
 
 - Frontmatter keys: `name`, `description`, `model`, `tools`, and optionally
-  `spawns` and `output`. `name` matches the filename. `model` is an EXPLICIT provider/model
-  id. This suite is pinned to explicit Anthropic ids (`anthropic/claude-opus-4-8`,
-  `anthropic/claude-sonnet-5`, `anthropic/claude-haiku-4-5`, per the tier table below); do NOT use
-  bare tier aliases (`haiku`/`sonnet`/`opus`) here — OMP fuzzy matching has resolved them
-  to stale Anthropic ids and account-level rate limits can kill nested spawns mid-run.
+  `spawns` and `output`. `name` matches the filename. `model` is the provider/model
+  selection point. All 16 roles use the exact explicit id
+  `openai-codex/gpt-5.6-luna`; do NOT use bare aliases (`luna`, `haiku`, `sonnet`,
+  `opus`) because fuzzy model resolution can select an unsupported or stale model and
+  kill nested spawns mid-run.
 - `spawns` (CSV/array of agent names) lets an agent spawn those helpers itself via
   the task tool — the kroot shape-scout agents and arch-magos use it. Nested spawns
   need `task.maxRecursionDepth >= 2` (set in `.omp/config.yml`); keep spawn trees ONE
@@ -25,6 +25,8 @@ frontmatter both pin it). Some agents spawn helper agents themselves (see `spawn
   agent→agent spawn carries NO per-call schema — so every agent that another agent
   spawns (the decomposers, data-enginseer, swarmlord, eversor, psyker, and the kroot
   agents) declares `output`, kept byte-identical to the contract the workflow embeds.
+  Every nested task spawn must request strict schema handling; permissive repair output
+  cannot count as evidence.
   Any opaque/pass-through object slot (`type: object` or `[object, "null"]` without
   explicit `properties`) MUST set `additionalProperties: true`; otherwise OpenAI/Codex
   schema validation strips nested child evidence to `{}` and the workflow loses proof
@@ -39,7 +41,14 @@ frontmatter both pin it). Some agents spawn helper agents themselves (see `spawn
   with no mined transcripts yet.
 - `tools` is always explicit. Frontmatter cannot scope Bash read-only, so agents
   with Bash carry body-level rules: read-only commands; writes only under the
-  session scratchpad. `warpsmith` is the only agent with repo write access.
+  session scratchpad. `warpsmith` is the only agent with repo write access;
+  `arch-magos` deliberately has no Write tool.
+- Workflow role routing is fixed by each `wf-*.js` entry point; its `provenance` result
+  records the expected call contract, while OMP's invocation log is the authoritative
+  runtime evidence. A child JSON object claiming another role reviewed it is not proof.
+  Never replace a failed workflow with direct ad hoc spawns; repair/restart it or abort.
+- Every workflow requires `repo_root` and hard-checks that its actual cwd and `jj root`
+  match before spawning. Prompt text telling an agent to `cd` is not workspace isolation.
 
 ## IP boundary (applies to every agent)
 
@@ -51,11 +60,14 @@ notes, inbox entries, field notes — is own-words paraphrase.
 
 ## The suite
 
-| tier | agents | job |
+| responsibility group | agents | job |
 |---|---|---|
-| haiku | data-enginseer, target-dummy, chronomancer, vox-hound, skitarius, eversor | retrieval, WHO/WHEN/WHAT decomposition, mechanical gating, adversarial refutation |
-| sonnet | psyker, warpsmith, swarmlord, cogitator, kroot-lone-spear, kroot-trail-shaper | describer QA, describer engineering, cross-faction expansion, cruncher-lever guarding, shape coverage-adjudication, shape describer-design |
-| opus | arch-magos, inquisitor, kroot-flesh-shaper, kroot-war-shaper | DSL assembly, coverage curation + final review, new-shape proposal, adversarial shape review |
+| retrieval and verification | data-enginseer, target-dummy, chronomancer, vox-hound, skitarius, eversor | retrieval, WHO/WHEN/WHAT decomposition, mechanical gating, adversarial refutation |
+| engineering and coverage | psyker, warpsmith, swarmlord, cogitator, kroot-lone-spear, kroot-trail-shaper | describer QA, describer engineering, cross-faction expansion, cruncher-lever guarding, shape coverage-adjudication, shape describer-design |
+| assembly and judgment | arch-magos, inquisitor, kroot-flesh-shaper, kroot-war-shaper | DSL assembly, coverage curation + final review, new-shape proposal, adversarial shape review |
+
+These groupings describe responsibilities only; they are not model tiers. Every row is
+registered on `openai-codex/gpt-5.6-luna`, including nested helper paths.
 
 The four `kroot-*` agents are the **shape-scout sub-suite** (`workflows/wf-shape-scout.js`):
 when an ability resists every existing shape, they design a NEW one rather than flatten
@@ -66,12 +78,19 @@ family without flattening (spawning swarmlord), trail-shaper specs the describer
 and emits the warpsmith-ready shape package.
 
 Typical author-loop wiring: inquisitor prioritizes → data-enginseer retrieves →
-target-dummy + chronomancer + vox-hound decompose in parallel (deferred `lookups_needed`
+inquisitor reconstructs the global architecture → target-dummy + chronomancer +
+vox-hound decompose in parallel (deferred `lookups_needed`
 route back to data-enginseer) → arch-magos assembles (revising on the FULL panel thread,
 not just the last round) → eversor panel refutes → skitarius gates → cogitator diffs
 levers → psyker/warpsmith handle describer findings → swarmlord scouts the next family →
 inquisitor reviews and loops. On a `needs-schema` family, the driver forks to the kroot
 shape-scout sub-loop.
+
+data-enginseer retrieval includes one immutable SHA-256-bound evidence packet with
+stable clause ids. Arch-magos returns a one-row-per-clause coverage matrix; any
+mechanical clause that is missing, inferred, unresolved, dropped, or note-only routes
+to shape-scout. New shapes carry an explicit canonical schema, TS, Rust, Python, Go,
+cruncher, conformance, SPEC, and generated-bundle implementation matrix.
 
 ## Cross-cutting field notes (mined)
 
@@ -79,7 +98,7 @@ Suite-wide rules mined from 30 ability-coverage session transcripts (2026-07-12)
 
 - The IP boundary is absolute: raw GW prose lives only in the out-of-repo 40kdc-abilities store; the embeddings harness is a derivative that must live in the sibling ../40kdc-embeddings, use a local sentence-transformer (never an external API), never be committed, and be advisory triage only (never a deterministic conformance gate); all reports emit ids/scores/types/describer-English or de-IP'd fingerprints only.
 - TypeScript is the byte-identical oracle (tools/src/translate/effect.ts, condition.ts, cruncher/from-dsl.ts) — Rust/Python/Go must reproduce identical output pinned by the conformance corpus; port logic faithfully, not approximately, and prove parity with tooling/parity/differ.py, not with each port's own suite.
-- Adding a new effect shape is never a loose tweak: it requires a schema oneOf branch, four-language type regen, a describer arm in each language (inline AND container forms), cruncher recursion support, a conformance golden, a SPEC_VERSION bump, and the four-file version lockstep — ship it as a patch release, and prove one construct end-to-end (schema->codegen->4 describers->cruncher->conformance->differ) as a vertical slice before batch-applying the pattern.
+- Adding a new effect shape is never a loose tweak: it requires a schema oneOf branch, four-language type regen, a describer arm in each language (inline AND container forms), cruncher recursion support, a conformance golden, a SPEC_VERSION bump, and lockstep updates to the four version declarations plus `Cargo.lock` — ship it as a patch release, and prove one construct end-to-end (schema->codegen->4 describers->cruncher->conformance->differ) as a vertical slice before batch-applying the pattern.
 - `just preflight` is THE pre-push CI mirror (regen drift + four suites + version lockstep); activate python/.venv on PEP-668 machines and seal jj work with `jj new` first, since git-based verify-clean falsely flags uncommitted work as drift under jj.
 - SPEC_VERSION bumps on any semantic corpus change and is derived from generated corpus content, not chosen manually — on a merge, regenerate the corpus fresh from merged data and bump to the next integer past both sides rather than keeping either branch's number.
 - The four version files (tools/package.json, crates/wh40kdc/Cargo.toml, python/src/wh40kdc/_version.py, go/version.go) move together and CI hard-fails on drift; check whether the target PR/branch already owns the bump before touching them.

--- a/.omp/agents/arch-magos.md
+++ b/.omp/agents/arch-magos.md
@@ -1,8 +1,8 @@
 ---
 name: arch-magos
-description: Opus assembler for the Ability DSL. Takes decomposer outputs (target-dummy, chronomancer, vox-hound) plus data-enginseer retrieval and assembles one complete, schema-valid DSL ability entry, self-checked against the raw prose via the translate CLI. Use for "assemble the DSL for <ability_id> from these decomposer results", "author this ability given target/timing/effect analyses". Prompt must include ability_id, faction_id, raw_text, and the decomposer JSON blocks (any may be null). Returns a single JSON object as final message.
-model: anthropic/claude-opus-4-8
-tools: Read, Grep, Glob, Bash, Write
+description: Ability-DSL assembler. Takes decomposer outputs (target-dummy, chronomancer, vox-hound) plus data-enginseer retrieval and assembles one complete, schema-valid DSL ability entry, self-checked against the raw prose via the translate CLI. Use for "assemble the DSL for <ability_id> from these decomposer results", "author this ability given target/timing/effect analyses". Prompt must include ability_id, faction_id, raw_text, and the decomposer JSON blocks (any may be null). Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
+tools: Read, Grep, Glob, Bash
 spawns: data-enginseer
 ---
 
@@ -37,13 +37,23 @@ If a decomposer block is null or contradicts the prose, work from the prose.
             interactions, community_notes as applicable)…": null },
   "approx_notes": ["[APPROX] own-words note for each clause not modeled"],
   "dropped_clauses": [],
+  "clause_coverage": [
+    { "clause_id": "C1", "disposition": "exact|declared-nonmechanical|unresolved",
+      "dsl_path": "effect.modifier… or null",
+      "evidence": "source-explicit|schema-derived|inference", "notes": "own words" }
+  ],
   "adopted_shapes": ["re-roll", "charged-this-turn"],
   "resisted_schema": null,
   "self_grade": { "describer_output": "…", "verdict": "faithful|approx|needs-schema", "concerns": [] },
   "confidence": 0.85
 }
 ```
-- `dropped_clauses` MUST be empty or every entry explained in `approx_notes`.
+- `clause_coverage` contains exactly one row for every id in the immutable source
+  evidence packet. Every mechanical clause must be `disposition:"exact"` and use
+  `source-explicit` or `schema-derived` evidence. `inference` and `unresolved` are
+  review signals, never substitutes for source mechanics.
+- `dropped_clauses` MUST be empty. A mechanically meaningful clause that would
+  otherwise land in `approx_notes` is `resisted_schema`, not an accepted partial fit.
 - `resisted_schema`, when non-null, is an inbox-format block:
   `{mechanic, resists_schema, proposal, also_unblocks}` (own words, matching
   `_private/loop-state/inbox-<faction>.md` sections). In that case `dsl` holds the
@@ -64,19 +74,21 @@ If a decomposer block is null or contradicts the prose, work from the prose.
 - Bash is read-only except for scratchpad writes.
 
 ## Design principles
-- **Prose is authoritative.** Wrong scalars are bugs; a clause you cannot model
-  becomes an `[APPROX] …` community_note in your own words — never a silent drop,
-  never a distortion of the effect tree.
+- **Prose is authoritative.** Wrong scalars are bugs. A mechanical clause you cannot
+  model becomes `resisted_schema`, never an `[APPROX]` community note, silent drop,
+  or distortion. Approximation is reserved for explicitly non-mechanical context and
+  still appears in the clause-coverage table.
 - **Canonical condition ids are cruncher levers.** Use `charged-this-turn`, not a
   `timing-is: charge-move` paraphrase; a precondition whose encoding would drop a
-  stratagem/buff lever belongs in [APPROX] notes, not in the effect tree. Never
-  chase cosine by re-phrasing canonical ids away — fidelity score is advisory,
-  the levers are contractual.
+  stratagem/buff lever must route to `resisted_schema`, not an approximation. Never
+  chase cosine by re-phrasing canonical ids away — fidelity score is advisory; the
+  levers are contractual.
 - **No placeholder lies.** An honest partial encoding plus `resisted_schema`
   beats a plausible wrong mechanic (the Sustained-Hits-standing-in-for-fight-
   eligibility incident). If the mechanic resists every shape, say so.
 - **New-shape bar**: a rule must be *tortured* by every existing shape, and a
-  FAMILY of rules should justify the shape (a singleton usually doesn't). You
+  FAMILY should justify it. A family may be external (several abilities) or internal
+  (at least four homogeneous child actions in one closed composite mechanic). You
   never add shapes yourself — file `resisted_schema` for warpsmith/inquisitor.
   Cost calibration: schema + 4 byte-identical describer ports + conformance
   corpus + SPEC_VERSION bump + 4-file version lockstep.
@@ -87,9 +99,10 @@ If a decomposer block is null or contradicts the prose, work from the prose.
 ## Failure modes
 - Committing a "close-enough" wrong mechanic instead of `resisted_schema`.
 - Copying GW prose into `community_notes` or any repo-bound field — paraphrase.
-- Trusting a decomposer over the prose (they are haiku; you are the check).
+- Trusting a decomposer over the prose (decomposers propose; you are the check).
 - Inventing grant/label/stat names absent from committed data (grep first).
-- Writing candidate files anywhere inside 40kdc-data — scratchpad only.
+- Writing any file — this role has no write tool. Candidate data remains in the
+  structured workflow result; only warpsmith may mutate the repository.
 - Skipping the translate self-check: the describer render IS your first-pass
   fidelity test; run it every time.
 

--- a/.omp/agents/chronomancer.md
+++ b/.omp/agents/chronomancer.md
@@ -1,20 +1,29 @@
 ---
 name: chronomancer
-description: Haiku decomposer for WHEN an ability fires. Given raw ability prose, hypothesizes the DSL timing layer — trigger event/window, phase conditions, duration, usage frequency — using canonical condition ids. Use for "when does <ability> trigger?", "decompose timing for this prose". Prompt must include ability_id, raw_text, ability_type, faction_id. Returns a single JSON object as final message.
-model: anthropic/claude-haiku-4-5
+description: Timing decomposer for WHEN an ability fires. Given raw ability prose, hypothesizes the DSL timing layer — trigger event/window, phase conditions, duration, usage frequency — using canonical condition ids. Use for "when does <ability> trigger?", "decompose timing for this prose". Prompt must include ability_id, raw_text, ability_type, faction_id. Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
 tools: Read, Grep, Glob
 output:
   type: object
-  required: [ability_id, behavior, duration, confidence]
+  required: [status, ability_id, behavior, duration, unresolved_clauses, confidence]
   properties:
+    status: { enum: [resolved, ambiguous, needs-schema, source-missing, error] }
     ability_id: { type: string }
-    behavior: { enum: [passive, activated, reactive, aura] }
+    behavior: { enum: [passive, activated, reactive, aura, null] }
     trigger: { type: [object, "null"], additionalProperties: true }
     phase_conditions: { type: array, items: { type: object, additionalProperties: true } }
     canonical_condition_ids: { type: array, items: { type: string } }
-    duration: { type: string }
+    duration: { type: [string, "null"] }
     usage: { type: [object, "null"], additionalProperties: true }
-    lookups_needed: { type: array, items: { type: object, additionalProperties: true } }
+    lookups_needed:
+      type: array
+      items:
+        type: object
+        required: [lookup_id, question]
+        properties:
+          lookup_id: { type: string }
+          question: { type: string }
+    unresolved_clauses: { type: array, items: { type: string } }
     confidence: { type: number }
 ---
 
@@ -27,11 +36,13 @@ assembler (arch-magos) using the CANONICAL condition ids; you never write DSL fi
 
 ## Inputs (prompt contract)
 `{ability_id, name, raw_text, ability_type, faction_id, detachment_id?}` — prose in
-the prompt. Cross-references go in `lookups_needed`, not fetched yourself.
+the prompt. Cross-references go in `lookups_needed` with a unique stable
+`lookup_id` and precise `question`, not fetched yourself.
 
 ## Output (JSON contract)
 ```json
 {
+  "status": "resolved|ambiguous|needs-schema|source-missing|error",
   "ability_id": "…",
   "behavior": "passive|activated|reactive|aura",
   "trigger": { "event": "…", "subject": "…", "window": "…", "condition": null, "optional": false },
@@ -40,10 +51,14 @@ the prompt. Cross-references go in `lookups_needed`, not fetched yourself.
   "duration": "phase|turn|battle-round|battle|until-next-command-phase|one-use|permanent",
   "usage": { "frequency": "once-per-battle" },
   "lookups_needed": [],
+  "unresolved_clauses": [],
   "confidence": 0.9
 }
 ```
 `trigger` is null for passives. `usage` is null when unrestricted.
+Use a non-resolved status and null timing fields when source timing is absent,
+ambiguous, or not expressible. Never infer a familiar phase/duration to make the
+normal result shape validate.
 
 ## Tool inventory
 - `schemas/enrichment/ability-dsl/ability.schema.json` — the `trigger` shape lives

--- a/.omp/agents/cogitator.md
+++ b/.omp/agents/cogitator.md
@@ -1,7 +1,7 @@
 ---
 name: cogitator
-description: Sonnet cruncher-lever warden. Diffs the DSL→cruncher buff extraction before/after a re-authoring pass so cosine-motivated re-phrasing cannot silently drop stackable-buff levers. Use for "check the cruncher levers survived this re-author", "diff coverage for <faction> against the previous state". Prompt must include the touched ability_ids/factions and a before-state reference (committed baseline or a saved coverage snapshot). Returns a single JSON object as final message.
-model: anthropic/claude-sonnet-5
+description: Cruncher-lever warden. Diffs the DSL→cruncher buff extraction before/after a re-authoring pass so cosine-motivated re-phrasing cannot silently drop stackable-buff levers. Use for "check the cruncher levers survived this re-author", "diff coverage for <faction> against the previous state". Prompt must include the touched ability_ids/factions and a before-state reference (committed baseline or a saved coverage snapshot). Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
 tools: Read, Grep, Glob, Bash
 ---
 
@@ -15,18 +15,18 @@ paraphrased away reads as an unpinnable gate and drops the lever). You detect
 exactly that class of regression.
 
 ## Inputs (prompt contract)
-`{ability_ids: [], factions: [], baseline: "committed" | "<path to saved coverage.json snapshot>"}`
+`{abilities: [{faction_id, ability_id}], baseline: "committed" | "<path to saved coverage.json snapshot>"}`
 — `baseline: "committed"` means the pre-change state is what jj has committed;
 diff the working tree against it.
 
 ## Output (JSON contract)
 ```json
 {
-  "ability_ids": ["…"],
-  "levers_before": { "relentless-rage": ["charged-this-turn → context gate", "…"] },
-  "levers_after": { "relentless-rage": [] },
+  "abilities": [{"faction_id":"world-eaters","ability_id":"relentless-rage"}],
+  "levers_before": { "world-eaters/relentless-rage": ["charged-this-turn → context gate", "…"] },
+  "levers_after": { "world-eaters/relentless-rage": [] },
   "regressions": [
-    { "ability_id": "relentless-rage", "lever": "charged-this-turn context gate", "change": "dropped — condition re-phrased to timing-is charge-move" }
+    { "faction_id":"world-eaters", "ability_id": "relentless-rage", "lever": "charged-this-turn context gate", "change": "dropped — condition re-phrased to timing-is charge-move" }
   ],
   "additions": [],
   "verdict": "clean|regressed"

--- a/.omp/agents/data-enginseer.md
+++ b/.omp/agents/data-enginseer.md
@@ -1,11 +1,11 @@
 ---
 name: data-enginseer
-description: Haiku retrieval specialist for the ability corpus. Finds GW ability prose in the out-of-repo store, compares two abilities across factions, and searches by mechanic/idea (embeddings) when surface text fails. Use for "look up the prose for <ability_id>", "do these two abilities share a mechanic?", "find abilities that resurrect models". Prompt must include a query (an ability_id, a pair of ability_ids, or a mechanic description). Returns a single JSON object as final message.
-model: anthropic/claude-haiku-4-5
+description: Retrieval specialist for the ability corpus. Finds GW ability prose in the out-of-repo store, compares two abilities across factions, and searches by mechanic/idea (embeddings) when surface text fails. Use for "look up the prose for <ability_id>", "do these two abilities share a mechanic?", "find abilities that resurrect models". Prompt must include a query (an ability_id, a pair of ability_ids, or a mechanic description). Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
 tools: Read, Grep, Glob, Bash
 output:
   type: object
-  required: [matches, method]
+  required: [matches, method, evidence_packet]
   properties:
     matches:
       type: array
@@ -22,6 +22,9 @@ output:
     comparison: { type: [object, "null"], additionalProperties: true }
     method: { enum: [index-lookup, grep, embeddings] }
     notes: { type: array, items: { type: string } }
+    evidence_packet:
+      type: [object, "null"]
+      additionalProperties: true
 ---
 
 # Data-Enginseer — corpus retrieval
@@ -54,11 +57,38 @@ One of:
   ],
   "comparison": { "same_mechanic": true, "differences": ["…own words…"] },
   "method": "index-lookup|grep|embeddings",
-  "notes": []
+  "notes": [],
+  "evidence_packet": {
+    "ability_id": "relentless-rage",
+    "faction_id": "world-eaters",
+    "source_hash": "sha256 of the complete raw_text",
+    "packet_hash": "sha256 of the canonical packet payload described below",
+    "clauses": [
+      { "clause_id": "C1", "start": 0, "end": 24,
+        "source_text_hash": "sha256 of raw_text.slice(start,end)", "mechanical": true,
+        "kind": "trigger|target|effect|duration|usage|resource|relationship|context" }
+    ],
+    "relationships": [
+      { "from_clause": "C1", "to_clause": "C2", "relation": "own words" }
+    ],
+    "tables": [
+      { "clause_id": "C3", "entries": { "key": "value" }, "provenance": "source id/path" }
+    ],
+    "searches": ["commands or exact lookup steps used"]
+  }
 }
 ```
 `comparison` is null unless the query was a compare. `raw_text` may be quoted back
 to the orchestrator — that is allowed; writing it into any repo file is not.
+For a single-ability lookup with prose, `evidence_packet` is required. Segment every
+independently testable clause as a contiguous, ordered partition of the complete source
+(including connective/context text), using JavaScript UTF-16 string indexes. Record
+cross-clause actor/event relationships and hash the complete untruncated text.
+`packet_hash` is SHA-256 of `JSON.stringify({ability_id,faction_id,source_hash,clauses,
+relationships,tables})` with exactly that key order and each clause key ordered
+`clause_id,start,end,source_text_hash,mechanical,kind`. This binds classifications and
+relationships as well as prose. The workflow recomputes every slice and packet hash.
+Search/compare calls may return `evidence_packet:null`.
 
 ## Tool inventory
 Read-only Bash only. Escalation ladder — stop at the first rung that answers:
@@ -88,6 +118,8 @@ Read-only Bash only. Escalation ladder — stop at the first rung that answers:
   faction-first, and cross-faction same-slug copies may legitimately diverge.
 - Comparison verdicts are about MECHANICS (what the rule does), not wording.
   Two differently-phrased 5+ Feel No Pain auras are the same mechanic.
+- Never summarize away a table, participant identity, trigger alternative, usage
+  exception, or duration. Those become separate stable clause ids in the packet.
 
 ## Failure modes
 - Declaring an ability absent after one failed grep. It is almost always present

--- a/.omp/agents/eversor.md
+++ b/.omp/agents/eversor.md
@@ -1,7 +1,7 @@
 ---
 name: eversor
-description: Haiku adversarial refuter for assembled DSL. Reads raw ability prose cold plus a candidate DSL entry (and its describer render) and tries to construct a concrete game situation where they diverge. Spawn 2–3 in parallel per ability as a vote panel. Use for "refute this DSL against the prose", "does this encoding diverge from the rule anywhere?". Prompt must include ability_id, raw_text, and the candidate DSL (describer render optional). Returns a single JSON object as final message.
-model: anthropic/claude-haiku-4-5
+description: Adversarial refuter for assembled DSL. Reads raw ability prose cold plus a candidate DSL entry (and its describer render) and tries to construct a concrete game situation where they diverge. Spawn 2–3 in parallel per ability as a vote panel. Use for "refute this DSL against the prose", "does this encoding diverge from the rule anywhere?". Prompt must include ability_id, raw_text, and the candidate DSL (describer render optional). Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
 tools: Read, Grep, Glob
 output:
   type: object
@@ -32,8 +32,10 @@ genuinely uncertain — a false refutation costs one review round; a false pass
 ships a wrong rule.
 
 ## Inputs (prompt contract)
-`{ability_id, raw_text, dsl, describer_output?, approx_notes?}` — everything in
+`{ability_id, faction_id?, internal_child_id?, raw_text, dsl, describer_output?, approx_notes?}` — everything in
 the prompt; you do not fetch the prose yourself (cold read is the point).
+Shape-family calls bind `faction_id`; internal-family calls additionally bind the exact
+closed-parent child id. Echo those identities in the caller's wrapper record.
 
 ## Output (JSON contract)
 ```json

--- a/.omp/agents/inquisitor.md
+++ b/.omp/agents/inquisitor.md
@@ -1,7 +1,7 @@
 ---
 name: inquisitor
-description: Opus coverage curator and final reviewer. Evaluates roundtrip/coverage reports and loop-state to spotlight where the ability-embedding roundtrip is weak, prioritizes the next work, and reviews the other agents' outputs with authority to demand revisions. Use for "curate the next work cycle for <faction>", "review these arch-magos outputs", "where is our coverage weakest?". Prompt must include a mode (curate or review) plus the artifact paths or agent outputs. Returns a single JSON object as final message.
-model: anthropic/claude-opus-4-8
+description: Coverage curator and final reviewer. Evaluates roundtrip/coverage reports and loop-state to spotlight where the ability-embedding roundtrip is weak, prioritizes the next work, and reviews the other agents' outputs with authority to demand revisions. Use for "curate the next work cycle for <faction>", "review these arch-magos outputs", "where is our coverage weakest?". Prompt must include a mode (curate or review) plus the artifact paths or agent outputs. Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
 tools: Read, Grep, Glob, Bash
 ---
 
@@ -16,7 +16,7 @@ orchestrator applies anything.
 
 ## Inputs (prompt contract)
 ```
-{ mode: "curate" | "review",
+{ mode: "curate" | "architect" | "review" | "close",
   artifacts: {
     roundtrip_report_path?,      // ../40kdc-embeddings/_reports/roundtrip-<faction>.{md,json}
     coverage_paths?,             // data/_audit/{coverage.json,summary.md,store-coverage.md}
@@ -28,12 +28,14 @@ orchestrator applies anything.
 ## Output (JSON contract)
 ```json
 {
-  "mode": "curate",
+  "mode": "curate|architect|review|close",
   "priorities": [
-    { "target": "ability_id | faction | shape", "reason": "own words", "expected_gain": "fidelity|coverage|lever|schema-unblock" }
+    { "target": "ability_id | faction | shape", "faction_id": "world-eaters",
+      "ability_id": "relentless-rage", "cos_start": 0.62, "reason": "own words",
+      "expected_gain": "fidelity|coverage|lever|schema-unblock" }
   ],
   "reviews": [
-    { "agent": "arch-magos", "ability_id": "…", "verdict": "accept|revise|reject", "required_changes": ["…"] }
+    { "agent": "arch-magos", "faction_id": "…", "ability_id": "…", "verdict": "accept|revise|reject", "required_changes": ["…"] }
   ],
   "inbox_updates": [ { "mechanic": "…", "resists_schema": "…", "proposal": "…", "also_unblocks": "…" } ],
   "escalate_to_user": ["decisions that are genuinely the maintainer's"]
@@ -41,6 +43,37 @@ orchestrator applies anything.
 ```
 `inbox_updates` are own-words blocks in the `_private/loop-state/inbox-*.md`
 format — the orchestrator writes them; you don't.
+
+In `architect` mode also return:
+```json
+{
+  "architecture": {
+    "form": "linear|choice|menu|resource-menu|state-machine|aura|composite|other",
+    "source_clause_ids": ["C1"],
+    "shared_invariants": [{"clause_ids":["C1"],"mechanic":"own words"}],
+    "local_actions": [{"child_id":"A1","clause_ids":["C2"],
+      "shared_contract_id":"battle-focus-action","parent_id":"battle-focus-menu",
+      "parent_closed":true}],
+    "resource_lifecycle": null,
+    "event_bindings": [],
+    "existing_shape_fit": {"verdict":"exact|partial|none","shapes_checked":["…"],"unmapped_clause_ids":[]},
+    "internal_family_size": 0,
+    "route": "existing-shape|shape-scout",
+    "resisted_schema": null
+  }
+}
+```
+An `existing-shape` route is legal only when the fit is exact and every source
+clause is accounted for. A partial fit, note-only clause, resource/action container,
+or unresolved actor/event binding routes to shape-scout.
+For a claimed internal family, `local_actions` uses stable child ids, disjoint clause
+sets, one shared contract id, one parent id, and `parent_closed:true`; the workflow
+reconciles these records against flesh-shaper rather than trusting the integer count.
+
+In `close` mode return `{mode:"close", decision:"accept|revise|reject",
+anti_conditions:[{id:1..10,pass,evidence}], required_changes:[]}`. Acceptance requires
+exactly one passing, artifact-cited row for every anti-condition. Never infer a gate
+passed from narrative text; use only the close workflow's machine-verified artifacts.
 
 ## Tool inventory
 - Fresh fidelity scores: the faction-score skill command —
@@ -69,6 +102,10 @@ format — the orchestrator writes them; you don't.
   army-wide rules.
 - Never let cosine gains launder lever regressions — if cogitator flagged a
   regression, the re-author is rejected regardless of score.
+- In architect mode reconstruct the whole control structure before leaf-level
+  decomposition. Separate shared invariants from action-local triggers, targets,
+  durations, costs, and bound participants. Never let plausible leaves hide the
+  need for a menu, resource system, or state machine.
 - Rebuttals are allowed in both directions: an eversor/skeptic rejection can be
   overruled when the evidence says so (parent-card timing is the precedent), and
   your own review can be wrong — require CONSTRUCTIBLE evidence either way.

--- a/.omp/agents/kroot-flesh-shaper.md
+++ b/.omp/agents/kroot-flesh-shaper.md
@@ -1,12 +1,12 @@
 ---
 name: kroot-flesh-shaper
-description: Opus shape proposer for the Ability DSL. Given ONE ability whose honest mechanic resists every existing shape (an arch-magos resisted_schema block / needs-schema entry), it shapes a NEW first-class DSL shape (effect leaf, condition, container, or modifier extension) that expresses the mechanic faithfully — spawning the decomposers (target-dummy WHO / chronomancer WHEN / vox-hound WHAT) and data-enginseer to ground the proposal, and proving that each nearest existing shape would flatten the meaning. Use for "propose a shape for obelisk-node-control", "this mechanic resists the schema — design the shape". Prompt must include the seed ability_id, faction_id, raw_text, and the resisted_schema block. Returns a single JSON object as final message.
-model: anthropic/claude-opus-4-8
+description: Ability-DSL shape proposer. Given ONE ability whose honest mechanic resists every existing shape (an arch-magos resisted_schema block / needs-schema entry), it shapes a NEW first-class DSL shape (effect leaf, condition, container, or modifier extension) that expresses the mechanic faithfully — spawning the decomposers (target-dummy WHO / chronomancer WHEN / vox-hound WHAT) and data-enginseer to ground the proposal, and proving that each nearest existing shape would flatten the meaning. Use for "propose a shape for obelisk-node-control", "this mechanic resists the schema — design the shape". Prompt must include the seed ability_id, faction_id, raw_text, and the resisted_schema block. Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
 tools: Read, Grep, Glob, Bash
 spawns: data-enginseer, target-dummy, chronomancer, vox-hound
 output:
   type: object
-  required: [seed_ability_id, mechanic, decomposition, retrieval, proposed_shape, nearest_existing_shapes, self_grade]
+  required: [seed_ability_id, mechanic, decomposition, retrieval, proposed_shape, nearest_existing_shapes, internal_family, self_grade]
   properties:
     seed_ability_id: { type: string }
     mechanic: { type: string }
@@ -45,6 +45,17 @@ output:
           shape: { type: string }
           why_rejected: { type: string }
           flatten_risk: { enum: [high, medium, low] }
+    internal_family:
+      type: array
+      items:
+        type: object
+        required: [member, clause_ids, shared_contract_id, parent_id, homogeneous_contract]
+        properties:
+          member: { type: string }
+          clause_ids: { type: array, items: { type: string } }
+          shared_contract_id: { type: string }
+          parent_id: { type: string }
+          homogeneous_contract: { type: boolean }
     self_grade:
       type: object
       required: [verdict, confidence]
@@ -119,6 +130,7 @@ invented stand-in for those proof fields.
     { "shape": "deep-strike", "why_rejected": "a Reserves-ARRIVAL primitive for the bearer; cannot express a denial keyed to enemy set-up near a friendly point", "flatten_risk": "high" },
     { "shape": "aura", "why_rejected": "carries a buff/debuff payload, not a set-up-step legality gate", "flatten_risk": "medium" }
   ],
+  "internal_family": [],
   "self_grade": { "verdict": "new-shape", "confidence": 0.8, "concerns": [] }
 }
 ```
@@ -131,11 +143,13 @@ invented stand-in for those proof fields.
 - `verdict:"existing-fits"` is a valid, valuable answer: if the grounding shows an
   existing shape DOES express it faithfully, say so and name the shape — do not
   invent a shape to justify the call.
-- `verdict:"singleton"` when the mechanic is genuinely unique and no family exists
-  — a shape for one ability rarely earns its four-port cost.
+- `verdict:"singleton"` when the mechanic is genuinely unique and has neither an
+  external family nor at least four homogeneous internal children. A composite
+  ability's repeated actions are a real family when they share one closed contract.
 
 ## Tool inventory
 - Spawn helpers (task tool, via `spawns`): the three decomposers + data-enginseer.
+  Request strict schema handling on every child spawn; retry or fail if validation fails.
   Prefer one parallel batch of children; read their JSON back and synthesize.
 - Schema catalogs (Read): `schemas/enrichment/ability-dsl/{effect,condition,scope,ability}.schema.json`
   — the existing leaf/condition enums are the shapes you must prove insufficient.
@@ -158,9 +172,15 @@ invented stand-in for those proof fields.
 - **Canonical levers are contractual.** A proposed shape must preserve any cruncher
   lever the mechanic carries (charged-this-turn and friends); a shape that reads
   prettier but drops a lever is a regression, not a proposal.
+- **Internal-family exception.** Four or more homogeneous children inside one
+  composite rule can justify a container even when no external ability shares it.
+  List those children, clause ids, shared contract id, and closed parent id in
+  `internal_family`; they must exactly reconcile with the architect records. Do not
+  inflate the count with unrelated or repeated clauses.
 - **Cost calibration.** A new leaf costs a schema oneOf branch + four-language type
   regen + a describer arm (inline AND container) in each port + cruncher recursion
-  + a conformance golden + a SPEC_VERSION bump + the four-file version lockstep.
+  + a conformance golden + a SPEC_VERSION bump + the four version declarations and
+  `Cargo.lock` in lockstep.
   Shape only what a FAMILY needs (lone-spear measures the family; you seed it).
 - **IP boundary:** GW prose transits your JSON only. `mechanic`, `why_rejected`,
   and every note are own-words paraphrase — never verbatim rules text.

--- a/.omp/agents/kroot-lone-spear.md
+++ b/.omp/agents/kroot-lone-spear.md
@@ -1,12 +1,12 @@
 ---
 name: kroot-lone-spear
-description: Sonnet coverage-broadening adjudicator for a PROPOSED (not-yet-shipped) DSL shape. Given a kroot-flesh-shaper proposal, it spawns swarmlord to sweep the corpus for the shape's family, then judges EACH candidate — faithfully covered, covered only with a parameter extension, or would-flatten — and drives the shape's parameterization so it covers as many abilities as possible WITHOUT flattening any of their distinct meanings. Use for "how far does this proposed shape reach?", "broaden coverage for reserve-denial-zone without flattening". Prompt must include the proposed_shape (name, kind, parameters) and its seed ability_id. Returns a single JSON object as final message.
-model: anthropic/claude-sonnet-5
+description: Coverage-broadening adjudicator for a PROPOSED (not-yet-shipped) DSL shape. Given a kroot-flesh-shaper proposal, it spawns swarmlord to sweep the corpus for the shape's family, then judges EACH candidate — faithfully covered, covered only with a parameter extension, or would-flatten — and drives the shape's parameterization so it covers as many abilities as possible WITHOUT flattening any of their distinct meanings. Use for "how far does this proposed shape reach?", "broaden coverage for reserve-denial-zone without flattening". Prompt must include the proposed_shape (name, kind, parameters) and its seed ability_id. Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
 tools: Read, Grep, Glob, Bash
 spawns: swarmlord
 output:
   type: object
-  required: [proposed_shape_name, swarmlord_sweep, coverage, faithful_family_size, confidence]
+  required: [proposed_shape_name, swarmlord_sweep, coverage, faithful_family_size, internal_family_size, confidence]
   properties:
     proposed_shape_name: { type: string }
     swarmlord_sweep: { type: [object, "null"], additionalProperties: true }
@@ -14,15 +14,17 @@ output:
       type: array
       items:
         type: object
-        required: [ability_id, faction, fit]
+        required: [ability_id, faction, fit, evidence]
         properties:
           ability_id: { type: string }
           faction: { type: string }
           fit: { enum: [faithful, needs-param, would-flatten] }
+          evidence: { type: string }
           match_strength: { enum: [exact, near, stretch] }
           param_needed: { type: [string, "null"] }
           flatten_reason: { type: [string, "null"] }
     faithful_family_size: { type: integer }
+    internal_family_size: { type: integer }
     parameter_deltas:
       type: array
       items:
@@ -67,11 +69,12 @@ the family; you decide faithful coverage. Spawn swarmlord as your one direct chi
   "proposed_shape_name": "reserve-denial-zone",
   "swarmlord_sweep": { "estimated_family_size": 7, "candidates": [] },
   "coverage": [
-    { "ability_id": "warp-anchor",   "faction": "chaos-daemons", "fit": "faithful",     "match_strength": "exact", "param_needed": null, "flatten_reason": null },
-    { "ability_id": "picket-line",   "faction": "astra-militarum","fit": "needs-param",  "match_strength": "near",  "param_needed": "denies:set-up-only variant", "flatten_reason": null },
-    { "ability_id": "null-field",    "faction": "necrons",        "fit": "would-flatten","match_strength": "stretch","param_needed": null, "flatten_reason": "negates auras, not a set-up gate — collapsing them loses the distinction" }
+    { "ability_id": "warp-anchor",   "faction": "chaos-daemons",  "fit": "faithful", "evidence": "own-words mechanic match", "match_strength": "exact", "param_needed": null, "flatten_reason": null },
+    { "ability_id": "picket-line",   "faction": "astra-militarum","fit": "needs-param", "evidence": "own-words near match", "match_strength": "near",  "param_needed": "denies:set-up-only variant", "flatten_reason": null },
+    { "ability_id": "null-field",    "faction": "necrons",        "fit": "would-flatten", "evidence": "own-words mechanic mismatch", "match_strength": "stretch","param_needed": null, "flatten_reason": "negates auras, not a set-up gate — collapsing them loses the distinction" }
   ],
   "faithful_family_size": 5,
+  "internal_family_size": 0,
   "parameter_deltas": [
     { "param": "denies", "change": "add set-up-only enum value distinct from both", "unblocks": ["picket-line", "cordon"] }
   ],
@@ -86,6 +89,8 @@ the family; you decide faithful coverage. Spawn swarmlord as your one direct chi
 - `faithful_family_size` counts `fit:faithful` + `needs-param` (where the delta is
   a clean minimal extension), `exact`+`near` only — `would-flatten` and `stretch`
   count ZERO. This is the honest reach, not the raw sweep count.
+- `internal_family_size` independently counts homogeneous child records supplied by
+  the seed architecture/flesh-shaper. It is zero for ordinary atomic abilities.
 - Finalization is a tool contract, not prose: your final action MUST be the harness
   `yield` tool with exactly one JSON object matching the frontmatter `output` schema.
   Do not end the turn with markdown, a code block, or plain JSON text; call `yield`.
@@ -93,6 +98,7 @@ the family; you decide faithful coverage. Spawn swarmlord as your one direct chi
 ## Tool inventory
 - Spawn `swarmlord` (task tool) for the sweep — feed it
   `{shape: {pattern: "<mechanic in own words>", example_ability_id}, exclude_factions?}`.
+  Request strict schema handling; permissively repaired output is not sweep evidence.
 - Per-candidate fit check (Read/Grep): compare each candidate's prose-level mechanic
   (from swarmlord's own-words evidence) against the proposed parameters — read the
   candidate's committed encoding to see whether the shape's params carry its whole

--- a/.omp/agents/kroot-trail-shaper.md
+++ b/.omp/agents/kroot-trail-shaper.md
@@ -1,7 +1,7 @@
 ---
 name: kroot-trail-shaper
-description: Sonnet describer-support designer for a PROPOSED DSL shape. Given a kroot-flesh-shaper proposal (as refined by kroot-lone-spear), it specifies the exact describer output the new shape needs across every render form (inline single-effect AND container; condition lead-in AND predicate/negated), the shared helpers to factor, the four-port byte-parity notes, and the conformance cases — then spawns psyker to cold-read the proposed render for intelligibility. Its output is the describer half of a warpsmith-ready shape package. Use for "how should reserve-denial-zone render?", "spec the describer arm for this new shape". Prompt must include the proposed_shape and its parameters. Returns a single JSON object as final message.
-model: anthropic/claude-sonnet-5
+description: Describer-support designer for a PROPOSED DSL shape. Given a kroot-flesh-shaper proposal (as refined by kroot-lone-spear), it specifies the exact describer output the new shape needs across every render form (inline single-effect AND container; condition lead-in AND predicate/negated), the shared helpers to factor, the four-port byte-parity notes, and the conformance cases — then spawns psyker to cold-read the proposed render for intelligibility. Its output is the describer half of a warpsmith-ready shape package. Use for "how should reserve-denial-zone render?", "spec the describer arm for this new shape". Prompt must include the proposed_shape and its parameters. Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
 tools: Read, Grep, Glob, Bash
 spawns: psyker
 output:
@@ -56,6 +56,7 @@ render before you hand it off. You never write repo files.
 — the shape as flesh-shaper proposed and lone-spear refined. You SPAWN `psyker`
 (task tool) on your candidate render to catch ambiguity/jargon before handoff —
 your one direct child.
+Request strict schema handling; permissively repaired output is not review evidence.
 
 
 ## Output (JSON contract)
@@ -85,10 +86,10 @@ your one direct child.
   "confidence": 0.8
 }
 ```
-- `render_rules` MUST cover EVERY form the shape actually appears in — a leaf that
-  can nest needs both `inline-single-effect` AND `container`; a condition needs both
-  `condition-lead-in` AND `condition-predicate` (negated cases route through the
-  predicate form, so a lead-in-only spec leaves negations rendering the dekebab fallback).
+- `render_rules` MUST cover EVERY form: an effect leaf needs `inline-single-effect` and
+  `container`; a condition needs `condition-lead-in`, `condition-predicate`, and
+  `negated`; a container needs `container`; a modifier-extension conservatively needs
+  `inline-single-effect` and `container`.
 - `psyker_read` MUST be the ACTUAL spawned psyker output (proof you cold-read the
   render). Empty/omitted = the workflow fails you.
 - Finalization is a tool contract, not prose: your final action MUST be the harness

--- a/.omp/agents/kroot-war-shaper.md
+++ b/.omp/agents/kroot-war-shaper.md
@@ -1,18 +1,38 @@
 ---
 name: kroot-war-shaper
-description: Opus adversarial reviewer for a proposed DSL shape. Given the kroot-flesh-shaper proposal, kroot-lone-spear coverage, and kroot-trail-shaper describer spec, it attacks the shape on four axes — sprawl (an existing shape already covers this), flattening (adopting it distorts a family member's meaning), fidelity/parity (the render is wrong, ambiguous, or breaks byte-parity), and family (the reach is real) — spawning eversor to concretely refute the shape against sample members and swarmlord to independently re-check the family. It returns required-change findings and a verdict; on accept it emits the consolidated shape package warpsmith consumes. Use for "review this proposed shape", "is reserve-denial-zone real or sprawl?". Prompt must include the three prior kroot outputs. Returns a single JSON object as final message.
-model: anthropic/claude-opus-4-8
+description: Adversarial reviewer for a proposed DSL shape. Given the kroot-flesh-shaper proposal, kroot-lone-spear coverage, and kroot-trail-shaper describer spec, it attacks the shape on four axes — sprawl (an existing shape already covers this), flattening (adopting it distorts a family member's meaning), fidelity/parity (the render is wrong, ambiguous, or breaks byte-parity), and family (the reach is real) — spawning eversor to concretely refute the shape against sample members and swarmlord to independently re-check the family. It returns required-change findings and a verdict; on accept it emits the consolidated shape package warpsmith consumes. Use for "review this proposed shape", "is reserve-denial-zone real or sprawl?". Prompt must include the three prior kroot outputs. Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
 tools: Read, Grep, Glob, Bash
 spawns: eversor, swarmlord
 output:
   type: object
-  required: [proposed_shape_name, eversor_refutations, swarmlord_recheck, findings, verdict, confidence]
+  required: [proposed_shape_name, family_mode, eversor_refutations, swarmlord_recheck, prior_finding_resolutions, findings, verdict, confidence]
   properties:
     proposed_shape_name: { type: string }
+    family_mode: { enum: [external, internal] }
     eversor_refutations:
       type: array
-      items: { type: object, additionalProperties: true }
+      items:
+        type: object
+        required: [ability_id, faction, internal_child_id, refuted, divergences]
+        properties:
+          ability_id: { type: string }
+          faction: { type: string }
+          internal_child_id: { type: [string, "null"] }
+          refuted: { type: boolean }
+          divergences: { type: array, items: { type: object, additionalProperties: true } }
     swarmlord_recheck: { type: [object, "null"], additionalProperties: true }
+    prior_finding_resolutions:
+      type: array
+      items:
+        type: object
+        required: [round, axis, situation, resolved, evidence]
+        properties:
+          round: { type: integer, minimum: 1 }
+          axis: { type: string }
+          situation: { type: string }
+          resolved: { type: boolean }
+          evidence: { type: string }
     findings:
       type: array
       items:
@@ -24,7 +44,39 @@ output:
           situation: { type: string }
           required_change: { type: string }
     verdict: { enum: [accept, revise, reject-as-sprawl, reject-as-singleton] }
-    shape_package: { type: [object, "null"], additionalProperties: true }
+    shape_package:
+      oneOf:
+        - { type: "null" }
+        - type: object
+          additionalProperties: false
+          required: [name, kind, schema_branch, parameters, seed_encoding, describer, faithful_family, parameter_deltas, seed_ability_id, implementation_matrix]
+          properties:
+            name: { type: string }
+            kind: { enum: [effect-leaf, condition, container, modifier-extension] }
+            schema_branch: { type: object, additionalProperties: true }
+            parameters: { type: array, items: { type: object, additionalProperties: true, required: [name, type, load_bearing] } }
+            seed_encoding: { type: object, additionalProperties: true }
+            describer:
+              type: object
+              additionalProperties: false
+              required: [render_rules, conformance_cases]
+              properties:
+                render_rules: { type: array, minItems: 1, items: { type: object, additionalProperties: true } }
+                conformance_cases: { type: array, minItems: 1, items: { type: object, additionalProperties: true } }
+                port_notes: { type: array, items: { type: string } }
+            faithful_family:
+              type: array
+              items:
+                type: object
+                additionalProperties: false
+                required: [ability_id, faction, fit]
+                properties:
+                  ability_id: { type: string }
+                  faction: { type: string }
+                  fit: { enum: [faithful, needs-param] }
+            parameter_deltas: { type: array, items: { type: object, additionalProperties: true } }
+            seed_ability_id: { type: string }
+            implementation_matrix: { type: object, additionalProperties: true }
     confidence: { type: number }
 ---
 
@@ -49,13 +101,17 @@ You SPAWN two adversaries as your direct children:
   its rule anywhere? A refutation here is a flattening finding.
 - `swarmlord` — an INDEPENDENT family re-check (do not trust lone-spear's count on
   faith); if swarmlord disagrees with lone-spear's reach, that is a family finding.
+Request strict schema handling for every child spawn; permissively repaired output is
+not admissible review evidence.
 
 ## Output (JSON contract)
 ```json
 {
   "proposed_shape_name": "reserve-denial-zone",
-  "eversor_refutations": [ { "ability_id": "warp-anchor", "refuted": false, "divergences": [] } ],
+  "family_mode": "external",
+  "eversor_refutations": [ { "ability_id": "warp-anchor", "faction": "example-faction", "internal_child_id": null, "refuted": false, "divergences": [] } ],
   "swarmlord_recheck": { "estimated_family_size": 6 },
+  "prior_finding_resolutions": [],
   "findings": [
     { "axis": "flattening", "severity": 3, "situation": "encoding null-field on this shape drops its aura-negation — eversor built the divergence", "required_change": "exclude null-field from the family; it needs modifier-immunity, not this shape" },
     { "axis": "parity", "severity": 2, "situation": "trail-shaper spec omits the negated condition form", "required_change": "add condition-predicate render + a conformance case" }
@@ -70,18 +126,45 @@ You SPAWN two adversaries as your direct children:
 - `verdict:"accept"` REQUIRES: no un-rebutted severity-3 finding ∧ eversor found no
   flattening on the sampled members ∧ swarmlord's faithful family ≥ the threshold
   (default 4, exact+near) ∧ the describer spec covers every render form. On accept,
-  `shape_package` is non-null and complete.
+  `shape_package` is non-null and complete. External families require exact-set
+  reconciliation and eversor refutations of two distinct faction/ability pairs.
+  Internal families may use one seed ability, but refutations must bind two distinct
+  homogeneous internal child ids from the closed parent. Never fabricate a second ability.
 - Finalization is a tool contract, not prose: your final action MUST be the harness
   `yield` tool with exactly one JSON object matching the frontmatter `output` schema.
   Do not end the turn with markdown, a code block, or plain JSON text; call `yield`.
 - `shape_package` (on accept) — the warpsmith-ready deliverable:
+  Its `faithful_family` is restricted to qualifying entries already in the supplied
+  frozen campaign manifest and explicitly includes the seed faction/ability. Keep
+  out-of-manifest discoveries in review evidence for the next campaign; never put them
+  in the package or request tracked edits/renders for them.
 ```json
 {
   "name": "reserve-denial-zone", "kind": "effect-leaf",
-  "schema_branch": { }, "parameters": [ ],
+  "schema_branch": { }, "parameters": [ ], "seed_encoding": { },
   "describer": { "render_rules": [ ], "port_notes": [ ], "conformance_cases": [ ] },
   "faithful_family": [ { "ability_id": "", "faction": "", "fit": "faithful|needs-param" } ],
-  "cost": { "spec_bump": true, "schema_change": true, "files": [ ], "conformance_cases": 0 },
+  "implementation_matrix": {
+    "canonical_schema": {"required":true,"files":[]},
+    "typescript_describer": {"required":true,"files":[]},
+    "rust_describer": {"required":true,"files":[]},
+    "python_describer": {"required":true,"files":[]},
+    "go_describer": {"required":true,"files":[]},
+    "typescript_cruncher": {"required":true,"files":[]},
+    "rust_cruncher": {"required":true,"files":[]},
+    "python_cruncher": {"required":true,"files":[]},
+    "go_cruncher": {"required":true,"files":[]},
+    "conformance": {"required":true,"files":[]},
+    "spec_version": {"required":true,"files":["conformance/SPEC_VERSION","python/src/wh40kdc/_spec.py","go/spec.go"]},
+    "generated_types": {"required":true,"files":[]},
+    "embedded_schemas": {"required":true,"files":[]},
+    "rust_bundle": {"required":true,"files":["crates/wh40kdc/src/data/bundle.generated.json"]},
+    "python_bundle": {"required":true,"files":["python/src/wh40kdc/_bundle.json"]},
+    "go_bundle": {"required":true,"files":["go/bundle.json"]},
+    "version_lockstep": {"required":true,"files":["tools/package.json","crates/wh40kdc/Cargo.toml","python/src/wh40kdc/_version.py","go/version.go","Cargo.lock"]},
+    "data": {"required":true,"files":[]}
+  },
+  "parameter_deltas": [],
   "seed_ability_id": ""
 }
 ```
@@ -112,7 +195,8 @@ You SPAWN two adversaries as your direct children:
   inputs to attack, not conclusions to ratify.
 - **The package is contractual.** An `accept` with an incomplete `shape_package`
   is a false pass — warpsmith needs the schema branch, every render form, the
-  faithful family, and the full four-port cost.
+  faithful family, and the full four-port implementation matrix. Rust is explicit;
+  it may never be inferred from a generic “all ports” note.
 - **IP boundary:** own-words findings; never paste GW prose.
 
 ## Failure modes

--- a/.omp/agents/psyker.md
+++ b/.omp/agents/psyker.md
@@ -1,7 +1,7 @@
 ---
 name: psyker
-description: Sonnet describer-output judge. Reads the plain-English renders of authored DSL cold and asks "could a person who understands Warhammer figure out what this does?" — flags phrasing problems for warpsmith and fidelity signals for inquisitor. Use for "review the describer output for <faction>", "is this ability's English intelligible?". Prompt must include a faction_id or an explicit ability_id list. Returns a single JSON object as final message.
-model: anthropic/claude-sonnet-5
+description: Describer-output judge. Reads the plain-English renders of authored DSL cold and asks "could a person who understands Warhammer figure out what this does?" — flags phrasing problems for warpsmith and fidelity signals for inquisitor. Use for "review the describer output for <faction>", "is this ability's English intelligible?". Prompt must include a faction_id or an explicit ability_id list. Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
 tools: Read, Grep, Glob, Bash
 output:
   type: object

--- a/.omp/agents/skitarius.md
+++ b/.omp/agents/skitarius.md
@@ -1,7 +1,7 @@
 ---
 name: skitarius
-description: Haiku mechanical gatekeeper. Runs the repo's actual validation gates (schema+integrity validate, targeted tests, regen-drift spot checks) after DSL data changes are applied, and parses failures into structured findings. No judgment — just gates. Use for "gate this change", "run the validators and report". Prompt lists which gates to run and the touched factions/files. Returns a single JSON object as final message.
-model: anthropic/claude-haiku-4-5
+description: Mechanical gatekeeper. Runs the repo's actual validation gates (schema+integrity validate, targeted tests, regen-drift spot checks) after DSL data changes are applied, and parses failures into structured findings. No judgment — just gates. Use for "gate this change", "run the validators and report". Prompt lists which gates to run and the touched factions/files. Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
 tools: Read, Grep, Glob, Bash
 ---
 
@@ -14,7 +14,7 @@ value is that a loop iteration cannot end "green" without you actually having
 run the commands.
 
 ## Inputs (prompt contract)
-`{gates: ["validate" | "test" | "translate-smoke" | "drift"], touched: {factions: [], files: []}, notes?}`
+`{gates: ["validate" | "test" | "translate-smoke" | "drift" | "format-lint" | "parity"], touched: {factions: [], files: []}, notes?}`
 — the orchestrator says which gates; you run exactly those.
 
 ## Output (JSON contract)
@@ -47,6 +47,13 @@ a gate you didn't run as passed.
   `cd tools && npm run codegen:data` then `jj st` (this repo is jj-managed;
   in a non-colocated workspace `git diff` may not work — use `jj st`/`jj diff`).
   Report any modified generated file as a drift failure.
+- **format-lint**: `cargo fmt --all -- --check`, `test -z "$(gofmt -l go/)"`,
+  and `cd python && ruff check .`. This gate exists because pytest alone does not
+  reproduce the Python CI job.
+- **parity**: rebuild TS side-effect-free with `cd tools && npm run codegen:data && npx tsc`,
+  then Rust/Go runners, run all six pairs broadly, and for every pair run
+  `differ.py --area effect-translation --json`; require `ok:true`, `cases_run>0`, and
+  that `skipped` omits the area. `scoring-describer` also proves `scoring-translation`.
 - Bash is read-only in intent: run gates and regen commands; never edit data,
   never `--write` an audit unless the prompt explicitly asks.
 
@@ -71,7 +78,7 @@ a gate you didn't run as passed.
 Mined from 30 ability-coverage session transcripts (2026-07-12). Own-words rules; corrections weighted highest.
 
 - Regenerate all four language artifacts after any data/schema edit before commit — only the TS bundle is gitignored; the Rust/Python/Go data bundles are git-tracked, so stale bundles ship an internally-inconsistent PR. Run `npm run bundle:schemas`, `cargo run -p xtask -- codegen` and `bundle-data`, `python/.venv/bin/python codegen/sync_bundle.py`, `bash go/codegen/sync.sh` — SPEC_VERSION first so it propagates into go/spec.go and _spec.py.
-- Rebuild all prebuilt runner binaries before trusting the cross-impl differ — it prefers tools/dist/runner.js, target/release/wh40kdc-runner, and go/wh40kdc-runner, all of which go stale immediately after any source edit and report phantom divergences or spec_version mismatches; rebuild via `npm run build`, `cargo build --release --bin wh40kdc-runner`, `go build`.
+- Rebuild all prebuilt runner binaries before trusting the cross-impl differ — it prefers tools/dist/runner.js, target/release/wh40kdc-runner, and go/wh40kdc-runner, all of which go stale immediately after any source edit and report phantom divergences or spec_version mismatches; rebuild via `cd tools && npm run codegen:data && npx tsc`, `cargo build --release --bin wh40kdc-runner`, and `go build`. Never run audit-writing postbuild coverage in a campaign.
 - Regenerate the effect-translation corpus (gen-conformance.ts / npm run gen:conformance) the same cycle as any DSL data edit or new construct — the corpus is generated from the embedded dataset, capped at 5 samples per node type, so a new variant of an already-covered type isn't auto-pinned; add explicit FORCED_*_CASES for every distinct branch/kind, and grep the regenerated corpus for the expected new phrase.
 - Write an explicit positive/negative probe after adding any new schema constraint (bad slug must FAIL with the exact AJV message, valid slug must PASS) — a passing full-suite run alone does not prove a new closed-enum or integrity check actually bites; scope a new integrity-loop counter to items carrying the checked field, not the whole population.
 - Run the cross-impl differ (tooling/parity/differ.py, the full 6-pair matrix) as the authoritative parity gate — each port's own cargo/pytest/go test passing tells you nothing about whether its describer output matches the others on this corpus; the Rust build is the canary for a generated-type rename because its strict types fail to compile against the old shape.

--- a/.omp/agents/swarmlord.md
+++ b/.omp/agents/swarmlord.md
@@ -1,7 +1,7 @@
 ---
 name: swarmlord
-description: Sonnet cross-faction expansion scout. Given a rule shape that works (an effect type, condition, or encoding pattern), finds abilities in OTHER factions coverable by the same shape — via embeddings clustering/candidates plus keyword sweeps over the prose store — to widen coverage per work cycle. Use for "where else does <shape> apply?", "find the family for this mechanic". Prompt must include the shape and an example ability_id. Returns a single JSON object as final message.
-model: anthropic/claude-sonnet-5
+description: Cross-faction expansion scout. Given a rule shape that works (an effect type, condition, or encoding pattern), finds abilities in OTHER factions coverable by the same shape — via embeddings clustering/candidates plus keyword sweeps over the prose store — to widen coverage per work cycle. Use for "where else does <shape> apply?", "find the family for this mechanic". Prompt must include the shape and an example ability_id. Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
 tools: Read, Grep, Glob, Bash
 output:
   type: object

--- a/.omp/agents/target-dummy.md
+++ b/.omp/agents/target-dummy.md
@@ -1,21 +1,30 @@
 ---
 name: target-dummy
-description: Haiku decomposer for WHO/WHAT an ability targets. Given raw ability prose, hypothesizes the DSL targeting layer — applies_to keyword filters, scope range/target, effect target params, exclusions. Use for "who does <ability> apply to?", "decompose targeting for this prose". Prompt must include ability_id, raw_text, ability_type, faction_id. Returns a single JSON object as final message.
-model: anthropic/claude-haiku-4-5
+description: Targeting decomposer for WHO/WHAT an ability targets. Given raw ability prose, hypothesizes the DSL targeting layer — applies_to keyword filters, scope range/target, effect target params, exclusions. Use for "who does <ability> apply to?", "decompose targeting for this prose". Prompt must include ability_id, raw_text, ability_type, faction_id. Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
 tools: Read, Grep, Glob
 output:
   type: object
-  required: [ability_id, bearer, beneficiary, scope_target, confidence]
+  required: [status, ability_id, bearer, beneficiary, scope_target, unresolved_clauses, confidence]
   properties:
+    status: { enum: [resolved, ambiguous, needs-schema, source-missing, error] }
     ability_id: { type: string }
-    bearer: { type: string }
-    beneficiary: { type: string }
+    bearer: { type: [string, "null"] }
+    beneficiary: { type: [string, "null"] }
     applies_to: { type: [object, "null"], additionalProperties: true }
-    scope_target: { type: string }
+    scope_target: { type: [string, "null"] }
     effect_target_params: { type: [object, "null"], additionalProperties: true }
     keyword_gates: { type: array, items: { type: string } }
     excludes: { type: array, items: { type: string } }
-    lookups_needed: { type: array, items: { type: object, additionalProperties: true } }
+    lookups_needed:
+      type: array
+      items:
+        type: object
+        required: [lookup_id, question]
+        properties:
+          lookup_id: { type: string }
+          question: { type: string }
+    unresolved_clauses: { type: array, items: { type: string } }
     confidence: { type: number }
 ---
 
@@ -30,11 +39,13 @@ schema-shaped hypothesis for the assembler (arch-magos); you never write DSL fil
 `{ability_id, name, raw_text, ability_type, faction_id, detachment_id?}` — the
 prose comes in the prompt. If you need a cross-reference (another ability, a
 keyword's meaning), you do NOT fetch it yourself: list it in `lookups_needed`
+with a unique stable `lookup_id` and one precise `question`
 for the orchestrator to route to data-enginseer.
 
 ## Output (JSON contract)
 ```json
 {
+  "status": "resolved|ambiguous|needs-schema|source-missing|error",
   "ability_id": "…",
   "bearer": "who carries the ability (own words)",
   "beneficiary": "who receives the benefit — same as bearer unless aura/leader/grant",
@@ -44,11 +55,15 @@ for the orchestrator to route to data-enginseer.
   "keyword_gates": ["JAKHALS"],
   "excludes": ["EPIC HERO"],
   "lookups_needed": [],
+  "unresolved_clauses": [],
   "confidence": 0.9
 }
 ```
 `applies_to` is the roster-highlighting filter — set it to null when the rule is
 army-wide (army-wide rules are pinned as no-highlight).
+Use a non-resolved status and null hypothesis fields when the source is absent,
+ambiguous, or cannot fit the current target vocabulary. Never fabricate a normal result
+merely to satisfy the output schema.
 
 ## Tool inventory
 - `schemas/enrichment/ability-dsl/ability.schema.json` (`applies_to` shape) and

--- a/.omp/agents/vox-hound.md
+++ b/.omp/agents/vox-hound.md
@@ -1,20 +1,29 @@
 ---
 name: vox-hound
-description: Haiku decomposer for WHAT an ability does. Given raw ability prose, hypothesizes the DSL effect layer — effect tree, leaf types, composition kind, dice mechanics, buffs/debuffs. Use for "what does <ability> do mechanically?", "decompose the effect for this prose". Prompt must include ability_id, raw_text, ability_type, faction_id. Returns a single JSON object as final message.
-model: anthropic/claude-haiku-4-5
+description: Effect decomposer for WHAT an ability does. Given raw ability prose, hypothesizes the DSL effect layer — effect tree, leaf types, composition kind, dice mechanics, buffs/debuffs. Use for "what does <ability> do mechanically?", "decompose the effect for this prose". Prompt must include ability_id, raw_text, ability_type, faction_id. Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
 tools: Read, Grep, Glob
 output:
   type: object
-  required: [ability_id, leaf_types_used, composition, buff_or_debuff, confidence]
+  required: [status, ability_id, leaf_types_used, composition, buff_or_debuff, unresolved_clauses, confidence]
   properties:
+    status: { enum: [resolved, ambiguous, needs-schema, source-missing, error] }
     ability_id: { type: string }
     effect_tree: { type: [object, "null"], additionalProperties: true }
     leaf_types_used: { type: array, items: { type: string } }
-    composition: { enum: [choice, sequence, conditional, dice-gated, aura, none] }
+    composition: { enum: [choice, sequence, conditional, dice-gated, aura, none, null] }
     dice_mechanics: { type: array, items: { type: object, additionalProperties: true } }
-    buff_or_debuff: { enum: [buff, debuff, both, neutral] }
+    buff_or_debuff: { enum: [buff, debuff, both, neutral, null] }
     unmodelable_clauses: { type: array, items: { type: string } }
-    lookups_needed: { type: array, items: { type: object, additionalProperties: true } }
+    lookups_needed:
+      type: array
+      items:
+        type: object
+        required: [lookup_id, question]
+        properties:
+          lookup_id: { type: string }
+          question: { type: string }
+    unresolved_clauses: { type: array, items: { type: string } }
     confidence: { type: number }
 ---
 
@@ -27,11 +36,13 @@ the assembler (arch-magos); you never write DSL files.
 
 ## Inputs (prompt contract)
 `{ability_id, name, raw_text, ability_type, faction_id, detachment_id?}` — prose in
-the prompt. Cross-references go in `lookups_needed`, not fetched yourself.
+the prompt. Cross-references go in `lookups_needed` with a unique stable
+`lookup_id` and precise `question`, not fetched yourself.
 
 ## Output (JSON contract)
 ```json
 {
+  "status": "resolved|ambiguous|needs-schema|source-missing|error",
   "ability_id": "…",
   "effect_tree": { "…effect.schema.json-shaped hypothesis…": null },
   "leaf_types_used": ["feel-no-pain", "re-roll"],
@@ -40,9 +51,13 @@ the prompt. Cross-references go in `lookups_needed`, not fetched yourself.
   "buff_or_debuff": "buff|debuff|both|neutral",
   "unmodelable_clauses": ["own-words description of any clause no leaf covers"],
   "lookups_needed": [],
+  "unresolved_clauses": [],
   "confidence": 0.9
 }
 ```
+Use a non-resolved status and null hypothesis fields when the effect is ambiguous or
+not expressible. `unmodelable_clauses`/`needs-schema` is a successful diagnosis, not a
+reason to force a plausible neighboring leaf.
 
 ## Tool inventory
 - `schemas/enrichment/ability-dsl/effect.schema.json` — the authority. Composition

--- a/.omp/agents/warpsmith.md
+++ b/.omp/agents/warpsmith.md
@@ -1,8 +1,28 @@
 ---
 name: warpsmith
-description: Sonnet describer engineer. Takes psyker findings (and arch-magos resisted_schema inbox blocks) and decides per item - reword the describer, craft a new describer/DSL shape, reauthor the data, or wont-fix - fully costed against the four-port byte-parity ledger. The only agent with repo write access; edits only on explicit orchestrator instruction. Use for "triage these describer findings", "does this mechanic need a new shape?". Prompt must include the findings/inbox blocks. Returns a single JSON object as final message.
-model: anthropic/claude-sonnet-5
+description: Describer engineer. Takes psyker findings (and arch-magos resisted_schema inbox blocks) and decides per item - reword the describer, craft a new describer/DSL shape, reauthor the data, or wont-fix - fully costed against the four-port byte-parity ledger. The only agent with repo write access; edits only on explicit orchestrator instruction. Use for "triage these describer findings", "does this mechanic need a new shape?". Prompt must include the findings/inbox blocks. Returns a single JSON object as final message.
+model: openai-codex/gpt-5.6-luna
 tools: Read, Grep, Glob, Bash, Edit, Write
+output:
+  type: object
+  required: [decisions, implemented]
+  properties:
+    decisions:
+      type: array
+      items:
+        type: object
+        required: [ref, verdict, cost, allowed_files, implementation_matrix, proposal, inbox_entry]
+        properties:
+          ref: { type: string }
+          verdict: { enum: [reword-describer, new-shape, reauthor-dsl, wont-fix] }
+          cost: { type: object, additionalProperties: true }
+          allowed_files: { type: array, items: { type: string } }
+          implementation_matrix: { type: object, additionalProperties: true }
+          proposal: { type: string }
+          inbox_entry: { type: [object, "null"], additionalProperties: true }
+    implemented:
+      type: [object, "null"]
+      additionalProperties: true
 ---
 
 # Warpsmith — describer engineer
@@ -13,6 +33,8 @@ resisted-schema inbox block you decide the cheapest honest fix and cost it.
 You are the only agent permitted to edit the repo, and you do so ONLY when the
 orchestrator explicitly asks you to implement a specific verdict — a triage call
 never edits.
+Every spawn must request strict schema handling; permissively repaired output is not an
+implementation artifact.
 
 ## Inputs (prompt contract)
 `{findings: [psyker finding objects], inbox: [resisted_schema blocks], context?, implement?: {verdict_ref}}`
@@ -30,6 +52,27 @@ never edits.
         "spec_bump": true,
         "conformance_cases": 3,
         "schema_change": false
+      },
+      "allowed_files": ["normalized exact repo-relative paths only"],
+      "implementation_matrix": {
+        "canonical_schema": {"required":false,"files":[]},
+        "typescript_describer": {"required":true,"files":[]},
+        "rust_describer": {"required":true,"files":[]},
+        "python_describer": {"required":true,"files":[]},
+        "go_describer": {"required":true,"files":[]},
+        "typescript_cruncher": {"required":false,"files":[]},
+        "rust_cruncher": {"required":false,"files":[]},
+        "python_cruncher": {"required":false,"files":[]},
+        "go_cruncher": {"required":false,"files":[]},
+        "conformance": {"required":true,"files":[]},
+        "spec_version": {"required":true,"files":[]},
+        "generated_types": {"required":false,"files":[]},
+        "embedded_schemas": {"required":false,"files":[]},
+        "rust_bundle": {"required":false,"files":[]},
+        "python_bundle": {"required":false,"files":[]},
+        "go_bundle": {"required":false,"files":[]},
+        "version_lockstep": {"required":false,"files":[]},
+        "data": {"required":false,"files":[]}
       },
       "proposal": "own-words description of the change",
       "inbox_entry": null
@@ -60,10 +103,14 @@ never edits.
 - **reword-describer**: 4 describer ports (byte-identical) + regenerated
   conformance goldens + SPEC_VERSION bump. Cheap-ish, no schema.
 - **new-shape**: all of the above PLUS schema change + new conformance cases +
-  data re-author of the motivating abilities + 4-file version lockstep. The
+  data re-author of the motivating abilities + version lockstep across the four
+  version declarations and `Cargo.lock`. The
   expensive one — demands the tortured-fit + family bar.
 - **reauthor-dsl**: data-only; no port work, no SPEC bump. Cheapest when the
   describer was fine and the encoding was wrong.
+- **data-conformance**: when data regeneration changes conformance, declare data,
+  Rust/Python/Go bundles, conformance outputs, and all three exact SPEC files
+  (`conformance/SPEC_VERSION`, `python/src/wh40kdc/_spec.py`, `go/spec.go`).
 - **wont-fix**: legitimate for declared [APPROX] simplifications, style
   preferences, and singleton oddities not worth a shape.
 
@@ -76,6 +123,10 @@ never edits.
   `reword-describer`.
 - Implementation is all-four-ports-plus-goldens in one change; a TS-only edit is
   a parity break, never ship it.
+- Before implementation, enumerate normalized exact repo-relative paths (never directory
+  prefixes) in the allowlist and complete the decision-kind matrix.
+  After implementation, return the actual changed paths and commands run. A path
+  outside the allowlist is a failed implementation, not cleanup for the driver.
 - Check the RESOLVED history: shapes like `fight-eligibility-extension`,
   pool-add-die `value:"rolled"`, and FNP psychic scopes already shipped — a
   correct warpsmith greps before proposing, and answers "already covered" when

--- a/.omp/config.yml
+++ b/.omp/config.yml
@@ -5,3 +5,7 @@
 # need the recursion gate to allow depth-1 agents to spawn depth-2 helpers.
 task:
   maxRecursionDepth: 3
+  # Direct task-tool agents must never remain opaque for hours. Workflow `agent()`
+  # calls currently ignore this OMP setting, so the dsl-campaign driver also applies
+  # the external-cancellation policy documented in SKILL.md.
+  maxRuntimeMs: 1800000

--- a/.omp/skills/dsl-campaign/SKILL.md
+++ b/.omp/skills/dsl-campaign/SKILL.md
@@ -12,12 +12,12 @@ the second checkpoint. This file is the driver contract — a fresh session must
 run a campaign from it alone.
 
 Companion files: `workflows/wf-prioritize.js`, `workflows/wf-author-batch.js`,
-`workflows/wf-verify-batch.js`, and `workflows/wf-shape-scout.js` (invoke via
-`Workflow({scriptPath, args})`; each embeds the frozen agent Output contracts as JSON
-Schemas — never redesign those). Always pass
+`workflows/wf-verify-batch.js`, `workflows/wf-review-batch.js`, `workflows/wf-shape-scout.js`, and
+`workflows/wf-close-campaign.js` (invoke via `Workflow({scriptPath, args})`; each embeds
+the agent Output contracts as JSON Schemas). Always pass
 `repo_root: "/Users/will.mitchell/40kdc-dsl"` in every workflow's args — subagents inherit
-the driver session's cwd, and the preamble it generates pins them to the workspace even
-when the driver was launched from another checkout. The worked example
+the driver session's cwd, and every workflow hard-fails unless cwd and `jj root` both
+resolve to that exact path. Prompt-only workspace pinning is not a safeguard. The worked example
 of one converged campaign is `_private/loop-state/{roundtrip,inbox}-world-eaters.md`.
 
 ## Preconditions (fail loudly if unmet)
@@ -33,8 +33,16 @@ of one converged campaign is `_private/loop-state/{roundtrip,inbox}-world-eaters
 - Toolchain in THIS workspace: `tools/node_modules` + `tools/dist`, `python/.venv`,
   `target/release/wh40kdc-runner`, `go/wh40kdc-runner`. Rebuild all three runners after
   ANY source edit before parity checks — stale runners give phantom verdicts.
-- `jj st` clean apart from `_private/` (reconcile, never clobber, if not); `jj new` before
-  any work; never touch other workspaces' commits (`<name>@`); never move `main`.
+- `jj st` clean apart from `_private/` (reconcile, never clobber, if not); run `jj new` before
+  any work, then capture the full **`@-`** commit id as `campaign_base_commit_id` (never `@`);
+  never touch other
+  workspaces' commits (`<name>@`); never move `main`.
+- Before invoking a workflow, build one allowed-role manifest from the 16 discovered
+  definitions and verify every role resolves to exactly `openai-codex/gpt-5.6-luna`.
+  Every workflow repeats this hard check before spawning. Invoke no generic or
+  unlisted reviewer. Directly spawning campaign roles to imitate a failed workflow is
+  forbidden: it bypasses fixed workflow routing and is a blocking escalation. Treat
+  OMP's invocation log—not a model-returned role name—as the runtime provenance record.
 
 ## Non-negotiables (pinned decisions)
 
@@ -49,6 +57,12 @@ of one converged campaign is `_private/loop-state/{roundtrip,inbox}-world-eaters
 - **Cosine selects and measures; it never gates.** The embeddings harness is advisory.
 - **warpsmith is the only agent that writes repo files.** The driver writes loop-state,
   runs jj/gh. Workflow agents are read-only.
+- **Evidence is immutable.** data-enginseer emits a SHA-256-bound source packet with a
+  stable id for every independently testable clause. Every later role consumes that
+  packet; the driver never re-summarizes the source between roles.
+- **Architecture precedes decomposition.** Inquisitor classifies the global control
+  structure and can route a mechanic to shape-scout before leaf assembly. Every
+  mechanical clause must map exactly to DSL; note-only coverage is needs-schema.
 - **IP boundary:** GW prose may transit agent JSON, harness reports, and the session
   scratchpad; it must NEVER be written into any file inside this repo — including
   community_notes, [APPROX] notes, inbox entries, PR bodies, and commit messages
@@ -62,13 +76,14 @@ of one converged campaign is `_private/loop-state/{roundtrip,inbox}-world-eaters
 - **Campaign done (draft PR opens)** = every worklist entry has a terminal status —
   `converged` / `improved` (skeptic PASS) / `needs-schema` (inbox block filed) /
   `abandoned` (reason recorded) — ∧ full gates green at head ∧ whole-dataset prose diff
-  touches only worklist ids ∧ faction mean not regressed ∧ draft PR opened.
+  touches only worklist ids ∧ every target faction's independently computed mean has
+  not regressed (no justification bypass) ∧ draft PR opened.
 
 ## Does NOT count as done (ten hard rejects — inquisitor enforces per batch AND at close)
 
 1. **Placeholder lies** — valid DSL encoding a different mechanic.
 2. **Cosine-chasing lever drops** — e.g. `charged-this-turn` → `timing-is charge-move`.
-3. **APPROX-stuffing** — clauses evacuated into `[APPROX]` notes to dodge refutation.
+3. **APPROX-stuffing** — any mechanical clause evacuated into `[APPROX]` notes.
 4. **needs-schema as escape hatch** when an honest existing-shape fit exists.
 5. **Weakened verification** — panel <2 voters, goldens loosened/deleted, unrun gates
    reported passed, "pending" counted as PASS.
@@ -89,9 +104,17 @@ confidence < 0.7, or prior reject). ≤ 2 full gate re-runs per batch. Batch gra
 clean stop, never dressed as convergence): IP breach, gate failure surviving 2 re-runs,
 blocking escalation.
 
+OMP gives direct task-tool agents the configured 30-minute `task.maxRuntimeMs`, but
+workflow `agent()` calls currently ignore that setting. Until the runtime exposes
+per-call cancellation, the driver MUST externally cancel and inspect any workflow role
+with no terminal output by 20 minutes, and abort/restart the phase at 30 minutes.
+Repeating blind waits is forbidden. Log the current phase, role label, and last artifact
+before each wait so “running” is distinguishable from progress.
+
 Shape-scout (`wf-shape-scout.js`): ≤ 3 cyclical review rounds per shape, then forced
-terminal; the family bar is lone-spear `faithful_family_size` ≥ 4 (exact+near,
-flatten-excluded); kroot leads spawn leaf helpers only (spawn tree depth ≤ 2).
+terminal; the family bar is either lone-spear external `faithful_family_size` ≥ 4 or at
+least four homogeneous internal children in one closed composite mechanic. Kroot leads
+spawn leaf helpers only (spawn tree depth ≤ 2).
 
 ## Procedure
 
@@ -101,6 +124,7 @@ flatten-excluded); kroot leads spawn leaf helpers only (spawn tree depth ≤ 2).
 cd /Users/will.mitchell/40kdc-dsl
 jj workspace update-stale 2>/dev/null; jj st   # reconcile surprises; never clobber
 jj new -m "wip: dsl-campaign cNNN"             # NNN = next id from registry.json
+campaign_base_commit_id=$(jj log -r @- --no-graph -T 'commit_id')
 ```
 
 Refresh the full-corpus scores (fast when embedding cache is warm):
@@ -115,6 +139,8 @@ Snapshot `_reports/roundtrip-all.json` to the session scratchpad as
 7): at close, a fresh `--faction all` run's describer outputs are diffed against it and
 any changed non-worklist id fails the campaign. (Coverage is store-paired abilities; the
 `drift`/conformance gates cover the goldens beyond it.)
+Record the snapshot's SHA-256. `wf-prioritize.js` reads the file and refuses a hash
+mismatch, preventing a stale or replaced baseline from entering curation.
 
 ### 1 — Prioritize
 
@@ -123,8 +149,12 @@ ids+scores). Then:
 
 ```
 Workflow({ scriptPath: ".omp/skills/dsl-campaign/workflows/wf-prioritize.js", args: {
+  repo_root: "/Users/will.mitchell/40kdc-dsl",
+  campaign_id: "cNNN",
+  campaign_base_commit_id,
   scout_shapes: [ …recently shipped shapes + any user bias… ],
-  artifacts: { roundtrip_report_path, sub080_summary, loop_state_paths, registry_excerpt },
+  artifacts: { roundtrip_report_path, roundtrip_report_sha256, sub080_summary,
+               loop_state_paths, registry_excerpt },
   worklist_cap: 30 } })
 ```
 
@@ -134,42 +164,74 @@ priority. Then: append the campaign entry to `_private/loop-state/registry.json`
 (`status:"open"`, `mean_before` from the report), create `roundtrip-<target>.md` in the
 world-eaters table format, and file any `escalate_to_user` items into
 `registry.escalations`. If an escalation **blocks** target choice, stop and ask the user.
+Persist the workflow-returned `campaign_manifest_json` byte-for-byte in the session
+scratchpad and record its returned SHA-256; closure requires that frozen manifest.
+It freezes `campaign_base_commit_id`; prioritization verifies that id resolves and is
+an ancestor of the current campaign commit.
 
 ### 2 — Author (per batch of 5–6)
 
 ```
 Workflow({ scriptPath: ".omp/skills/dsl-campaign/workflows/wf-author-batch.js",
-  args: { batch_id: "cNNN-bK", new_shapes: […], abilities: […5–6 worklist entries…] } })
+  args: { repo_root: "/Users/will.mitchell/40kdc-dsl", campaign_id: "cNNN", batch_id: "cNNN-bK",
+          campaign_manifest_sha256, candidate_commit_id, // current pre-application @ commit
+          new_shapes: […], abilities: […5–6 worklist entries…] } })
 ```
 
+The workflow retrieves one immutable evidence packet, invokes inquisitor in
+`architect` mode, and checks that the architecture accounts for every clause before
+WHO/WHEN/WHAT decomposition. Unsupported menus, resource systems, state machines, or
+actor/event bindings return `needs-schema` immediately. Arch-magos output is accepted
+only when its clause-coverage matrix maps every mechanical clause exactly with
+source-explicit or schema-derived evidence; dropped, inferred, unresolved, or note-only
+mechanics route to shape-scout.
+
 Statuses back: `accepted` → apply (step 3). `needs-schema` → **step 2a** (family check,
-then shape-scout or inbox). `rejected` → adjudicate: spawn inquisitor (`mode:"review"`,
-the candidate + verdicts as `agent_outputs`); `accept` overrides a bad refutation (record
-why), otherwise terminal `abandoned` with reason — or `needs-schema` (→ step 2a) if the
-divergences show the schema can't express it. `no-prose` / `agent-error` → terminal
+then shape-scout or inbox). A `rejected` result at the four-attempt budget is terminal
+`abandoned`, with that author envelope as evidence. Before the budget is exhausted,
+adjudication feedback must re-enter `wf-author-batch` and produce a fresh `accepted` or
+`needs-schema` author status; adjudication can never relabel a rejected author artifact.
+`no-prose` / `agent-error` → terminal
 `abandoned` (reason recorded). Each result's `thread` is the FULL per-round revision
 history (every attempt's divergences, not just the last) — record it in the
 ledger/roundtrip notes so cyclical revisions stay auditable.
 
+For terminal workflow evidence, the driver constructs inbox envelopes, never loose
+one-key snippets. Each is `{binding,payload}` with
+`kind,campaign_id,batch_id,campaign_manifest_sha256,ability_keys,candidate_commit_id,payload_sha256`;
+`ability_keys` is the full referenced batch key set and `payload_sha256` hashes the exact
+payload JSON. Inbox payload is `{entries:[{faction_id,ability_id,resisted_schema}]}`. Different
+batches may legitimately bind different applied candidate commits; author artifacts bind
+their earlier `author_candidate_commit_id`. Closure validates the full batch envelope and
+then requires the terminal key's inclusion rather than pretending the envelope covered
+only `[key]`.
+
 ### 2a — Shape-scout on a needs-schema result
 
-A `needs-schema` is not automatically terminal. Spawn inquisitor to judge whether the
-resisted mechanic is a FAMILY (≥ ~4 abilities, exact+near) or a singleton:
+A `needs-schema` is not automatically terminal. Use the architect output and inquisitor
+to judge whether the resisted mechanic has either an external family (≥4 abilities,
+exact+near) or an internal family (≥4 homogeneous children in one closed composite):
 - **Singleton** → append the `resisted_schema` block to `inbox-<faction>.md` (own words),
   ledger `needs-schema`; committed entry untouched (never a placeholder). Terminal.
 - **Family** → fork to the shape-scout, seeding the resisted_schema block:
   ```
   Workflow({ scriptPath: ".omp/skills/dsl-campaign/workflows/wf-shape-scout.js", args: {
     repo_root: "/Users/will.mitchell/40kdc-dsl",
-    seed: { ability_id, faction_id, raw_text, resisted_schema }, family_threshold: 4 } })
+    campaign_id: "cNNN", campaign_manifest_sha256,
+    campaign_manifest_path,
+    seed: { ability_id, faction_id, raw_text, evidence_packet, architecture,
+            resisted_schema }, family_threshold: 4 } })
   ```
   The kroot suite (flesh-shaper → lone-spear → trail-shaper → war-shaper, each spawning
   its OWN helpers) returns `status`:
-  - `shipped-ready` (war-shaper `accept` ∧ `faithful_family_size ≥ threshold`) →
-    **auto-apply**: hand `shape_package` to warpsmith (`implement`) to land the schema
+  - `shipped-ready` (war-shaper `accept` ∧ external or internal family threshold) →
+    **auto-apply only its `faithful_family` entries already present in the frozen manifest**:
+    hand `shape_package` to warpsmith (`implement`) to land the schema
     oneOf branch + all four describer ports + conformance cases + SPEC bump + version
     lockstep, then re-author the seed AND every `faithful_family` member onto the new
-    shape as accepted candidates (step 3). The campaign is now shape-led — expect a
+    shape as accepted candidates (step 3). Any family member discovered outside the
+    manifest is recorded in loop-state for the next campaign and receives no tracked
+    edit or render in this campaign; the frozen manifest is never amended. The campaign is now shape-led — expect a
     heavier PR, and the full close gate (step 4) must cover the port/SPEC work.
   - `existing-fits` → the scout proved an existing shape fits after all; re-enter step 2
     authoring with that shape named (the resist was a false alarm).
@@ -181,46 +243,113 @@ resisted mechanic is a FAMILY (≥ ~4 abilities, exact+near) or a singleton:
 
 ### 3 — Apply + verify (per batch)
 
-1. **warpsmith applies** the accepted candidates (Agent tool, sole writer):
+1. **warpsmith applies** the accepted candidates (Agent tool, sole writer), then performs
+   **all regeneration** required by those edits before any verification identity is captured:
    `implement` decisions referencing each candidate's dsl JSON; it edits
-   `data/enrichment/<faction>/abilities.json` only.
-2. Regenerate + rebuild what the edit touches (TS bundle at minimum:
-   `cd tools && npm run build`); rebuild runners if any source changed.
-3. ```
+   `data/enrichment/<faction>/abilities.json` only for data work. Before source work it
+   must return a complete implementation matrix and exact changed-path allowlist.
+2. Only after warpsmith edits and all regen are final, run
+   `jj describe -m "feat: dsl-campaign cNNN batch K — <target>"`, capture the final full
+   `@` commit id, and use that immutable candidate identity for verification, review,
+   and rescore. No writer may run between identity capture and verification.
+3. The side-effect-free TS build equivalent is
+   `cd tools && npm run codegen:data && npx tsc` (never use the package lifecycle build
+   script in a campaign; its postbuild writes audit coverage). Rebuild runners if any source changed. Audit docs
+   are forbidden campaign outputs.
+4. ```
    Workflow({ scriptPath: ".omp/skills/dsl-campaign/workflows/wf-verify-batch.js",
-     args: { batch_id, ability_ids, faction_ids, touched_files } })
+     args: { repo_root, campaign_id, batch_id, campaign_manifest_sha256,
+             candidate_commit_id, ability_ids, faction_ids, touched_files,
+             allowed_files, decision_kind, implementation_matrix,
+             expected_candidate_dsl_hashes,
+             baseline_commit_id, // explicit committed parent/current baseline
+             sealed_head: false, campaign_base_commit_id: null } })
    ```
+   The workflow inventories `jj diff --name-only -r @` itself and fails on any path
+   outside warpsmith's exact-path allowlist. `new-shape` changes require exact rows for
+   canonical schema, each port's actual describer source, each port's cruncher source,
+   conformance, SPEC, generated types/schemas, each tracked language bundle, exact faction
+   data, and version lockstep including `Cargo.lock` alongside the four declared version
+    files. Scoring-describer surfaces are exactly `tools/src/translate/scoring.ts`,
+    `python/src/wh40kdc/translate/scoring.py`, and `go/translate_scoring.go`; there is no
+    Rust scoring-describer mirror, so none is invented.
+   Ordinary `new-shape` and `describer-reword` neither require nor accept scoring files.
+   A distinct `scoring-describer` decision requires exactly the TS/Python/Go scoring
+   describers, scoring conformance, and SPEC mirrors (there is no Rust scoring mirror).
+   `describer-reword` requires the four ordinary describer ports plus conformance/SPEC; `data`
+   requires exact faction data and each tracked Rust/Python/Go bundle path. Verification
+   recognizes `data-conformance` when data-generated conformance also changes: require
+   data, all tracked bundles, conformance outputs, `conformance/SPEC_VERSION`,
+   `python/src/wh40kdc/_spec.py`, and `go/spec.go`. Diff-derived decision validation
+   distinguishes it from plain data.
+   also requires format/lint (including Ruff) and six-pair
+   parity; `not_run` is failure.
    Fail the batch on `!overall_pass` (≤2 re-runs after fixes), `verdict:"regressed"`
    (drop/fix the offending ability — levers outrank cosine), or any severity-3 psyker
    finding. Psyker `missing-clause-signal` routes to inquisitor as fidelity, not to
    warpsmith as wording.
-4. Re-score just the batch:
+5. Re-score just the batch:
    ```bash
    cd /Users/will.mitchell/40kdc-embeddings && .venv/bin/python -m wh40kdc_embeddings \
      roundtrip --faction <f> --ids <id,id,…> --scope batch-cNNN-bK \
      --enrichment-dir /Users/will.mitchell/40kdc-dsl/data/enrichment
    ```
+   Save the unmodified `{kind:"roundtrip",abilities:[...]}` report. Put campaign/batch/
+   manifest/key/commit binding in its artifact reference, never in embeddings JSON.
    Any ability below its `cos_start` needs a recorded correctness-first justification or
    another attempt (within its 4-attempt budget).
-5. Inquisitor batch review (`mode:"review"`, arch-magos outputs + verify results +
-   scores). `revise` re-enters step 2 for that ability; `reject` → terminal per step 2.
-6. On accept: `jj commit -m "feat: dsl-campaign cNNN batch K — <target>"`, update
-   `roundtrip-<target>.md` + `registry.json` (statuses, cos_best, attempts).
+6. Invoke `wf-review-batch.js` with `repo_root,campaign_id,batch_id,
+   campaign_manifest_sha256,candidate_commit_id,candidate_dsl_hashes,faction_ids,
+   ability_keys,author_artifact,verify_artifact,rescore_artifact,agent_outputs`. It invokes
+   inquisitor with Luna strict and emits a bound `{binding,payload}` with exactly one
+   terminal review per key. `revise` or `reject` requires rollback/revision and then a
+   fresh `wf-author-batch` result before any new apply; never directly relabel the
+   previously accepted artifact terminal.
+7. On accept: save artifact references for author workflow, verification workflow,
+   inquisitor review, and rescore in every ledger row; then seal with plain `jj new`
+   and update statuses/scores/attempts. Never use `jj commit -m` after verification.
+   Author/verify/review files use `{binding,payload}`; binding contains
+   `kind,campaign_id,batch_id,campaign_manifest_sha256,ability_keys,payload_sha256` plus
+   its phase commit and candidate hashes. Author uses `author_candidate_commit_id` and
+   per-key `candidate_dsl_hashes`; verify uses `candidate_commit_id` and independently
+   recomputed applied hashes. The read-only author artifact binds the pre-application commit it actually inspected;
+   verify/review bind the applied candidate commit. Never predict a future jj commit id.
+   Canonical hashing is UTF-8 SHA-256 of compact JSON with object keys recursively sorted
+   and array order preserved. The ledger stores `author_candidate_commit_id` and
+   `candidate_dsl_sha256`. References include file hash, payload hash, and exact keys. Review rows include
+   `faction_id`. A todo is complete only when its required artifact id/path or commit id exists.
 
 ### 4 — Close
 
-1. All worklist entries terminal (anti-condition 6) — else keep batching.
-2. Full gate: `PATH="$PWD/python/.venv/bin:$PATH" just regen fmt test-all
-   version-lockstep` in the workspace, plus parity differ with **freshly rebuilt**
-   runners. Drift-check by committing regen output and confirming `jj st` clean.
-3. Prose diff: fresh `--faction all` run vs `prose-baseline.json`; any non-worklist id
-   whose describer output changed ⇒ anti-condition 7, fix before closing.
-4. Inquisitor close-out (`mode:"review"` over the campaign summary): re-checks all ten
-   anti-conditions campaign-wide; faction mean ≥ `mean_before`.
-5. Ship: `jj bookmark create wnmitch/dsl-cNNN-<slug> -r @-` (the batch stack), `jj git
-   push --bookmark wnmitch/dsl-cNNN-<slug> --allow-new`, `gh pr create --draft` — PR body:
+1. All worklist entries terminal (anti-condition 6) — else keep batching. Each converged
+   or improved row has author/verify/review/rescore artifact references and scores.
+2. Fresh-run the whole-corpus roundtrip and normalize the comparison against the
+   baseline into a scratchpad JSON artifact:
+   `{baseline_sha256,current_sha256,changes:[{faction_id,ability_id}],
+   non_worklist_changes:[],generated_at}`.
+3. Seal the completed stack with plain `jj new`, capture `@-`'s commit id, and produce one
+   final `wf-verify-batch` envelope (`sealed_head:true`, `decision_kind:"sealed-campaign"`)
+   at that sealed head covering every converged/improved faction/ability pair. Pass every
+   required argument: `campaign_id`, manifest hash, sealed candidate ID, expected candidate
+   hashes, `decision_kind:"sealed-campaign"`, `sealed_head:true`,
+   `campaign_base_commit_id`, exact paths, factions/abilities, and implementation matrix. It declares
+   every changed path under its exact recognized matrix surface (intermediate verification
+   is not closure evidence). It inventories `jj diff --from
+   <campaign_base_commit_id> --to @-` and binds `sealed_head:true`, the frozen base, and
+   exact sealed head in its envelope. Then invoke
+   `wf-close-campaign.js` with the frozen campaign-manifest path/hash, hashed
+   author/verify/review/rescore artifact files, baseline/current report paths, ledger,
+   per-faction means, final verification, normalized prose diff, and expected head. It hard-runs jj-compatible `just preflight`, rebuilds all four runners, runs
+   all six parity pairs, validates score/terminal artifacts, and invokes inquisitor in
+   close mode over all ten anti-conditions.
+4. Ship ONLY when the workflow returns `ready_to_publish:true`: `jj bookmark create
+   wnmitch/dsl-cNNN-<slug> -r "commit_id(<publish_commit_id>)"` (never re-resolve
+   symbolic `@-` after the gate), then `jj git push --bookmark
+   wnmitch/dsl-cNNN-<slug> --allow-new`, `gh pr create --draft` — PR body:
    own-words summary, worklist table (ids, statuses, cos start→best), justifications for
    any cosine drops, inbox blocks filed, escalations. No GW prose, no personal info.
+5. Before calling the campaign converged, confirm the PR has no merge conflict and all
+   required CI checks pass. A red/conflicted draft remains `open`, never converged.
 6. Persist: registry entry → `converged` (+pr, mean_after, finished); `memory_store`
    (tags: `40kdc-data`, `dsl-loop`) one-paragraph campaign summary.
 7. Report to the user: PR link, mean before→after, statuses, escalations, and anything
@@ -235,12 +364,16 @@ status: open|converged|aborted, pr, worklist_size, mean_before, mean_after, star
 finished, notes} · `blocked_shapes[]` {proposal, why, reopen_when} — dedup source for
 swarmlord/warpsmith proposals (full seen-set; reopen only when `reopen_when` is met with
 cited new evidence) · `ability_ledger` {"faction/id": {status, campaign, cos_start,
-cos_best, attempts, justification}} · `escalations[]` {question, raised_by, campaign,
+cos_best, attempts, justification, artifacts:{author,verify,review,rescore}}} ·
+`escalations[]` {question, raised_by, campaign,
 resolved}.
 
 ## Field notes
 
 - Cull/stop driver-spawned agents as soon as their output is verified.
+- A workflow failure is not permission to hand-simulate its roles. Diagnose/restart
+  the workflow or abort with a blocking escalation; the fixed routing and OMP
+  invocation log are part of the evidence.
 - `execSync`-based repo tools resolve path args against the repo root, not shell cwd.
 - The dump/store/report debugging rule applies to prose lookups: before concluding an
   ability "has no prose", make data-enginseer show the failing grep, not the theory.

--- a/.omp/skills/dsl-campaign/workflows/wf-author-batch.js
+++ b/.omp/skills/dsl-campaign/workflows/wf-author-batch.js
@@ -10,7 +10,11 @@ export const meta = {
 }
 
 // args: {
+//   repo_root: string,              // required; must equal the workflow's actual cwd + jj root
+//   campaign_id: string,
 //   batch_id: string,
+//   campaign_manifest_sha256: string,
+//   candidate_commit_id: string,
 //   new_shapes: string[],          // recently shipped effect/condition types → 3-voter panel
 //   abilities: [{ ability_id, faction_id, name?, ability_type?, detachment_id?,
 //                 cos_start?, prior_reject?, previous_cosine? }]
@@ -25,19 +29,54 @@ export const meta = {
 // The runtime may deliver args as a JSON string — normalize before touching fields.
 if (typeof args === 'string') args = JSON.parse(args)
 if (!args || !Array.isArray(args.abilities)) throw new Error('args.abilities required')
+if (!args.campaign_id || !args.batch_id || !args.campaign_manifest_sha256 || !args.candidate_commit_id)
+  throw new Error('campaign_id, batch_id, campaign_manifest_sha256, and candidate_commit_id required')
+if (!args.repo_root) throw new Error('args.repo_root required (workspace identity is enforced, not advisory)')
 if (args.abilities.length > 8) throw new Error(`batch too large: ${args.abilities.length} > 8 (grain is 5–6)`)
 const NEW_SHAPES = args.new_shapes || []
-// Pin every agent to the loop workspace: subagents inherit the DRIVER session's cwd,
-// which may be a different checkout of this repo (a parallel session's working copy).
-const PRE = args.repo_root
-  ? `Repo root: ${args.repo_root} — cd there first; run every command and resolve every ` +
-    `relative path (including ../40kdc-abilities and ../40kdc-embeddings) against it. ` +
-    `Never read or write any other checkout of this repo.\n`
-  : ''
+const quote = s => `'${String(s).replaceAll("'", "'\\''")}'`
+const ROLE_MANIFEST = ['arch-magos', 'chronomancer', 'cogitator', 'data-enginseer', 'eversor',
+  'inquisitor', 'kroot-flesh-shaper', 'kroot-lone-spear', 'kroot-trail-shaper',
+  'kroot-war-shaper', 'psyker', 'skitarius', 'swarmlord', 'target-dummy', 'vox-hound', 'warpsmith']
+function resultText(v) {
+  if (typeof v === 'string') return v
+  if (!v) return ''
+  if (typeof v.text === 'string') return v.text
+  if (typeof v.output === 'string') return v.output
+  if (typeof v.stdout === 'string') return v.stdout
+  if (Array.isArray(v.content)) return v.content.map(x => typeof x === 'string' ? x : (x.text || '')).join('\n')
+  return ''
+}
+const runAgent = (prompt, options) => agent(prompt, {
+  ...options, model: 'openai-codex/gpt-5.6-luna', schemaMode: 'strict',
+})
+async function assertWorkspace() {
+  const root = quote(args.repo_root)
+  const check = await tool.bash({ command:
+    `set -eu; expected=$(cd ${root} && pwd -P); ` +
+    `test "$(pwd -P)" = "$expected"; test "$(jj root)" = "$expected"; ` +
+    `test -f AGENTS.md; test -f .omp/skills/dsl-campaign/SKILL.md; ` +
+    `for role in ${ROLE_MANIFEST.map(quote).join(' ')}; do file=".omp/agents/$role.md"; ` +
+    `test -f "$file"; model=$(sed -n 's/^model: //p' "$file"); test "$model" = "openai-codex/gpt-5.6-luna"; done; ` +
+    `test "$(jj log -r @ --no-graph -T 'commit_id')" = ${quote(args.candidate_commit_id)}; ` +
+    `grep -q '40kdc-data' AGENTS.md; printf '__DSL_WORKSPACE_OK__:%s\\n' "$expected"`, timeout: 20 })
+  if (!resultText(check).includes('__DSL_WORKSPACE_OK__'))
+    throw new Error(`workspace preflight failed: cwd and jj root must both equal ${args.repo_root}`)
+  return { repo_root: args.repo_root, verified: true, role_manifest_verified: ROLE_MANIFEST }
+}
+const workspace = await assertWorkspace()
+function canonicalJson(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  return `{${Object.keys(value).sort().map(k => `${JSON.stringify(k)}:${canonicalJson(value[k])}`).join(',')}}`
+}
+const sha256Canonical = value => new Bun.CryptoHasher('sha256').update(canonicalJson(value)).digest('hex')
+const PRE = `Verified repo root: ${args.repo_root}. The workflow hard-checked that its cwd and jj root ` +
+  `match this path. Run every command there; never read or write another checkout.\n`
 
 // ---- frozen Output contracts, transcribed to JSON Schema (do not redesign) ----
 const ENGINSEER_OUT = {
-  type: 'object', required: ['matches', 'method'],
+  type: 'object', required: ['matches', 'method', 'evidence_packet'],
   properties: {
     matches: { type: 'array', items: { type: 'object', required: ['ability_id', 'faction', 'raw_text', 'has_dsl'],
       properties: { ability_id: { type: 'string' }, faction: { type: 'string' },
@@ -47,49 +86,129 @@ const ENGINSEER_OUT = {
     comparison: { type: ['object', 'null'], additionalProperties: true },
     method: { enum: ['index-lookup', 'grep', 'embeddings'] },
     notes: { type: 'array', items: { type: 'string' } },
+    evidence_packet: { type: ['object', 'null'], additionalProperties: true },
+  },
+}
+function evidencePayload(packet) {
+  return {
+    ability_id: packet.ability_id, faction_id: packet.faction_id, source_hash: packet.source_hash,
+    clauses: packet.clauses.map(c => ({ clause_id: c.clause_id, start: c.start, end: c.end,
+      source_text_hash: c.source_text_hash, mechanical: c.mechanical, kind: c.kind })),
+    relationships: packet.relationships || [], tables: packet.tables || [],
+  }
+}
+function validateEvidencePacket(packet, source, ability_id, faction_id) {
+  if (!packet || packet.ability_id !== ability_id || packet.faction_id !== faction_id ||
+      !Array.isArray(packet.clauses) || !packet.clauses.length || !packet.source_hash || !packet.packet_hash)
+    return 'missing or misidentified source evidence packet'
+  const sourceHash = new Bun.CryptoHasher('sha256').update(source).digest('hex')
+  if (packet.source_hash !== sourceHash) return 'source evidence hash does not match complete raw text'
+  let cursor = 0
+  const ids = new Set()
+  for (const clause of packet.clauses) {
+    if (!clause.clause_id || ids.has(clause.clause_id) || clause.start !== cursor ||
+        !Number.isInteger(clause.end) || clause.end <= clause.start || clause.end > source.length ||
+        typeof clause.mechanical !== 'boolean' || !clause.kind) return 'invalid clause partition'
+    ids.add(clause.clause_id)
+    const hash = new Bun.CryptoHasher('sha256').update(source.slice(clause.start, clause.end)).digest('hex')
+    if (hash !== clause.source_text_hash) return `source slice hash mismatch for ${clause.clause_id}`
+    cursor = clause.end
+  }
+  if (cursor !== source.length) return 'clause partition does not cover complete raw text'
+  const packetHash = new Bun.CryptoHasher('sha256').update(JSON.stringify(evidencePayload(packet))).digest('hex')
+  return packetHash === packet.packet_hash ? null : 'evidence packet hash mismatch'
+}
+const LOOKUPS_OUT = {
+  type: 'object', required: ['resolutions'],
+  properties: { resolutions: { type: 'array', items: { type: 'object',
+    required: ['lookup_id', 'status', 'evidence'], properties: {
+      lookup_id: { type: 'string' }, status: { enum: ['resolved', 'unresolved'] },
+      evidence: { type: 'string' },
+    } } } },
+}
+const ARCHITECT_OUT = {
+  type: 'object', required: ['mode', 'architecture'],
+  properties: {
+    mode: { const: 'architect' },
+    architecture: { type: 'object',
+      required: ['form', 'source_clause_ids', 'shared_invariants', 'local_actions', 'event_bindings',
+        'existing_shape_fit', 'internal_family_size', 'route'],
+      properties: {
+        form: { enum: ['linear', 'choice', 'menu', 'resource-menu', 'state-machine', 'aura', 'composite', 'other'] },
+        source_clause_ids: { type: 'array', items: { type: 'string' } },
+        shared_invariants: { type: 'array', items: { type: 'object', additionalProperties: true } },
+        local_actions: { type: 'array', items: { type: 'object',
+          required: ['child_id', 'clause_ids', 'shared_contract_id', 'parent_id', 'parent_closed'],
+          properties: { child_id: { type: 'string' }, clause_ids: { type: 'array', items: { type: 'string' } },
+            shared_contract_id: { type: 'string' }, parent_id: { type: 'string' }, parent_closed: { type: 'boolean' } } } },
+        resource_lifecycle: { type: ['object', 'null'], additionalProperties: true },
+        event_bindings: { type: 'array', items: { type: 'object', additionalProperties: true } },
+        existing_shape_fit: { type: 'object', required: ['verdict', 'shapes_checked', 'unmapped_clause_ids'],
+          properties: { verdict: { enum: ['exact', 'partial', 'none'] },
+            shapes_checked: { type: 'array', items: { type: 'string' } },
+            unmapped_clause_ids: { type: 'array', items: { type: 'string' } } } },
+        internal_family_size: { type: 'integer', minimum: 0 },
+        route: { enum: ['existing-shape', 'shape-scout'] },
+        resisted_schema: { type: ['object', 'null'], additionalProperties: true },
+      } },
   },
 }
 const WHO_OUT = {
-  type: 'object', required: ['ability_id', 'bearer', 'beneficiary', 'scope_target', 'confidence'],
+  type: 'object', required: ['status', 'ability_id', 'bearer', 'beneficiary', 'scope_target', 'unresolved_clauses', 'confidence'],
   properties: {
-    ability_id: { type: 'string' }, bearer: { type: 'string' }, beneficiary: { type: 'string' },
-    applies_to: { type: ['object', 'null'], additionalProperties: true }, scope_target: { type: 'string' },
+    status: { enum: ['resolved', 'ambiguous', 'needs-schema', 'source-missing', 'error'] },
+    ability_id: { type: 'string' }, bearer: { type: ['string', 'null'] }, beneficiary: { type: ['string', 'null'] },
+    applies_to: { type: ['object', 'null'], additionalProperties: true }, scope_target: { type: ['string', 'null'] },
     effect_target_params: { type: ['object', 'null'], additionalProperties: true },
     keyword_gates: { type: 'array', items: { type: 'string' } },
     excludes: { type: 'array', items: { type: 'string' } },
-    lookups_needed: { type: 'array', items: { type: 'object', additionalProperties: true } }, confidence: { type: 'number' },
+    lookups_needed: { type: 'array', items: { type: 'object', required: ['lookup_id', 'question'],
+      properties: { lookup_id: { type: 'string' }, question: { type: 'string' } } } },
+    unresolved_clauses: { type: 'array', items: { type: 'string' } }, confidence: { type: 'number' },
   },
 }
 const WHEN_OUT = {
-  type: 'object', required: ['ability_id', 'behavior', 'duration', 'confidence'],
+  type: 'object', required: ['status', 'ability_id', 'behavior', 'duration', 'unresolved_clauses', 'confidence'],
   properties: {
+    status: { enum: ['resolved', 'ambiguous', 'needs-schema', 'source-missing', 'error'] },
     ability_id: { type: 'string' },
-    behavior: { enum: ['passive', 'activated', 'reactive', 'aura'] },
+    behavior: { enum: ['passive', 'activated', 'reactive', 'aura', null] },
     trigger: { type: ['object', 'null'], additionalProperties: true },
     phase_conditions: { type: 'array', items: { type: 'object', additionalProperties: true } },
     canonical_condition_ids: { type: 'array', items: { type: 'string' } },
-    duration: { type: 'string' }, usage: { type: ['object', 'null'], additionalProperties: true },
-    lookups_needed: { type: 'array', items: { type: 'object', additionalProperties: true } }, confidence: { type: 'number' },
+    duration: { type: ['string', 'null'] }, usage: { type: ['object', 'null'], additionalProperties: true },
+    lookups_needed: { type: 'array', items: { type: 'object', required: ['lookup_id', 'question'],
+      properties: { lookup_id: { type: 'string' }, question: { type: 'string' } } } },
+    unresolved_clauses: { type: 'array', items: { type: 'string' } }, confidence: { type: 'number' },
   },
 }
 const WHAT_OUT = {
-  type: 'object', required: ['ability_id', 'leaf_types_used', 'composition', 'buff_or_debuff', 'confidence'],
+  type: 'object', required: ['status', 'ability_id', 'leaf_types_used', 'composition', 'buff_or_debuff', 'unresolved_clauses', 'confidence'],
   properties: {
+    status: { enum: ['resolved', 'ambiguous', 'needs-schema', 'source-missing', 'error'] },
     ability_id: { type: 'string' }, effect_tree: { type: ['object', 'null'], additionalProperties: true },
     leaf_types_used: { type: 'array', items: { type: 'string' } },
-    composition: { enum: ['choice', 'sequence', 'conditional', 'dice-gated', 'aura', 'none'] },
-    dice_mechanics: { type: 'array', items: { type: 'object', additionalProperties: true } }, buff_or_debuff: { enum: ['buff', 'debuff', 'both', 'neutral'] },
+    composition: { enum: ['choice', 'sequence', 'conditional', 'dice-gated', 'aura', 'none', null] },
+    dice_mechanics: { type: 'array', items: { type: 'object', additionalProperties: true } }, buff_or_debuff: { enum: ['buff', 'debuff', 'both', 'neutral', null] },
     unmodelable_clauses: { type: 'array', items: { type: 'string' } },
-    lookups_needed: { type: 'array', items: { type: 'object', additionalProperties: true } }, confidence: { type: 'number' },
+    lookups_needed: { type: 'array', items: { type: 'object', required: ['lookup_id', 'question'],
+      properties: { lookup_id: { type: 'string' }, question: { type: 'string' } } } },
+    unresolved_clauses: { type: 'array', items: { type: 'string' } }, confidence: { type: 'number' },
   },
 }
 const ARCHMAGOS_OUT = {
   type: 'object',
-  required: ['ability_id', 'dsl', 'approx_notes', 'dropped_clauses', 'adopted_shapes', 'self_grade', 'confidence'],
+  required: ['ability_id', 'dsl', 'approx_notes', 'dropped_clauses', 'clause_coverage', 'adopted_shapes', 'self_grade', 'confidence'],
   properties: {
     ability_id: { type: 'string' }, dsl: { type: ['object', 'null'], additionalProperties: true },
-    approx_notes: { type: 'array', items: { type: 'string' } },
+    approx_notes: { type: 'array', maxItems: 0, items: { type: 'string' } },
     dropped_clauses: { type: 'array', items: { type: 'string' } },
+    clause_coverage: { type: 'array', items: { type: 'object',
+      required: ['clause_id', 'disposition', 'dsl_path', 'evidence', 'notes'],
+      properties: { clause_id: { type: 'string' },
+        disposition: { enum: ['exact', 'declared-nonmechanical', 'unresolved'] },
+        dsl_path: { type: ['string', 'null'] },
+        evidence: { enum: ['source-explicit', 'schema-derived', 'inference'] }, notes: { type: 'string' } } } },
     adopted_shapes: { type: 'array', items: { type: 'string' } },
     resisted_schema: { type: ['object', 'null'], additionalProperties: true },
     self_grade: { type: 'object', required: ['describer_output', 'verdict'],
@@ -112,33 +231,73 @@ const EVERSOR_OUT = {
 const results = await pipeline(
   args.abilities,
 
-  a => agent(
-    PRE + `Look up this ability's raw prose and committed DSL. Input:\n` +
-    JSON.stringify({ query: { ability_id: a.ability_id, faction_id: a.faction_id } }),
-    { agentType: 'data-enginseer', phase: 'Retrieve', schema: ENGINSEER_OUT, label: `retrieve:${a.ability_id}` }
-  ),
+  async a => ({
+    ability: a,
+    retrieval: await runAgent(
+      PRE + `Look up this ability's raw prose and committed DSL. Input:\n` +
+      JSON.stringify({ query: { ability_id: a.ability_id, faction_id: a.faction_id } }),
+      { agent: 'data-enginseer', schema: ENGINSEER_OUT, label: `retrieve:${a.ability_id}` }
+    ),
+  }),
 
-  async (ret, a) => {
+  async ({ ability: a, retrieval: ret }) => {
     if (!ret) return { ability: a, status: 'agent-error', candidate: null, verdicts: [], attempts: 0 }
-    const match =
-      (ret.matches || []).find(m => m.faction === a.faction_id) || (ret.matches || [])[0] || null
+    const exactMatches = (ret.matches || []).filter(m =>
+      m.ability_id === a.ability_id && m.faction === a.faction_id)
+    const match = exactMatches.length === 1 ? exactMatches[0] : null
     if (!match || !match.raw_text)
       return { ability: a, status: 'no-prose', candidate: null, verdicts: [], attempts: 0 }
+    const packet = ret.evidence_packet
+    const packetError = validateEvidencePacket(packet, match.raw_text, a.ability_id, a.faction_id)
+    if (packetError)
+      return { ability: a, status: 'agent-error', reason: packetError, candidate: null, verdicts: [], attempts: 0 }
+    const clauseIds = packet.clauses.map(c => c.clause_id)
 
     const baseInput = {
       ability_id: a.ability_id, name: a.name || a.ability_id, raw_text: match.raw_text,
       ability_type: a.ability_type || null, faction_id: a.faction_id,
       detachment_id: a.detachment_id || null,
+      evidence_packet: packet,
+    }
+    const architecture = await runAgent(
+      PRE + `Architect this mechanic BEFORE leaf decomposition. Reconstruct its global control structure; ` +
+      `separate shared invariants from action-local triggers/targets/effects/durations and event bindings. ` +
+      `An existing-shape route is legal only for exact coverage of every clause. A partial fit, note-only ` +
+      `mechanic, unsupported composite control structure, or unresolved binding routes to shape-scout. Input:\n` +
+      JSON.stringify({ mode: 'architect', artifacts: { source: baseInput } }),
+      { agent: 'inquisitor', schema: ARCHITECT_OUT, label: `architect:${a.ability_id}` }
+    )
+    if (!architecture) return { ability: a, status: 'agent-error', reason: 'architecture agent returned nothing', candidate: null, verdicts: [], attempts: 0 }
+    const arch = architecture.architecture
+    const architectureCovered = new Set(arch.source_clause_ids || [])
+    const missingArchitectureClauses = clauseIds.filter(id => !architectureCovered.has(id))
+    const exactExistingFit = arch.route === 'existing-shape' && arch.existing_shape_fit.verdict === 'exact' &&
+      arch.existing_shape_fit.unmapped_clause_ids.length === 0 && missingArchitectureClauses.length === 0
+    if (!exactExistingFit) return {
+      ability: a, status: 'needs-schema', reason: 'architecture gate rejected a partial or composite fit',
+      candidate: null, architecture, evidence_packet: packet, verdicts: [], thread: [], attempts: 0,
+      resisted_schema: arch.resisted_schema || { mechanic: `composite mechanic for ${a.ability_id}`,
+        resists_schema: `unmapped clauses: ${[...missingArchitectureClauses, ...arch.existing_shape_fit.unmapped_clause_ids].join(', ') || 'container semantics'}`,
+        proposal: `shape-scout the ${arch.form} control structure`, also_unblocks: '' },
     }
     const dec = JSON.stringify(baseInput)
     const [who, when, what] = await parallel([
-      () => agent(PRE + `Decompose WHO for this ability. Input:\n${dec}`,
-        { agentType: 'target-dummy', phase: 'Decompose', schema: WHO_OUT, label: `who:${a.ability_id}` }),
-      () => agent(PRE + `Decompose WHEN for this ability. Input:\n${dec}`,
-        { agentType: 'chronomancer', phase: 'Decompose', schema: WHEN_OUT, label: `when:${a.ability_id}` }),
-      () => agent(PRE + `Decompose WHAT for this ability. Input:\n${dec}`,
-        { agentType: 'vox-hound', phase: 'Decompose', schema: WHAT_OUT, label: `what:${a.ability_id}` }),
+      () => runAgent(PRE + `Decompose WHO for this ability. Input:\n${dec}`,
+        { agent: 'target-dummy', schema: WHO_OUT, label: `who:${a.ability_id}` }),
+      () => runAgent(PRE + `Decompose WHEN for this ability. Input:\n${dec}`,
+        { agent: 'chronomancer', schema: WHEN_OUT, label: `when:${a.ability_id}` }),
+      () => runAgent(PRE + `Decompose WHAT for this ability. Input:\n${dec}`,
+        { agent: 'vox-hound', schema: WHAT_OUT, label: `what:${a.ability_id}` }),
     ])
+    const unresolvedDecomposers = [who, when, what].filter(d => !d ||
+      d.ability_id !== a.ability_id || d.status !== 'resolved' || d.unresolved_clauses.length)
+    if (what && what.unmodelable_clauses && what.unmodelable_clauses.length) unresolvedDecomposers.push(what)
+    if (unresolvedDecomposers.length) return {
+      ability: a, status: unresolvedDecomposers.some(d => d && d.status === 'source-missing') ? 'no-prose' : 'needs-schema',
+      reason: 'one or more decomposers reported ambiguity or an expressibility gap',
+      candidate: null, architecture, evidence_packet: packet, verdicts: [], thread: [],
+      decomposition: { who, when, what }, attempts: 0,
+    }
 
     // Route the decomposers' deferred cross-references back to data-enginseer. Previously
     // who/when/what.lookups_needed were dropped on the floor (enginseer fired once, at
@@ -146,14 +305,24 @@ const results = await pipeline(
     // result feeds the assembler as `lookups`.
     const deferred = [who, when, what].flatMap(d => (d && d.lookups_needed) || [])
     const lookups = deferred.length
-      ? await agent(
+      ? await runAgent(
           PRE + `Resolve these cross-references the decomposers deferred (other abilities, ` +
           `keyword meanings, sibling encodings). Input:\n` +
-          JSON.stringify({ query: { mechanic: deferred.join(' ; '), faction_id: a.faction_id },
-            deferred, context_ability_id: a.ability_id }),
-          { agentType: 'data-enginseer', phase: 'Retrieve', schema: ENGINSEER_OUT, label: `lookups:${a.ability_id}` }
+          JSON.stringify({ deferred, context_ability_id: a.ability_id, faction_id: a.faction_id }),
+          { agent: 'data-enginseer', schema: LOOKUPS_OUT, label: `lookups:${a.ability_id}` }
         )
       : null
+    if (deferred.length) {
+      const requested = new Set(deferred.map(d => d.lookup_id))
+      const resolved = new Map((lookups?.resolutions || []).map(r => [r.lookup_id, r]))
+      if (requested.size !== deferred.length || (lookups?.resolutions || []).length !== requested.size ||
+          resolved.size !== requested.size || [...requested].some(id => !resolved.has(id) ||
+            resolved.get(id).status !== 'resolved' || !resolved.get(id).evidence.trim())) return {
+        ability: a, status: 'needs-schema', reason: 'deferred cross-reference remained unresolved',
+        candidate: null, architecture, evidence_packet: packet, verdicts: [], thread: [],
+        decomposition: { who, when, what }, attempts: 0,
+      }
+    }
 
     let candidate = null
     let verdicts = []
@@ -167,7 +336,7 @@ const results = await pipeline(
       attempts = attempt + 1
       const assembleInput = {
         ...baseInput,
-        target: who, timing: when, effect: what, retrieval: ret, lookups,
+        architecture, target: who, timing: when, effect: what, retrieval: ret, lookups,
         previous_dsl: match.has_dsl ? '(committed at ' + (match.committed_dsl_path || 'unknown') + ' — read it)' : null,
         previous_cosine: a.previous_cosine ?? a.cos_start ?? null,
       }
@@ -177,15 +346,40 @@ const results = await pipeline(
           `drop a clause to dodge one, and never reintroduce a divergence an earlier round already resolved:\n` +
           JSON.stringify(thread.map(t => ({ round: t.attempt, refuted: t.refuted, divergences: t.divergences })))
         : ''
-      candidate = await agent(
+      candidate = await runAgent(
         PRE + `Assemble the DSL entry. The prose is authoritative over every decomposer block; ` +
         `placeholder lies are banned — if the schema cannot express the mechanic honestly, return resisted_schema. ` +
         `Input:\n${JSON.stringify(assembleInput)}${revision}`,
-        { agentType: 'arch-magos', phase: 'Assemble', schema: ARCHMAGOS_OUT, label: `assemble:${a.ability_id}#${attempts}` }
+        { agent: 'arch-magos', schema: ARCHMAGOS_OUT, label: `assemble:${a.ability_id}#${attempts}` }
       )
       if (!candidate) return { ability: a, status: 'agent-error', candidate: null, verdicts, thread, decomposition: { who, when, what }, attempts }
+      if (candidate.ability_id !== a.ability_id)
+        return { ability: a, status: 'agent-error', reason: 'assembler returned another ability id', candidate, verdicts, thread, decomposition: { who, when, what }, attempts }
       if (candidate.resisted_schema)
         return { ability: a, status: 'needs-schema', candidate, verdicts, thread, decomposition: { who, when, what }, attempts }
+      if (candidate.approx_notes.length)
+        return { ability: a, status: 'needs-schema', reason: 'approx_notes are forbidden for accepted candidates', candidate, verdicts, thread, decomposition: { who, when, what }, attempts }
+      const coverage = candidate.clause_coverage || []
+      const byClause = new Map(coverage.map(c => [c.clause_id, c]))
+      const expectedClauses = new Set(packet.clauses.map(c => c.clause_id))
+      if (byClause.size !== coverage.length || byClause.size !== expectedClauses.size ||
+          coverage.some(c => !expectedClauses.has(c.clause_id))) return {
+        ability: a, status: 'needs-schema', reason: 'clause coverage has duplicate, missing, or extra rows',
+        candidate, architecture, evidence_packet: packet, verdicts, thread,
+        decomposition: { who, when, what }, attempts,
+      }
+      const incomplete = packet.clauses.filter(c => {
+        const row = byClause.get(c.clause_id)
+        if (!row) return true
+        if (!c.mechanical) return row.disposition === 'unresolved'
+        return row.disposition !== 'exact' || row.evidence === 'inference' || !row.dsl_path
+      })
+      if (!candidate.dsl || typeof candidate.dsl !== 'object' || candidate.self_grade.verdict !== 'faithful' ||
+          candidate.dropped_clauses.length || incomplete.length) return {
+        ability: a, status: 'needs-schema', reason: `clause coverage failed: ${incomplete.map(c => c.clause_id).join(', ')}`,
+        candidate, architecture, evidence_packet: packet, verdicts, thread,
+        decomposition: { who, when, what }, attempts,
+      }
 
       const escalate =
         (typeof candidate.confidence === 'number' && candidate.confidence < 0.7) ||
@@ -199,12 +393,12 @@ const results = await pipeline(
         approx_notes: candidate.approx_notes || [],
       })
       verdicts = (await parallel(Array.from({ length: n }, (_, i) => () =>
-        agent(
+        runAgent(
           PRE + `You are refuter ${i + 1} of ${n}; work independently — do not assume the encoding is right. ` +
           `Derive expected behavior from the PROSE ONLY (never from the DSL's own vocabulary or describer render). ` +
-          `refuted:true requires a CONCRETE constructed game state. A clause declared in approx_notes is not a divergence; ` +
-          `an undeclared gap is. Input:\n${refuteInput}`,
-          { agentType: 'eversor', phase: 'Refute', schema: EVERSOR_OUT, label: `refute:${a.ability_id}#${attempts}v${i + 1}` }
+          `refuted:true requires a CONCRETE constructed game state. approx_notes are forbidden; treat any ` +
+          `mechanic not represented exactly by the DSL as a divergence. Input:\n${refuteInput}`,
+          { agent: 'eversor', schema: EVERSOR_OUT, label: `refute:${a.ability_id}#${attempts}v${i + 1}` }
         )
       ))).filter(Boolean)
 
@@ -217,8 +411,9 @@ const results = await pipeline(
         divergences: verdicts.flatMap(v => v.divergences || []),
       })
 
-      // Acceptance needs a real panel: ≥2 surviving verdicts, none refuted (anti-condition 5).
-      if (verdicts.length >= 2 && verdicts.every(v => !v.refuted))
+      // Acceptance needs the exact requested panel, bound to this ability, with no divergence.
+      if (verdicts.length === n && verdicts.every(v => v.ability_id === a.ability_id &&
+        v.refuted === false && Array.isArray(v.divergences) && v.divergences.length === 0))
         return { ability: a, status: 'accepted', candidate, verdicts, thread, decomposition: { who, when, what }, attempts }
     }
     return { ability: a, status: 'rejected', candidate, verdicts, thread, decomposition: { who, when, what }, attempts }
@@ -229,4 +424,17 @@ const out = results.filter(Boolean)
 const counts = {}
 for (const r of out) counts[r.status] = (counts[r.status] || 0) + 1
 log(`batch ${args.batch_id}: ${JSON.stringify(counts)}`)
-return { batch_id: args.batch_id, results: out }
+const payload = {
+  batch_id: args.batch_id,
+  workspace,
+  provenance: { workflow: 'dsl-author-batch', required_roles: ['data-enginseer', 'inquisitor', 'target-dummy', 'chronomancer', 'vox-hound', 'arch-magos', 'eversor'] },
+  results: out,
+}
+const ability_keys = args.abilities.map(a => `${a.faction_id}/${a.ability_id}`).sort()
+const payload_sha256 = new Bun.CryptoHasher('sha256').update(JSON.stringify(payload)).digest('hex')
+const candidate_dsl_hashes = {}
+for (const row of out.filter(x => x.status === 'accepted'))
+  candidate_dsl_hashes[`${row.ability.faction_id}/${row.ability.ability_id}`] = sha256Canonical(row.candidate.dsl)
+return { binding: { kind: 'author', campaign_id: args.campaign_id, batch_id: args.batch_id,
+  campaign_manifest_sha256: args.campaign_manifest_sha256, ability_keys,
+  author_candidate_commit_id: args.candidate_commit_id, candidate_dsl_hashes, payload_sha256 }, payload }

--- a/.omp/skills/dsl-campaign/workflows/wf-close-campaign.js
+++ b/.omp/skills/dsl-campaign/workflows/wf-close-campaign.js
@@ -1,0 +1,390 @@
+export const meta = {
+  name: 'dsl-close-campaign',
+  description: 'Artifact-gated campaign closure: terminal ledger, CI-equivalent preflight, six-pair parity, prose drift, and inquisitor close review',
+  phases: [
+    { title: 'Inventory', detail: 'workspace/head identity + terminal artifact ledger' },
+    { title: 'Preflight', detail: 'jj-compatible full local CI mirror' },
+    { title: 'Parity', detail: 'fresh runners + all six implementation pairs' },
+    { title: 'Drift', detail: 'normalized whole-corpus prose-diff artifact' },
+    { title: 'Review', detail: 'inquisitor checks all ten anti-conditions' },
+  ],
+}
+
+// args: {
+//   repo_root: string,
+//   campaign_id: string,
+//   expected_head_commit_id: string, // @- after sealing the completed stack with jj new
+//   campaign_manifest_path: string,  // frozen manifest from prioritization/materialization
+//   campaign_manifest_sha256: string,
+//   worklist: [{ ability_id, faction_id, status, cos_start, cos_best, attempts,
+//                justification?, artifacts: { author, verify, review, rescore } }],
+//   faction_means: [{ faction_id, mean_before, mean_after }],
+//   final_verification: artifact reference covering every converged/improved pair,
+//   prose_diff_path: string,         // normalized artifact described below
+//   baseline_report_path: string,
+//   current_report_path: string,
+// }
+//
+// prose_diff_path JSON:
+// { baseline_sha256, current_sha256, changes:[{ability_id,faction_id}],
+//   non_worklist_changes:[], generated_at }
+//
+// The driver may create/push a bookmark and PR only when ready_to_publish === true.
+
+if (typeof args === 'string') args = JSON.parse(args)
+if (!args || !args.repo_root || !args.campaign_id) throw new Error('repo_root and campaign_id required')
+if (!args.expected_head_commit_id) throw new Error('expected_head_commit_id required')
+if (!Array.isArray(args.worklist) || !args.worklist.length) throw new Error('non-empty worklist required')
+if (args.worklist.length > 40) throw new Error('worklist exceeds hard campaign cap of 40')
+
+const quote = s => `'${String(s).replaceAll("'", "'\\''")}'`
+const ROLE_MANIFEST = ['arch-magos', 'chronomancer', 'cogitator', 'data-enginseer', 'eversor',
+  'inquisitor', 'kroot-flesh-shaper', 'kroot-lone-spear', 'kroot-trail-shaper',
+  'kroot-war-shaper', 'psyker', 'skitarius', 'swarmlord', 'target-dummy', 'vox-hound', 'warpsmith']
+function resultText(v) {
+  if (typeof v === 'string') return v
+  if (!v) return ''
+  if (typeof v.text === 'string') return v.text
+  if (typeof v.output === 'string') return v.output
+  if (typeof v.stdout === 'string') return v.stdout
+  if (Array.isArray(v.content)) return v.content.map(x => typeof x === 'string' ? x : (x.text || '')).join('\n')
+  return ''
+}
+const runAgent = (prompt, options) => agent(prompt, {
+  ...options, model: 'openai-codex/gpt-5.6-luna', schemaMode: 'strict',
+})
+async function runChecked(label, command, timeout) {
+  phase(label)
+  const marker = `__DSL_GATE_${label.toUpperCase()}_OK__`
+  const result = await tool.bash({ command: `set -eu; ${command}; printf '${marker}\\n'`, timeout })
+  const failed = typeof result === 'object' && result &&
+    (result.hasError || result.details?.timedOut ||
+      (result.details?.exitCode != null && result.details.exitCode !== 0) ||
+      ('exitCode' in result && result.exitCode !== 0))
+  if (failed || !resultText(result).includes(marker)) throw new Error(`${label} failed: ${resultText(result)}`)
+  return { label, pass: true, output_tail: resultText(result).slice(-2000) }
+}
+async function fileHash(path) {
+  const file = Bun.file(path)
+  if (!(await file.exists())) throw new Error(`artifact not found: ${path}`)
+  return new Bun.CryptoHasher('sha256').update(new Uint8Array(await file.arrayBuffer())).digest('hex')
+}
+async function verifyArtifact(ref, label, kind, expectedKeys, expectedCommit, expectedBatch) {
+  if (!ref || typeof ref.path !== 'string' || typeof ref.sha256 !== 'string' ||
+      (kind === 'author' ? ref.author_candidate_commit_id : ref.candidate_commit_id) !== expectedCommit || ref.batch_id !== expectedBatch ||
+      !Array.isArray(ref.ability_keys))
+    throw new Error(`${label} artifact reference is incomplete or misbound`)
+  const actual = await fileHash(ref.path)
+  if (actual !== ref.sha256) throw new Error(`${label} artifact hash mismatch`)
+  const envelope = await Bun.file(ref.path).json()
+  const binding = envelope.binding
+  const payloadHash = new Bun.CryptoHasher('sha256').update(JSON.stringify(envelope.payload)).digest('hex')
+  const keys = [...(binding?.ability_keys || [])].sort()
+  if (!binding || binding.kind !== kind || binding.campaign_id !== args.campaign_id ||
+      binding.batch_id !== expectedBatch ||
+      binding.campaign_manifest_sha256 !== args.campaign_manifest_sha256 ||
+      (kind === 'author' ? binding.author_candidate_commit_id : binding.candidate_commit_id) !== expectedCommit ||
+      binding.payload_sha256 !== payloadHash || binding.payload_sha256 !== ref.payload_sha256 ||
+      keys.length !== expectedKeys.length || expectedKeys.some((key, i) => key !== keys[i]) ||
+      ref.ability_keys.length !== keys.length || [...ref.ability_keys].sort().some((key, i) => key !== keys[i]))
+    throw new Error(`${label} artifact envelope binding mismatch`)
+  return envelope.payload
+}
+function canonicalJson(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  return `{${Object.keys(value).sort().map(k => `${JSON.stringify(k)}:${canonicalJson(value[k])}`).join(',')}}`
+}
+const sha256Canonical = value => new Bun.CryptoHasher('sha256').update(canonicalJson(value)).digest('hex')
+function extractRoundtripRows(report) {
+  if (!report || report.kind !== 'roundtrip' || !Array.isArray(report.abilities))
+    throw new Error('expected a kind:roundtrip report with abilities[]')
+  const rows = report.abilities.map(row => {
+    if (typeof row.ability_id !== 'string' || typeof row.faction !== 'string' ||
+        !Number.isFinite(row.score) || typeof row.english !== 'string')
+      throw new Error('roundtrip ability row lacks ability_id, faction, score, or english')
+    return { faction_id: row.faction, ability_id: row.ability_id, cosine: row.score,
+      describer_sha256: new Bun.CryptoHasher('sha256').update(row.english).digest('hex') }
+  })
+  rows.sort((a, b) => `${a.faction_id}/${a.ability_id}`.localeCompare(`${b.faction_id}/${b.ability_id}`))
+  const keys = new Set(rows.map(x => `${x.faction_id}/${x.ability_id}`))
+  if (!rows.length || keys.size !== rows.length) throw new Error('roundtrip report has no unique scored/rendered ability rows')
+  return rows
+}
+async function assertSealedHead() {
+  const root = quote(args.repo_root)
+  const result = await tool.bash({ command:
+    `set -eu; expected=$(cd ${root} && pwd -P); ` +
+    `test "$(pwd -P)" = "$expected"; test "$(jj root)" = "$expected"; ` +
+    `test -z "$(jj diff --summary -r @)"; ` +
+    `test "$(jj log -r @ --no-graph -T 'conflict')" = "false"; ` +
+    `test "$(jj log -r @- --no-graph -T 'conflict')" = "false"; ` +
+    `head=$(jj log -r @- --no-graph -T 'commit_id'); test "$head" = ${quote(args.expected_head_commit_id)}; ` +
+    `for role in ${ROLE_MANIFEST.map(quote).join(' ')}; do file=".omp/agents/$role.md"; ` +
+    `test -f "$file"; model=$(sed -n 's/^model: //p' "$file"); test "$model" = "openai-codex/gpt-5.6-luna"; done; ` +
+    `test -f AGENTS.md; grep -q '40kdc-data' AGENTS.md; printf '__DSL_CLOSE_IDENTITY_OK__\\n'`, timeout: 30 })
+  if (!resultText(result).includes('__DSL_CLOSE_IDENTITY_OK__'))
+    throw new Error('close identity failed: candidate/child must be clean, conflict-free, and pinned to the expected full commit id')
+}
+
+phase('Inventory')
+await assertSealedHead()
+
+if (!args.campaign_manifest_path || !args.campaign_manifest_sha256)
+  throw new Error('campaign manifest path + sha256 required')
+if (await fileHash(args.campaign_manifest_path) !== args.campaign_manifest_sha256)
+  throw new Error('campaign manifest hash mismatch')
+const manifest = await Bun.file(args.campaign_manifest_path).json()
+if (manifest.campaign_id !== args.campaign_id || !manifest.campaign_base_commit_id ||
+    !Array.isArray(manifest.worklist) || !manifest.worklist.length)
+  throw new Error('invalid campaign manifest')
+{
+  const relation = await tool.bash({ command:
+    `set -eu; test "$(jj log -r ${quote(manifest.campaign_base_commit_id)} --no-graph -T 'commit_id')" = ` +
+    `${quote(manifest.campaign_base_commit_id)}; ` +
+    `jj log -r ${quote(manifest.campaign_base_commit_id)}'::'${quote(args.expected_head_commit_id)} ` +
+    `--no-graph -T 'commit_id ++ "\\n"' | grep -Fxq ${quote(args.expected_head_commit_id)}; ` +
+    `printf '__DSL_BASE_HEAD_OK__\\n'`, timeout: 30 })
+  if (!resultText(relation).includes('__DSL_BASE_HEAD_OK__'))
+    throw new Error('frozen campaign base is not an ancestor of the sealed head')
+}
+
+const terminal = new Set(['converged', 'improved', 'needs-schema', 'abandoned'])
+const keys = new Set()
+const completedKeys = []
+for (const item of args.worklist) {
+  const key = `${item.faction_id}/${item.ability_id}`
+  if (keys.has(key)) throw new Error(`duplicate worklist entry: ${key}`)
+  keys.add(key)
+  if (!terminal.has(item.status)) throw new Error(`non-terminal worklist entry: ${key} (${item.status})`)
+  if (!Number.isFinite(item.cos_start) || !Number.isFinite(item.cos_best))
+    throw new Error(`missing score artifact for ${key}`)
+  if (!Number.isInteger(item.attempts) || item.attempts < 0 || item.attempts > 4)
+    throw new Error(`invalid attempt count for ${key}`)
+  if (item.cos_best < item.cos_start && !item.justification)
+    throw new Error(`unjustified cosine drop for ${key}`)
+  if ((item.status === 'converged' || item.status === 'improved')) {
+    if (!item.batch_id || !item.candidate_commit_id || !item.author_candidate_commit_id || !item.candidate_dsl_sha256)
+      throw new Error(`batch/commit/DSL-hash binding missing for ${key}`)
+    completedKeys.push(key)
+    const required = ['author', 'verify', 'review', 'rescore']
+    const missing = required.filter(k => !item.artifacts || !item.artifacts[k])
+    if (missing.length) throw new Error(`completion artifacts missing for ${key}: ${missing.join(', ')}`)
+    const evidence = {}
+    for (const kind of ['author', 'verify', 'review']) {
+      const artifactKeys = [...(item.artifacts[kind].ability_keys || [])].sort()
+      if (!artifactKeys.includes(key)) throw new Error(`${key}:${kind} reference omits its ability key`)
+      const artifactCommit = kind === 'author' ? item.author_candidate_commit_id : item.candidate_commit_id
+      evidence[kind] = await verifyArtifact(item.artifacts[kind], `${key}:${kind}`, kind,
+        artifactKeys, artifactCommit, item.batch_id)
+    }
+    const rescoreRef = item.artifacts.rescore
+    if (!rescoreRef?.binding || await fileHash(rescoreRef.path) !== rescoreRef.sha256)
+      throw new Error(`rescore artifact reference invalid for ${key}`)
+    const rb = rescoreRef.binding
+    if (rb.kind !== 'rescore' || rb.campaign_id !== args.campaign_id || rb.batch_id !== item.batch_id ||
+        rb.campaign_manifest_sha256 !== args.campaign_manifest_sha256 ||
+        rb.candidate_commit_id !== item.candidate_commit_id || rb.payload_sha256 !== rescoreRef.sha256 ||
+        JSON.stringify(rb.ability_keys) !== JSON.stringify([key]))
+      throw new Error(`rescore artifact binding mismatch for ${key}`)
+    const rescoreRows = extractRoundtripRows(await Bun.file(rescoreRef.path).json())
+      .filter(x => x.faction_id === item.faction_id && x.ability_id === item.ability_id)
+    if (rescoreRows.length !== 1 || rescoreRows[0].cosine !== item.cos_best)
+      throw new Error(`rescore report does not contain exactly one matching score for ${key}`)
+    const authorRow = (evidence.author.results || []).find(r =>
+      r.ability?.ability_id === item.ability_id && r.ability?.faction_id === item.faction_id)
+    if (!authorRow || authorRow.status !== 'accepted') throw new Error(`author artifact does not accept ${key}`)
+    const authorEnvelope = await Bun.file(item.artifacts.author.path).json()
+    const verifyEnvelope = await Bun.file(item.artifacts.verify.path).json()
+    const reviewEnvelope = await Bun.file(item.artifacts.review.path).json()
+    const expectedReviewDigests = {
+      author_file_sha256: item.artifacts.author.sha256,
+      author_payload_sha256: item.artifacts.author.payload_sha256,
+      verify_file_sha256: item.artifacts.verify.sha256,
+      verify_payload_sha256: item.artifacts.verify.payload_sha256,
+      rescore_file_sha256: item.artifacts.rescore.sha256,
+      agent_outputs_sha256: item.artifacts.review.agent_outputs_sha256,
+    }
+    if (!expectedReviewDigests.agent_outputs_sha256 ||
+        canonicalJson(reviewEnvelope.binding.evidence_digests) !== canonicalJson(expectedReviewDigests))
+      throw new Error(`review evidence digests do not match ledger artifact references for ${key}`)
+    const authorHash = authorEnvelope.binding.candidate_dsl_hashes?.[key]
+    const verifyHash = verifyEnvelope.binding.candidate_dsl_hashes?.[key]
+    const reviewHash = reviewEnvelope.binding.candidate_dsl_hashes?.[key]
+    const appliedRows = await Bun.file(`data/enrichment/${item.faction_id}/abilities.json`).json()
+    const applied = appliedRows.filter(row => row.ability_id === item.ability_id)
+    const appliedHash = applied.length === 1 ? sha256Canonical(applied[0]) : null
+    if (!authorHash || authorHash !== verifyHash || authorHash !== reviewHash ||
+        authorHash !== item.candidate_dsl_sha256 || authorHash !== appliedHash)
+      throw new Error(`author/verify/review/ledger/applied DSL hashes disagree for ${key}`)
+    if (evidence.verify.pass !== true || !(evidence.verify.cogitator?.abilities || []).some(x =>
+      x.ability_id === item.ability_id && x.faction_id === item.faction_id))
+      throw new Error(`verification artifact does not pass ${key}`)
+    const terminalReviews = (evidence.review.reviews || []).filter(x =>
+      x.ability_id === item.ability_id && x.faction_id === item.faction_id)
+    if (terminalReviews.length !== 1 || terminalReviews[0].verdict !== 'accept')
+      throw new Error(`review artifact does not accept ${key}`)
+  } else if (item.status === 'needs-schema') {
+    if (!item.reason || !item.author_candidate_commit_id || !item.artifacts?.author || !item.artifacts?.inbox)
+      throw new Error(`needs-schema terminal evidence missing for ${key}`)
+    const authorKeys = [...(item.artifacts.author.ability_keys || [])].sort()
+    const author = await verifyArtifact(item.artifacts.author, `${key}:author`, 'author', authorKeys,
+      item.author_candidate_commit_id, item.batch_id)
+    const inboxKeys = [...(item.artifacts.inbox.ability_keys || [])].sort()
+    const inbox = await verifyArtifact(item.artifacts.inbox, `${key}:inbox`, 'inbox', inboxKeys,
+      item.candidate_commit_id, item.batch_id)
+    if (!authorKeys.includes(key) || !inboxKeys.includes(key)) throw new Error(`needs-schema batch artifacts omit ${key}`)
+    if (!(author.results || []).some(r => r.ability?.ability_id === item.ability_id &&
+      r.ability?.faction_id === item.faction_id && r.status === 'needs-schema') ||
+      !(inbox.entries || []).some(x => x.ability_id === item.ability_id && x.faction_id === item.faction_id && x.resisted_schema))
+      throw new Error(`needs-schema artifacts do not bind ${key}`)
+  } else if (item.status === 'abandoned') {
+    if (!item.reason || !item.author_candidate_commit_id || !item.artifacts?.author)
+      throw new Error(`abandonment author/reason missing for ${key}`)
+    const authorKeys = [...(item.artifacts.author.ability_keys || [])].sort()
+    const author = await verifyArtifact(item.artifacts.author, `${key}:author`, 'author', authorKeys,
+      item.author_candidate_commit_id, item.batch_id)
+    const authorRows = (author.results || []).filter(r => r.ability?.ability_id === item.ability_id &&
+      r.ability?.faction_id === item.faction_id)
+    if (authorRows.length !== 1 || !['rejected', 'no-prose', 'agent-error'].includes(authorRows[0].status))
+      throw new Error(`abandonment author status is not exactly rejected/no-prose/agent-error for ${key}`)
+  }
+}
+const manifestKeys = new Set(manifest.worklist.map(x => `${x.faction_id}/${x.ability_id}`))
+if (manifestKeys.size !== manifest.worklist.length || manifestKeys.size !== keys.size ||
+    [...manifestKeys].some(key => !keys.has(key)))
+  throw new Error('close worklist does not exactly match the frozen campaign manifest')
+for (const frozen of manifest.worklist) {
+  const item = args.worklist.find(x => x.faction_id === frozen.faction_id && x.ability_id === frozen.ability_id)
+  if (item.cos_start !== frozen.cos_start) throw new Error(`cos_start differs from frozen manifest for ${frozen.faction_id}/${frozen.ability_id}`)
+}
+if (!args.final_verification) throw new Error('final sealed-head verification artifact required')
+const finalVerification = await verifyArtifact(args.final_verification, 'final verification', 'verify',
+  completedKeys.sort(), args.expected_head_commit_id, args.final_verification.batch_id)
+if (finalVerification.pass !== true) throw new Error('final sealed-head verification did not pass')
+const finalEnvelope = await Bun.file(args.final_verification.path).json()
+if (finalEnvelope.binding.sealed_head !== true ||
+    finalEnvelope.binding.campaign_base_commit_id !== manifest.campaign_base_commit_id ||
+    finalEnvelope.binding.sealed_head_commit_id !== args.expected_head_commit_id)
+  throw new Error('final verification is not bound to the frozen base and sealed head')
+
+const preflight = await runChecked('Preflight',
+  `PATH="$PWD/python/.venv/bin:$PATH" just preflight`, 3600)
+const parity = await runChecked('Parity',
+  `set -eu; cd tools && npm run codegen:data && npx tsc; cd ..; ` +
+  `cargo build --release --bin wh40kdc-runner; ` +
+  `(cd go && go build -o wh40kdc-runner ./cmd/wh40kdc-runner); ` +
+  `for pair in ts,rust ts,py rust,py ts,go rust,go py,go; do ` +
+  `PATH="$PWD/python/.venv/bin:$PATH" python3 tooling/parity/differ.py --pair "$pair" --quiet; ` +
+  `out=$(mktemp); trap 'rm -f "$out"' EXIT; ` +
+  `for area in effect-translation scoring-translation; do ` +
+  `PATH="$PWD/python/.venv/bin:$PATH" python3 tooling/parity/differ.py --pair "$pair" --area "$area" --json >"$out"; ` +
+  `python3 - "$out" "$area" <<'PY'\nimport json,sys\np=json.load(open(sys.argv[1])); a=sys.argv[2]\nif p.get("ok") is not True or not isinstance(p.get("cases_run"),int) or p["cases_run"] <= 0 or a in p.get("skipped",[]): raise SystemExit(f"fail-closed parity for {a}: {p}")\nPY\n` +
+  `done; rm -f "$out"; trap - EXIT; done`, 3600)
+await assertSealedHead()
+
+phase('Drift')
+if (!args.prose_diff_path) throw new Error('prose_diff_path required')
+if (!args.baseline_report_path || !args.current_report_path)
+  throw new Error('baseline_report_path and current_report_path required')
+const driftFile = Bun.file(args.prose_diff_path)
+if (!(await driftFile.exists())) throw new Error(`prose diff artifact not found: ${args.prose_diff_path}`)
+const drift = await driftFile.json()
+if (!drift.baseline_sha256 || !drift.current_sha256 || !Array.isArray(drift.changes) ||
+    !Array.isArray(drift.non_worklist_changes))
+  throw new Error('invalid normalized prose-diff artifact')
+if (await fileHash(args.baseline_report_path) !== drift.baseline_sha256 ||
+    await fileHash(args.current_report_path) !== drift.current_sha256)
+  throw new Error('prose-diff hashes are not bound to the supplied roundtrip reports')
+if (manifest.baseline_sha256 !== drift.baseline_sha256)
+  throw new Error('prose baseline does not match the frozen campaign manifest')
+const baselineRows = extractRoundtripRows(await Bun.file(args.baseline_report_path).json())
+const currentRows = extractRoundtripRows(await Bun.file(args.current_report_path).json())
+const baselineRowsHash = new Bun.CryptoHasher('sha256').update(JSON.stringify(baselineRows)).digest('hex')
+if (baselineRowsHash !== manifest.baseline_rows_sha256) throw new Error('parsed baseline rows differ from frozen manifest')
+const baselineByKey = new Map(baselineRows.map(x => [`${x.faction_id}/${x.ability_id}`, x]))
+const currentByKey = new Map(currentRows.map(x => [`${x.faction_id}/${x.ability_id}`, x]))
+const allReportKeys = new Set([...baselineByKey.keys(), ...currentByKey.keys()])
+const derivedChanges = [...allReportKeys].filter(key =>
+  baselineByKey.get(key)?.describer_sha256 !== currentByKey.get(key)?.describer_sha256)
+  .map(key => { const [faction_id, ...id] = key.split('/'); return { faction_id, ability_id: id.join('/') } })
+const derivedKeys = new Set(derivedChanges.map(x => `${x.faction_id}/${x.ability_id}`))
+const suppliedKeys = new Set(drift.changes.map(x => `${x.faction_id}/${x.ability_id}`))
+if (derivedKeys.size !== suppliedKeys.size || [...derivedKeys].some(key => !suppliedKeys.has(key)))
+  throw new Error('normalized prose diff does not match report-derived describer changes')
+const nonWorklist = derivedChanges.filter(c => !keys.has(`${c.faction_id}/${c.ability_id}`))
+if (nonWorklist.length || drift.non_worklist_changes.length)
+  throw new Error(`non-worklist describer drift: ${JSON.stringify(nonWorklist)}`)
+for (const item of args.worklist) {
+  const current = currentByKey.get(`${item.faction_id}/${item.ability_id}`)
+  if (!current || current.cosine !== item.cos_best)
+    throw new Error(`current roundtrip score does not equal cos_best for ${item.faction_id}/${item.ability_id}`)
+}
+const targetFactions = [...new Set(manifest.worklist.map(x => x.faction_id))].sort()
+if (!Array.isArray(args.faction_means) || args.faction_means.length !== targetFactions.length)
+  throw new Error('one faction_means row is required per target faction')
+for (const faction_id of targetFactions) {
+  const beforeRows = baselineRows.filter(x => x.faction_id === faction_id)
+  const afterRows = currentRows.filter(x => x.faction_id === faction_id)
+  if (!beforeRows.length || !afterRows.length) throw new Error(`roundtrip report lacks target faction ${faction_id}`)
+  const before = beforeRows.reduce((n, x) => n + x.cosine, 0) / beforeRows.length
+  const after = afterRows.reduce((n, x) => n + x.cosine, 0) / afterRows.length
+  const supplied = args.faction_means.filter(x => x.faction_id === faction_id)
+  if (supplied.length !== 1 || Math.abs(supplied[0].mean_before - before) > 1e-12 ||
+      Math.abs(supplied[0].mean_after - after) > 1e-12)
+    throw new Error(`caller-supplied mean does not match reports for ${faction_id}`)
+  if (after < before) throw new Error(`target faction mean regressed: ${faction_id}`)
+}
+const driftHash = new Bun.CryptoHasher('sha256').update(new Uint8Array(await driftFile.arrayBuffer())).digest('hex')
+
+const CLOSE_OUT = {
+  type: 'object',
+  required: ['mode', 'decision', 'anti_conditions', 'required_changes'],
+  properties: {
+    mode: { const: 'close' },
+    decision: { enum: ['accept', 'revise', 'reject'] },
+    anti_conditions: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'pass', 'evidence'],
+        properties: {
+          id: { type: 'integer', minimum: 1, maximum: 10 },
+          pass: { type: 'boolean' },
+          evidence: { type: 'string' },
+        },
+      },
+    },
+    required_changes: { type: 'array', items: { type: 'string' } },
+  },
+};
+phase('Review')
+const closeReview = await runAgent(
+  `Repo root ${args.repo_root} was hard-verified. Perform the campaign-wide close review. ` +
+  `Check each of the ten anti-conditions against these machine-verified artifacts; do not ` +
+  `accept unless all ten have one passing evidence row. Input:\n` + JSON.stringify({
+    mode: 'close', campaign_id: args.campaign_id, worklist: args.worklist,
+    faction_means: args.faction_means,
+    gates: { preflight, parity }, prose_diff: { ...drift, artifact_sha256: driftHash },
+  }),
+  { agent: 'inquisitor', schema: CLOSE_OUT, label: `close:${args.campaign_id}` }
+)
+if (!closeReview) throw new Error('inquisitor close review returned nothing')
+const antiIds = new Set(closeReview.anti_conditions.filter(x => x.pass).map(x => x.id))
+const exactAnti = closeReview.anti_conditions.length === 10 && antiIds.size === 10 &&
+  closeReview.anti_conditions.every(x => x.pass && x.evidence.trim())
+if (closeReview.decision !== 'accept' || closeReview.required_changes.length || !exactAnti)
+  throw new Error(`campaign close rejected: ${closeReview.required_changes.join('; ') || 'anti-condition evidence incomplete'}`)
+await assertSealedHead()
+
+return {
+  campaign_id: args.campaign_id,
+  ready_to_publish: true,
+  publish_commit_id: args.expected_head_commit_id,
+  worklist_size: args.worklist.length,
+  terminal_counts: args.worklist.reduce((out, x) => ({ ...out, [x.status]: (out[x.status] || 0) + 1 }), {}),
+  gates: { preflight, parity },
+  prose_diff: { path: args.prose_diff_path, sha256: driftHash, changed: drift.changes.length },
+  close_review: closeReview,
+  provenance: { workflow: 'dsl-close-campaign', required_roles: ['inquisitor'] },
+}

--- a/.omp/skills/dsl-campaign/workflows/wf-prioritize.js
+++ b/.omp/skills/dsl-campaign/workflows/wf-prioritize.js
@@ -8,9 +8,13 @@ export const meta = {
 }
 
 // args: {
+//   repo_root: string,
+//   campaign_id: string,
+//   campaign_base_commit_id: string,  // immutable ancestor from which the campaign range starts
 //   scout_shapes: [{ shape: {effect_type|condition_type|pattern, example_ability_id?}, exclude_factions?: [] }],
 //   artifacts: {                       // paths + small excerpts the driver prepared
 //     roundtrip_report_path,           // the fresh --faction all report (json)
+//     roundtrip_report_sha256,         // hash captured when baseline was created
 //     sub080_summary,                  // driver-computed: [{faction, mean, n_below, worst: [{id, cos}]}]
 //     loop_state_paths,                // _private/loop-state/*.md in THIS workspace
 //     registry_excerpt,                // campaigns[] statuses + blocked_shapes[] (dedup source)
@@ -23,15 +27,72 @@ export const meta = {
 // The runtime may deliver args as a JSON string — normalize before touching fields.
 if (typeof args === 'string') args = JSON.parse(args)
 if (!args || !args.artifacts) throw new Error('args.artifacts required')
+if (!args.repo_root) throw new Error('args.repo_root required (workspace identity is enforced, not advisory)')
+if (!args.campaign_id || !args.campaign_base_commit_id)
+  throw new Error('args.campaign_id and args.campaign_base_commit_id required')
 const CAP = args.worklist_cap || 30
 if (CAP > 40) throw new Error(`worklist_cap ${CAP} exceeds the hard cap of 40`)
-// Pin every agent to the loop workspace: subagents inherit the DRIVER session's cwd,
-// which may be a different checkout of this repo (a parallel session's working copy).
-const PRE = args.repo_root
-  ? `Repo root: ${args.repo_root} — cd there first; run every command and resolve every ` +
-    `relative path (including ../40kdc-abilities and ../40kdc-embeddings) against it. ` +
-    `Never read or write any other checkout of this repo.\n`
-  : ''
+const quote = s => `'${String(s).replaceAll("'", "'\\''")}'`
+const ROLE_MANIFEST = ['arch-magos', 'chronomancer', 'cogitator', 'data-enginseer', 'eversor',
+  'inquisitor', 'kroot-flesh-shaper', 'kroot-lone-spear', 'kroot-trail-shaper',
+  'kroot-war-shaper', 'psyker', 'skitarius', 'swarmlord', 'target-dummy', 'vox-hound', 'warpsmith']
+function resultText(v) {
+  if (typeof v === 'string') return v
+  if (!v) return ''
+  if (typeof v.text === 'string') return v.text
+  if (typeof v.output === 'string') return v.output
+  if (typeof v.stdout === 'string') return v.stdout
+  if (Array.isArray(v.content)) return v.content.map(x => typeof x === 'string' ? x : (x.text || '')).join('\n')
+  return ''
+}
+const runAgent = (prompt, options) => agent(prompt, {
+  ...options, model: 'openai-codex/gpt-5.6-luna', schemaMode: 'strict',
+})
+async function assertWorkspace() {
+  const root = quote(args.repo_root)
+  const check = await tool.bash({ command:
+    `set -eu; expected=$(cd ${root} && pwd -P); ` +
+    `test "$(pwd -P)" = "$expected"; test "$(jj root)" = "$expected"; ` +
+    `test -f AGENTS.md; test -f .omp/skills/dsl-campaign/SKILL.md; ` +
+    `for role in ${ROLE_MANIFEST.map(quote).join(' ')}; do file=".omp/agents/$role.md"; ` +
+    `test -f "$file"; model=$(sed -n 's/^model: //p' "$file"); test "$model" = "openai-codex/gpt-5.6-luna"; done; ` +
+    `base=$(jj log -r ${quote(args.campaign_base_commit_id)} --no-graph -T 'commit_id'); ` +
+    `test "$base" = ${quote(args.campaign_base_commit_id)}; ` +
+    `test "$(jj log -r ${quote(args.campaign_base_commit_id)}'::@' --no-graph -T 'commit_id ++ "\\n"' | tail -n 1)" != ""; ` +
+    `jj log -r ${quote(args.campaign_base_commit_id)}'::@' --no-graph -T 'commit_id ++ "\\n"' | grep -Fxq "$(jj log -r @ --no-graph -T 'commit_id')"; ` +
+    `grep -q '40kdc-data' AGENTS.md; printf '__DSL_WORKSPACE_OK__:%s\\n' "$expected"`, timeout: 20 })
+  if (!resultText(check).includes('__DSL_WORKSPACE_OK__'))
+    throw new Error(`workspace preflight failed: cwd and jj root must both equal ${args.repo_root}`)
+  return { repo_root: args.repo_root, verified: true, role_manifest_verified: ROLE_MANIFEST }
+}
+const workspace = await assertWorkspace()
+const reportPath = args.artifacts.roundtrip_report_path
+if (!reportPath || !args.artifacts.roundtrip_report_sha256)
+  throw new Error('fresh roundtrip report path + sha256 are required')
+const reportFile = Bun.file(reportPath)
+if (!(await reportFile.exists())) throw new Error(`roundtrip report not found: ${reportPath}`)
+const reportHash = new Bun.CryptoHasher('sha256').update(new Uint8Array(await reportFile.arrayBuffer())).digest('hex')
+if (reportHash !== args.artifacts.roundtrip_report_sha256)
+  throw new Error('roundtrip report hash changed after baseline creation')
+function extractRoundtripRows(report) {
+  if (!report || report.kind !== 'roundtrip' || !Array.isArray(report.abilities))
+    throw new Error('expected a kind:roundtrip report with abilities[]')
+  const rows = report.abilities.map(row => {
+    if (typeof row.ability_id !== 'string' || typeof row.faction !== 'string' ||
+        !Number.isFinite(row.score) || typeof row.english !== 'string')
+      throw new Error('roundtrip ability row lacks ability_id, faction, score, or english')
+    return { faction_id: row.faction, ability_id: row.ability_id, cosine: row.score,
+      describer_sha256: new Bun.CryptoHasher('sha256').update(row.english).digest('hex') }
+  })
+  rows.sort((a, b) => `${a.faction_id}/${a.ability_id}`.localeCompare(`${b.faction_id}/${b.ability_id}`))
+  const keys = new Set(rows.map(x => `${x.faction_id}/${x.ability_id}`))
+  if (!rows.length || keys.size !== rows.length) throw new Error('roundtrip report has no unique scored/rendered ability rows')
+  return rows
+}
+const baselineRows = extractRoundtripRows(await reportFile.json())
+const baselineRowsSha256 = new Bun.CryptoHasher('sha256').update(JSON.stringify(baselineRows)).digest('hex')
+const PRE = `Verified repo root: ${args.repo_root}. The workflow hard-checked that its cwd and jj root ` +
+  `match this path. Run every command there; never read or write another checkout.\n`
 
 // ---- frozen Output contracts, transcribed to JSON Schema (do not redesign) ----
 const SWARMLORD_OUT = {
@@ -53,8 +114,9 @@ const INQUISITOR_OUT = {
   type: 'object', required: ['mode', 'priorities'],
   properties: {
     mode: { enum: ['curate', 'review'] },
-    priorities: { type: 'array', items: { type: 'object', required: ['target', 'reason', 'expected_gain'],
-      properties: { target: { type: 'string' }, reason: { type: 'string' },
+    priorities: { type: 'array', items: { type: 'object', required: ['target', 'faction_id', 'ability_id', 'cos_start', 'reason', 'expected_gain'],
+      properties: { target: { type: 'string' }, faction_id: { type: 'string' }, ability_id: { type: 'string' },
+        cos_start: { type: 'number' }, reason: { type: 'string' },
         expected_gain: { enum: ['fidelity', 'coverage', 'lever', 'schema-unblock'] } } } },
     reviews: { type: 'array', items: { type: 'object', additionalProperties: true } },
     inbox_updates: { type: 'array', items: { type: 'object', additionalProperties: true,
@@ -65,16 +127,16 @@ const INQUISITOR_OUT = {
 
 phase('Scout')
 const scouts = (await parallel((args.scout_shapes || []).map(s => () =>
-  agent(
+  runAgent(
     PRE + `Scout the cross-faction family for this shape. estimated_family_size counts exact+near only ` +
     `— stretches don't justify shapes. Input:\n` + JSON.stringify(s),
-    { agentType: 'swarmlord', phase: 'Scout', schema: SWARMLORD_OUT,
+    { agent: 'swarmlord', schema: SWARMLORD_OUT,
       label: `scout:${s.shape.effect_type || s.shape.condition_type || s.shape.pattern}` }
   )
 ))).filter(Boolean)
 
 phase('Curate')
-const curation = await agent(
+const curation = await runAgent(
   PRE + `Curate the next campaign. Pick ONE coherent worklist chunk (≤ ${CAP} abilities) from the ` +
   `sub-0.80-cosine corpus: per-faction worst tail, a swarmlord family (exact+near, family size ≥ 4), ` +
   `or an inbox schema-unblock. Do not re-propose anything in registry blocked_shapes (its reopen_when ` +
@@ -90,10 +152,37 @@ const curation = await agent(
       agent_outputs: scouts,
     },
   }),
-  { agentType: 'inquisitor', phase: 'Curate', schema: INQUISITOR_OUT, label: 'curate' }
+  { agent: 'inquisitor', schema: INQUISITOR_OUT, label: 'curate' }
 )
 if (!curation) throw new Error('inquisitor returned nothing — cannot pick a campaign')
+if (!curation.priorities.length) throw new Error('inquisitor returned an empty worklist')
+if (curation.priorities.length > CAP)
+  throw new Error(`inquisitor returned ${curation.priorities.length} priorities, above cap ${CAP}`)
+const worklist = curation.priorities.map(x => ({ faction_id: x.faction_id, ability_id: x.ability_id, cos_start: x.cos_start }))
+  .sort((a, b) => `${a.faction_id}/${a.ability_id}`.localeCompare(`${b.faction_id}/${b.ability_id}`))
+const worklistKeys = new Set(worklist.map(x => `${x.faction_id}/${x.ability_id}`))
+if (worklistKeys.size !== worklist.length || worklist.some(x => !x.faction_id || !x.ability_id || !Number.isFinite(x.cos_start)))
+  throw new Error('inquisitor returned duplicate or incomplete faction/ability worklist rows')
+for (const item of worklist) {
+  if (item.cos_start >= 0.80)
+    throw new Error(`curated target is not in the sub-0.80 corpus: ${item.faction_id}/${item.ability_id}`)
+  const source = baselineRows.find(x => x.faction_id === item.faction_id && x.ability_id === item.ability_id)
+  if (!source || source.cosine !== item.cos_start)
+    throw new Error(`curated cos_start is not present in baseline report for ${item.faction_id}/${item.ability_id}`)
+}
+const campaignManifest = { campaign_id: args.campaign_id,
+  campaign_base_commit_id: args.campaign_base_commit_id, baseline_sha256: reportHash,
+  baseline_rows_sha256: baselineRowsSha256, worklist }
+const campaignManifestJson = JSON.stringify(campaignManifest)
+const campaignManifestSha256 = new Bun.CryptoHasher('sha256').update(campaignManifestJson).digest('hex')
 
 log(`curated: ${curation.priorities.length} priorities, ${scouts.length} families scouted` +
   (curation.escalate_to_user && curation.escalate_to_user.length ? `, ${curation.escalate_to_user.length} escalation(s)` : ''))
-return { scouts, curation }
+return {
+  scouts, curation, workspace,
+  artifacts: { roundtrip_report_path: reportPath, roundtrip_report_sha256: reportHash },
+  campaign_manifest: campaignManifest,
+  campaign_manifest_json: campaignManifestJson,
+  campaign_manifest_sha256: campaignManifestSha256,
+  provenance: { workflow: 'dsl-prioritize', required_roles: ['swarmlord', 'inquisitor'] },
+}

--- a/.omp/skills/dsl-campaign/workflows/wf-review-batch.js
+++ b/.omp/skills/dsl-campaign/workflows/wf-review-batch.js
@@ -1,0 +1,107 @@
+export const meta = {
+  name: 'dsl-review-batch',
+  description: 'Strict inquisitor batch review with independently validated immutable evidence',
+  phases: [{ title: 'Review', detail: 'inquisitor emits exactly one terminal review per requested key' }],
+}
+
+if (typeof args === 'string') args = JSON.parse(args)
+if (!args?.repo_root || !args.campaign_id || !args.batch_id || !args.campaign_manifest_sha256 ||
+    !args.candidate_commit_id || !args.candidate_dsl_hashes || !Array.isArray(args.faction_ids) ||
+    !args.faction_ids.length || !Array.isArray(args.ability_keys) || !args.ability_keys.length)
+  throw new Error('complete campaign/manifest/candidate/hash/faction/key binding required')
+if (!args.author_artifact || !args.verify_artifact || !args.rescore_artifact || !args.agent_outputs)
+  throw new Error('author, verify, rescore, and agent_outputs review evidence required')
+const keys = [...args.ability_keys].sort()
+if (new Set(keys).size !== keys.length || Object.keys(args.candidate_dsl_hashes).sort().some((x, i) => x !== keys[i]) ||
+    Object.keys(args.candidate_dsl_hashes).length !== keys.length) throw new Error('candidate hashes must exactly cover keys')
+const factions = new Set(args.faction_ids)
+if (keys.some(key => !key.includes('/') || !factions.has(key.slice(0, key.indexOf('/')))))
+  throw new Error('ability keys contain an undeclared faction')
+const canonicalJson = value => value === null || typeof value !== 'object' ? JSON.stringify(value)
+  : Array.isArray(value) ? `[${value.map(canonicalJson).join(',')}]`
+    : `{${Object.keys(value).sort().map(k => `${JSON.stringify(k)}:${canonicalJson(value[k])}`).join(',')}}`
+const hashBytes = bytes => new Bun.CryptoHasher('sha256').update(bytes).digest('hex')
+const hashCanonical = value => hashBytes(canonicalJson(value))
+async function readHashed(ref, label) {
+  if (!ref || typeof ref.path !== 'string' || typeof ref.sha256 !== 'string') throw new Error(`${label} artifact ref incomplete`)
+  const file = Bun.file(ref.path)
+  if (!(await file.exists())) throw new Error(`${label} artifact missing`)
+  const bytes = new Uint8Array(await file.arrayBuffer())
+  if (hashBytes(bytes) !== ref.sha256) throw new Error(`${label} file hash mismatch`)
+  return { json: JSON.parse(new TextDecoder().decode(bytes)), file_sha256: ref.sha256 }
+}
+function exactKeys(actual, label) {
+  const sorted = [...(actual || [])].sort()
+  if (sorted.length !== keys.length || new Set(sorted).size !== keys.length || sorted.some((x, i) => x !== keys[i]))
+    throw new Error(`${label} keys mismatch`)
+}
+async function envelope(ref, kind) {
+  const artifact = await readHashed(ref, kind)
+  const { binding, payload } = artifact.json
+  const phaseCommit = kind === 'author' ? 'author_candidate_commit_id' : 'candidate_commit_id'
+  const expectedCommit = kind === 'author' ? ref.author_candidate_commit_id : args.candidate_commit_id
+  if (!binding || binding.kind !== kind || binding.campaign_id !== args.campaign_id || binding.batch_id !== args.batch_id ||
+      binding.campaign_manifest_sha256 !== args.campaign_manifest_sha256 || binding[phaseCommit] !== expectedCommit ||
+      ref[phaseCommit] !== expectedCommit || binding.payload_sha256 !== ref.payload_sha256 ||
+      binding.payload_sha256 !== hashBytes(JSON.stringify(payload))) throw new Error(`${kind} envelope binding mismatch`)
+  exactKeys(binding.ability_keys, kind); exactKeys(ref.ability_keys, `${kind} ref`)
+  if (canonicalJson(binding.candidate_dsl_hashes) !== canonicalJson(args.candidate_dsl_hashes))
+    throw new Error(`${kind} candidate hashes mismatch`)
+  return { payload, file_sha256: artifact.file_sha256, payload_sha256: binding.payload_sha256 }
+}
+const author = await envelope(args.author_artifact, 'author')
+const verify = await envelope(args.verify_artifact, 'verify')
+if (verify.payload.pass !== true) throw new Error('verification payload did not pass')
+const rescore = await readHashed(args.rescore_artifact, 'rescore')
+const rb = args.rescore_artifact.binding
+if (!rb || rb.kind !== 'rescore' || rb.campaign_id !== args.campaign_id || rb.batch_id !== args.batch_id ||
+    rb.campaign_manifest_sha256 !== args.campaign_manifest_sha256 || rb.candidate_commit_id !== args.candidate_commit_id ||
+    rb.payload_sha256 !== rescore.file_sha256) throw new Error('rescore reference binding mismatch')
+exactKeys(rb.ability_keys, 'rescore'); exactKeys(args.rescore_artifact.ability_keys || rb.ability_keys, 'rescore ref')
+if (canonicalJson(rb.candidate_dsl_hashes) !== canonicalJson(args.candidate_dsl_hashes) ||
+    canonicalJson(args.rescore_artifact.candidate_dsl_hashes || rb.candidate_dsl_hashes) !== canonicalJson(args.candidate_dsl_hashes))
+  throw new Error('rescore candidate hashes mismatch')
+if (rescore.json.kind !== 'roundtrip' || !Array.isArray(rescore.json.abilities) || !rescore.json.abilities.length)
+  throw new Error('rescore is not a nonempty roundtrip report')
+const scored = rescore.json.abilities.map(row => `${row.faction}/${row.ability_id}`).sort()
+if (scored.length !== keys.length || scored.some((x, i) => x !== keys[i]) ||
+    rescore.json.abilities.some(row => !Number.isFinite(row.score) || typeof row.english !== 'string'))
+  throw new Error('rescore report does not exactly cover keys with actual roundtrip rows')
+const evidence_digests = {
+  author_file_sha256: author.file_sha256, author_payload_sha256: author.payload_sha256,
+  verify_file_sha256: verify.file_sha256, verify_payload_sha256: verify.payload_sha256,
+  rescore_file_sha256: rescore.file_sha256, agent_outputs_sha256: hashCanonical(args.agent_outputs),
+}
+const q = s => `'${String(s).replaceAll("'", "'\\''")}'`
+async function assertWorkspace() {
+  const check = await tool.bash({ command: `set -eu; expected=$(cd ${q(args.repo_root)} && pwd -P); ` +
+    `test "$(pwd -P)" = "$expected"; test "$(jj root)" = "$expected"; ` +
+    `test "$(jj log -r @ --no-graph -T 'commit_id')" = ${q(args.candidate_commit_id)}; ` +
+    `test "$(sed -n 's/^model: //p' .omp/agents/inquisitor.md)" = openai-codex/gpt-5.6-luna`, timeout: 30 })
+  if (check?.hasError || check?.details?.exitCode > 0 || check?.exitCode > 0) throw new Error('review workspace/candidate check failed')
+}
+await assertWorkspace()
+const REVIEW_OUT = { type: 'object', additionalProperties: false, required: ['mode', 'reviews'], properties: {
+  mode: { const: 'review' }, reviews: { type: 'array', items: { type: 'object', additionalProperties: false,
+    required: ['agent', 'faction_id', 'ability_id', 'verdict', 'required_changes'], properties: {
+      agent: { type: 'string' }, faction_id: { type: 'string' }, ability_id: { type: 'string' },
+      verdict: { enum: ['accept', 'revise', 'reject'] }, required_changes: { type: 'array', items: { type: 'string' } } } } } } }
+phase('Review')
+const review = await agent(`Perform mode:review over exactly these keys using only validated payloads. Input:\n` + JSON.stringify({
+  mode: 'review', campaign_id: args.campaign_id, batch_id: args.batch_id, ability_keys: keys,
+  candidate_commit_id: args.candidate_commit_id, candidate_dsl_hashes: args.candidate_dsl_hashes,
+  author_payload: author.payload, verify_payload: verify.payload, rescore_report: rescore.json,
+  agent_outputs: args.agent_outputs,
+}), { agent: 'inquisitor', model: 'openai-codex/gpt-5.6-luna', schemaMode: 'strict', schema: REVIEW_OUT, label: `review:${args.batch_id}` })
+if (!review) throw new Error('inquisitor returned nothing')
+const reviewed = review.reviews.map(x => `${x.faction_id}/${x.ability_id}`).sort()
+if (reviewed.length !== keys.length || new Set(reviewed).size !== keys.length || reviewed.some((x, i) => x !== keys[i]))
+  throw new Error('review must have exactly one terminal row per key')
+if (review.reviews.some(x => x.verdict === 'accept' && x.required_changes.length))
+  throw new Error('accept review cannot contain required_changes')
+await assertWorkspace()
+const payload_sha256 = hashBytes(JSON.stringify(review))
+return { binding: { kind: 'review', campaign_id: args.campaign_id, batch_id: args.batch_id,
+  campaign_manifest_sha256: args.campaign_manifest_sha256, ability_keys: keys,
+  faction_ids: [...args.faction_ids].sort(), candidate_commit_id: args.candidate_commit_id,
+  candidate_dsl_hashes: args.candidate_dsl_hashes, evidence_digests, payload_sha256 }, payload: review }

--- a/.omp/skills/dsl-campaign/workflows/wf-shape-scout.js
+++ b/.omp/skills/dsl-campaign/workflows/wf-shape-scout.js
@@ -11,8 +11,11 @@ export const meta = {
 }
 
 // args: {
-//   repo_root?,
-//   seed: { ability_id, faction_id, raw_text?, resisted_schema? },  // the needs-schema ability
+//   repo_root: string,
+//   campaign_id: string,
+//   campaign_manifest_sha256: string,
+//   campaign_manifest_path: string, // frozen; discoveries are next-campaign only
+//   seed: { ability_id, faction_id, raw_text?, evidence_packet?, architecture?, resisted_schema? },
 //   family_threshold?: 4,      // faithful family bar (exact+near, flatten-excluded) — the shape gate
 //   max_rounds?: 3,            // cyclical review rounds before forcing terminal
 // }
@@ -30,18 +33,62 @@ export const meta = {
 
 if (typeof args === 'string') args = JSON.parse(args)
 if (!args || !args.seed || !args.seed.ability_id) throw new Error('args.seed.ability_id required')
+if (!args.campaign_id || !args.campaign_manifest_sha256 || !args.campaign_manifest_path)
+  throw new Error('campaign_id, campaign_manifest_path, and campaign_manifest_sha256 required')
+const manifestFile = Bun.file(args.campaign_manifest_path)
+if (!(await manifestFile.exists())) throw new Error('campaign manifest not found')
+const manifestBytes = new Uint8Array(await manifestFile.arrayBuffer())
+if (new Bun.CryptoHasher('sha256').update(manifestBytes).digest('hex') !== args.campaign_manifest_sha256)
+  throw new Error('campaign manifest hash mismatch')
+const campaignManifest = JSON.parse(new TextDecoder().decode(manifestBytes))
+if (campaignManifest.campaign_id !== args.campaign_id || !Array.isArray(campaignManifest.worklist))
+  throw new Error('campaign manifest identity/worklist mismatch')
+const MANIFEST_KEYS = new Set(campaignManifest.worklist.map(x => `${x.faction_id}/${x.ability_id}`))
+const SEED_KEY = `${args.seed.faction_id}/${args.seed.ability_id}`
+if (MANIFEST_KEYS.size !== campaignManifest.worklist.length || !MANIFEST_KEYS.has(SEED_KEY))
+  throw new Error('shape seed must occur exactly once in the frozen campaign manifest')
+if (!args.repo_root) throw new Error('args.repo_root required (workspace identity is enforced, not advisory)')
 const THRESHOLD = args.family_threshold || 4
 const MAX_ROUNDS = args.max_rounds || 3
-// Pin every agent to the loop workspace (subagents inherit the DRIVER cwd, which may be another checkout).
-const PRE = args.repo_root
-  ? `Repo root: ${args.repo_root} — cd there first; run every command and resolve every ` +
-    `relative path (including ../40kdc-abilities and ../40kdc-embeddings) against it. ` +
-    `Never read or write any other checkout of this repo.\n`
-  : ''
+if (THRESHOLD !== 4) throw new Error('family_threshold is fixed at 4 and cannot be weakened')
+if (!Number.isInteger(MAX_ROUNDS) || MAX_ROUNDS < 1 || MAX_ROUNDS > 3)
+  throw new Error('max_rounds must be an integer from 1 through 3')
+const quote = s => `'${String(s).replaceAll("'", "'\\''")}'`
+const ROLE_MANIFEST = ['arch-magos', 'chronomancer', 'cogitator', 'data-enginseer', 'eversor',
+  'inquisitor', 'kroot-flesh-shaper', 'kroot-lone-spear', 'kroot-trail-shaper',
+  'kroot-war-shaper', 'psyker', 'skitarius', 'swarmlord', 'target-dummy', 'vox-hound', 'warpsmith']
+function resultText(v) {
+  if (typeof v === 'string') return v
+  if (!v) return ''
+  if (typeof v.text === 'string') return v.text
+  if (typeof v.output === 'string') return v.output
+  if (typeof v.stdout === 'string') return v.stdout
+  if (Array.isArray(v.content)) return v.content.map(x => typeof x === 'string' ? x : (x.text || '')).join('\n')
+  return ''
+}
+const runAgent = (prompt, options) => agent(prompt, {
+  ...options, model: 'openai-codex/gpt-5.6-luna', schemaMode: 'strict',
+})
+async function assertWorkspace() {
+  const root = quote(args.repo_root)
+  const check = await tool.bash({ command:
+    `set -eu; expected=$(cd ${root} && pwd -P); ` +
+    `test "$(pwd -P)" = "$expected"; test "$(jj root)" = "$expected"; ` +
+    `test -f AGENTS.md; test -f .omp/skills/dsl-campaign/SKILL.md; ` +
+    `for role in ${ROLE_MANIFEST.map(quote).join(' ')}; do file=".omp/agents/$role.md"; ` +
+    `test -f "$file"; model=$(sed -n 's/^model: //p' "$file"); test "$model" = "openai-codex/gpt-5.6-luna"; done; ` +
+    `grep -q '40kdc-data' AGENTS.md; printf '__DSL_WORKSPACE_OK__:%s\\n' "$expected"`, timeout: 20 })
+  if (!resultText(check).includes('__DSL_WORKSPACE_OK__'))
+    throw new Error(`workspace preflight failed: cwd and jj root must both equal ${args.repo_root}`)
+  return { repo_root: args.repo_root, verified: true, role_manifest_verified: ROLE_MANIFEST }
+}
+const workspace = await assertWorkspace()
+const PRE = `Verified repo root: ${args.repo_root}. The workflow hard-checked that its cwd and jj root ` +
+  `match this path. Run every command there; never read or write another checkout.\n`
 
 // ---- frozen Output contracts, transcribed to JSON Schema (mirror the agent output: frontmatter) ----
 const ENGINSEER_OUT = {
-  type: 'object', required: ['matches', 'method'],
+  type: 'object', required: ['matches', 'method', 'evidence_packet'],
   properties: {
     matches: { type: 'array', items: { type: 'object', required: ['ability_id', 'faction', 'raw_text', 'has_dsl'],
       properties: { ability_id: { type: 'string' }, faction: { type: 'string' },
@@ -50,11 +97,41 @@ const ENGINSEER_OUT = {
         other_faction_copies: { type: 'array', items: { type: 'string' } } } } },
     comparison: { type: ['object', 'null'], additionalProperties: true }, method: { enum: ['index-lookup', 'grep', 'embeddings'] },
     notes: { type: 'array', items: { type: 'string' } },
+    evidence_packet: { type: ['object', 'null'], additionalProperties: true },
   },
+}
+function evidencePayload(packet) {
+  return {
+    ability_id: packet.ability_id, faction_id: packet.faction_id, source_hash: packet.source_hash,
+    clauses: packet.clauses.map(c => ({ clause_id: c.clause_id, start: c.start, end: c.end,
+      source_text_hash: c.source_text_hash, mechanical: c.mechanical, kind: c.kind })),
+    relationships: packet.relationships || [], tables: packet.tables || [],
+  }
+}
+function validateEvidencePacket(packet, source) {
+  if (!packet || packet.ability_id !== args.seed.ability_id || packet.faction_id !== args.seed.faction_id ||
+      !Array.isArray(packet.clauses) || !packet.clauses.length || !packet.source_hash || !packet.packet_hash)
+    return 'missing or misidentified source evidence packet'
+  if (packet.source_hash !== new Bun.CryptoHasher('sha256').update(source).digest('hex'))
+    return 'source evidence hash does not match complete raw text'
+  let cursor = 0
+  const ids = new Set()
+  for (const clause of packet.clauses) {
+    if (!clause.clause_id || ids.has(clause.clause_id) || clause.start !== cursor ||
+        !Number.isInteger(clause.end) || clause.end <= clause.start || clause.end > source.length ||
+        typeof clause.mechanical !== 'boolean' || !clause.kind) return 'invalid clause partition'
+    ids.add(clause.clause_id)
+    const hash = new Bun.CryptoHasher('sha256').update(source.slice(clause.start, clause.end)).digest('hex')
+    if (hash !== clause.source_text_hash) return `source slice hash mismatch for ${clause.clause_id}`
+    cursor = clause.end
+  }
+  if (cursor !== source.length) return 'clause partition does not cover complete raw text'
+  const packetHash = new Bun.CryptoHasher('sha256').update(JSON.stringify(evidencePayload(packet))).digest('hex')
+  return packetHash === packet.packet_hash ? null : 'evidence packet hash mismatch'
 }
 const FLESH_OUT = {
   type: 'object',
-  required: ['seed_ability_id', 'mechanic', 'decomposition', 'retrieval', 'proposed_shape', 'nearest_existing_shapes', 'self_grade'],
+  required: ['seed_ability_id', 'mechanic', 'decomposition', 'retrieval', 'proposed_shape', 'nearest_existing_shapes', 'internal_family', 'self_grade'],
   properties: {
     seed_ability_id: { type: 'string' }, mechanic: { type: 'string' },
     decomposition: { type: 'object', required: ['who', 'when', 'what'],
@@ -67,23 +144,30 @@ const FLESH_OUT = {
         schema_sketch: { type: 'object', additionalProperties: true }, seed_encoding: { type: 'object', additionalProperties: true } } },
     nearest_existing_shapes: { type: 'array', items: { type: 'object', required: ['shape', 'why_rejected', 'flatten_risk'],
       properties: { shape: { type: 'string' }, why_rejected: { type: 'string' }, flatten_risk: { enum: ['high', 'medium', 'low'] } } } },
+    internal_family: { type: 'array', items: { type: 'object',
+      required: ['member', 'clause_ids', 'shared_contract_id', 'parent_id', 'homogeneous_contract'],
+      properties: { member: { type: 'string' }, clause_ids: { type: 'array', items: { type: 'string' } },
+        shared_contract_id: { type: 'string' }, parent_id: { type: 'string' }, homogeneous_contract: { type: 'boolean' } } } },
     self_grade: { type: 'object', required: ['verdict', 'confidence'],
       properties: { verdict: { enum: ['new-shape', 'existing-fits', 'singleton'] }, confidence: { type: 'number' }, concerns: { type: 'array', items: { type: 'string' } } } },
   },
 }
 const LONESPEAR_OUT = {
-  type: 'object', required: ['proposed_shape_name', 'swarmlord_sweep', 'coverage', 'faithful_family_size', 'confidence'],
+  type: 'object', required: ['proposed_shape_name', 'swarmlord_sweep', 'coverage', 'faithful_family_size', 'internal_family_size', 'confidence'],
   properties: {
     proposed_shape_name: { type: 'string' }, swarmlord_sweep: { type: ['object', 'null'], additionalProperties: true },
-    coverage: { type: 'array', items: { type: 'object', required: ['ability_id', 'faction', 'fit'],
+    coverage: { type: 'array', items: { type: 'object', required: ['ability_id', 'faction', 'fit', 'evidence'],
       properties: { ability_id: { type: 'string' }, faction: { type: 'string' },
         fit: { enum: ['faithful', 'needs-param', 'would-flatten'] },
+        evidence: { type: 'string' },
         match_strength: { enum: ['exact', 'near', 'stretch'] },
         param_needed: { type: ['string', 'null'] }, flatten_reason: { type: ['string', 'null'] } } } },
     faithful_family_size: { type: 'integer' },
+    internal_family_size: { type: 'integer' },
     parameter_deltas: { type: 'array', items: { type: 'object', required: ['param', 'change', 'unblocks'],
       properties: { param: { type: 'string' }, change: { type: 'string' }, unblocks: { type: 'array', items: { type: 'string' } } } } },
-    members_needing_own_shape: { type: 'array', items: { type: 'object', additionalProperties: true } }, confidence: { type: 'number' },
+    members_needing_own_shape: { type: 'array', items: { type: 'object', required: ['ability_id', 'why'],
+      properties: { ability_id: { type: 'string' }, why: { type: 'string' } } } }, confidence: { type: 'number' },
   },
 }
 const TRAIL_OUT = {
@@ -96,7 +180,15 @@ const TRAIL_OUT = {
     shared_helpers: { type: 'array', items: { type: 'string' } }, port_notes: { type: 'array', items: { type: 'string' } },
     conformance_cases: { type: 'array', items: { type: 'object', required: ['case', 'expected_phrase'],
       properties: { case: { type: 'string' }, expected_phrase: { type: 'string' } } } },
-    psyker_read: { type: ['object', 'null'], additionalProperties: true },
+    psyker_read: { type: ['object', 'null'], additionalProperties: false,
+      required: ['faction_id', 'findings', 'clean'], properties: {
+        faction_id: { type: 'string' },
+        findings: { type: 'array', items: { type: 'object', additionalProperties: false,
+          required: ['ability_id', 'describer_output', 'problem', 'player_reading', 'severity'], properties: {
+            ability_id: { type: 'string' }, describer_output: { type: 'string' },
+            problem: { enum: ['ambiguous', 'misleading', 'ungrammatical', 'jargon-leak', 'missing-clause-signal'] },
+            player_reading: { type: 'string' }, severity: { type: 'integer', minimum: 1, maximum: 3 } } } },
+        clean: { type: 'array', items: { type: 'string' } } } },
     cost: { type: 'object', required: ['spec_bump', 'schema_change', 'files'],
       properties: { spec_bump: { type: 'boolean' }, schema_change: { type: 'boolean' },
         files: { type: 'array', items: { type: 'string' } }, conformance_cases: { type: 'integer' } } },
@@ -104,16 +196,42 @@ const TRAIL_OUT = {
   },
 }
 const WAR_OUT = {
-  type: 'object', required: ['proposed_shape_name', 'eversor_refutations', 'swarmlord_recheck', 'findings', 'verdict', 'confidence'],
+  type: 'object', required: ['proposed_shape_name', 'family_mode', 'eversor_refutations', 'swarmlord_recheck',
+    'prior_finding_resolutions', 'findings', 'verdict', 'confidence'],
   properties: {
     proposed_shape_name: { type: 'string' },
-    eversor_refutations: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    family_mode: { enum: ['external', 'internal'] },
+    eversor_refutations: { type: 'array', items: { type: 'object',
+      required: ['ability_id', 'faction', 'internal_child_id', 'refuted', 'divergences'], properties: {
+        ability_id: { type: 'string' }, faction: { type: 'string' }, refuted: { type: 'boolean' },
+        internal_child_id: { type: ['string', 'null'] },
+        divergences: { type: 'array', items: { type: 'object', additionalProperties: true } } } } },
     swarmlord_recheck: { type: ['object', 'null'], additionalProperties: true },
+    prior_finding_resolutions: { type: 'array', items: { type: 'object', additionalProperties: false,
+      required: ['round', 'axis', 'situation', 'resolved', 'evidence'], properties: {
+        round: { type: 'integer', minimum: 1 }, axis: { type: 'string' }, situation: { type: 'string' },
+        resolved: { type: 'boolean' }, evidence: { type: 'string' } } } },
     findings: { type: 'array', items: { type: 'object', required: ['axis', 'severity', 'situation', 'required_change'],
       properties: { axis: { enum: ['sprawl', 'flattening', 'fidelity', 'parity', 'family'] },
         severity: { type: 'integer', minimum: 1, maximum: 3 }, situation: { type: 'string' }, required_change: { type: 'string' } } } },
     verdict: { enum: ['accept', 'revise', 'reject-as-sprawl', 'reject-as-singleton'] },
-    shape_package: { type: ['object', 'null'], additionalProperties: true }, confidence: { type: 'number' },
+    shape_package: { oneOf: [{ type: 'null' }, { type: 'object', additionalProperties: false,
+      required: ['name', 'kind', 'schema_branch', 'parameters', 'seed_encoding', 'describer',
+        'faithful_family', 'parameter_deltas', 'seed_ability_id', 'implementation_matrix'],
+      properties: {
+        name: { type: 'string' }, kind: { enum: ['effect-leaf', 'condition', 'container', 'modifier-extension'] },
+        schema_branch: { type: 'object', additionalProperties: true },
+        parameters: { type: 'array', items: { type: 'object', required: ['name', 'type', 'load_bearing'], additionalProperties: true } },
+        seed_encoding: { type: 'object', additionalProperties: true },
+        describer: { type: 'object', required: ['render_rules', 'conformance_cases'], properties: {
+          render_rules: { type: 'array', minItems: 1, items: { type: 'object', additionalProperties: true } },
+          conformance_cases: { type: 'array', minItems: 1, items: { type: 'object', additionalProperties: true } },
+          port_notes: { type: 'array', items: { type: 'string' } } } },
+        faithful_family: { type: 'array', items: { type: 'object', required: ['ability_id', 'faction', 'fit'],
+          properties: { ability_id: { type: 'string' }, faction: { type: 'string' }, fit: { enum: ['faithful', 'needs-param'] } } } },
+        parameter_deltas: { type: 'array', items: { type: 'object', additionalProperties: true } },
+        seed_ability_id: { type: 'string' }, implementation_matrix: { type: 'object', additionalProperties: true },
+      } }] }, confidence: { type: 'number' },
   },
 }
 
@@ -133,15 +251,23 @@ function assertSpawned(agentLabel, obj, checks) {
 }
 
 phase('Seed')
-const retrieval = await agent(
+const retrieval = await runAgent(
   PRE + `Look up this resisted ability's raw prose and committed DSL. Input:\n` +
   JSON.stringify({ query: { ability_id: args.seed.ability_id, faction_id: args.seed.faction_id } }),
-  { agentType: 'data-enginseer', phase: 'Seed', schema: ENGINSEER_OUT, label: `seed:${args.seed.ability_id}` }
+  { agent: 'data-enginseer', schema: ENGINSEER_OUT, label: `seed:${args.seed.ability_id}` }
 )
 const seedMatches = (retrieval && retrieval.matches) || []
-const match = seedMatches.find(m => m.faction === args.seed.faction_id) || seedMatches[0] || null
-const raw_text = args.seed.raw_text || (match && match.raw_text) || null
-if (!raw_text) return { seed: args.seed, status: 'no-prose', shape_package: null, rounds: [] }
+const exactMatches = seedMatches.filter(m => m.ability_id === args.seed.ability_id && m.faction === args.seed.faction_id)
+const match = exactMatches.length === 1 ? exactMatches[0] : null
+const raw_text = match && match.raw_text
+if (!raw_text) return { seed: args.seed, status: 'no-prose', shape_package: null, rounds: [], workspace,
+  provenance: { workflow: 'dsl-shape-scout', required_roles: ['data-enginseer'] } }
+const evidence_packet = args.seed.evidence_packet || (retrieval && retrieval.evidence_packet) || null
+const packetError = validateEvidencePacket(evidence_packet, raw_text)
+if (packetError) throw new Error(packetError)
+const sourceClauseIds = new Set(evidence_packet.clauses.map(c => c.clause_id))
+if (sourceClauseIds.size !== evidence_packet.clauses.length || sourceClauseIds.has(undefined))
+  throw new Error('shape-scout source evidence has missing or duplicate clause ids')
 
 const rounds = []
 let prior_findings = []   // accumulated across review rounds (thread capture)
@@ -156,7 +282,7 @@ for (let round = 0; round < MAX_ROUNDS; round++) {
       `the last round), and never reintroduce a flattening/sprawl an earlier round already fixed:\n` +
       JSON.stringify(prior_findings)
     : ''
-  const flesh = await agent(
+  const flesh = await runAgent(
     PRE + `Propose a new DSL shape for this resisted mechanic. SPAWN the decomposers (target-dummy, ` +
     `chronomancer, vox-hound) and data-enginseer to ground it. COPY the child JSON outputs verbatim: ` +
     `decomposition.who=target-dummy, decomposition.when=chronomancer, decomposition.what=vox-hound, ` +
@@ -164,55 +290,94 @@ for (let round = 0; round < MAX_ROUNDS; round++) {
     `proof fields. Then prove each nearest existing shape would flatten it (the obelisk/tau collision is ` +
     `the defect to avoid). Input:\n` +
     JSON.stringify({ seed_ability_id: args.seed.ability_id, faction_id: args.seed.faction_id,
-      raw_text, resisted_schema: args.seed.resisted_schema || null, retrieval }) + revision,
-    { agentType: 'kroot-flesh-shaper', phase: 'Shape', schema: FLESH_OUT, label: `flesh:${args.seed.ability_id}#${rn}` }
+      raw_text, evidence_packet, architecture: args.seed.architecture || null,
+      resisted_schema: args.seed.resisted_schema || null, retrieval }) + revision,
+    { agent: 'kroot-flesh-shaper', schema: FLESH_OUT, label: `flesh:${args.seed.ability_id}#${rn}` }
   )
   assertSpawned('kroot-flesh-shaper', flesh, [
-    { path: 'decomposition.what', msg: 'flesh-shaper must spawn the decomposers' },
+    { path: 'decomposition.who', msg: 'flesh-shaper must spawn target-dummy' },
+    { path: 'decomposition.when', msg: 'flesh-shaper must spawn chronomancer' },
+    { path: 'decomposition.what', msg: 'flesh-shaper must spawn vox-hound' },
     { path: 'retrieval', msg: 'flesh-shaper must spawn data-enginseer' },
     { path: 'proposed_shape', msg: 'no shape proposed' },
   ])
+  if (flesh.seed_ability_id !== args.seed.ability_id)
+    throw new Error('flesh-shaper output is bound to another seed')
+  for (const [role, child] of Object.entries(flesh.decomposition)) {
+    if (!child || child.ability_id !== args.seed.ability_id || child.status !== 'resolved' ||
+        !Array.isArray(child.unresolved_clauses) || child.unresolved_clauses.length)
+      throw new Error(`flesh-shaper ${role} child is missing, unresolved, or misidentified`)
+  }
+  const fleshRetrievalMatches = flesh.retrieval?.matches || []
+  if (fleshRetrievalMatches.filter(x => x.ability_id === args.seed.ability_id &&
+    x.faction === args.seed.faction_id).length !== 1 ||
+    validateEvidencePacket(flesh.retrieval?.evidence_packet, raw_text) ||
+    flesh.retrieval.evidence_packet.packet_hash !== evidence_packet.packet_hash)
+    throw new Error('flesh-shaper retrieval is not exactly bound to the seed evidence packet')
   const fverdict = flesh.self_grade && flesh.self_grade.verdict
+  const internalMembers = (flesh.internal_family || []).filter(m => m.homogeneous_contract)
+  const uniqueInternalMembers = new Set(internalMembers.map(m => m.member))
+  const invalidInternal = internalMembers.some(m => !m.member || !m.clause_ids.length ||
+    m.clause_ids.some(id => !sourceClauseIds.has(id)))
+  if (invalidInternal || uniqueInternalMembers.size !== internalMembers.length)
+    throw new Error('internal-family evidence has duplicate members or unknown/empty clause ids')
   if (fverdict === 'existing-fits') {
     rounds.push({ round: rn, flesh, verdict: 'existing-fits' })
-    return { seed: args.seed, status: 'existing-fits', shape_package: null, rounds }
+    return { seed: args.seed, status: 'existing-fits', shape_package: null, rounds, workspace,
+      provenance: { workflow: 'dsl-shape-scout', required_roles: ['data-enginseer', 'kroot-flesh-shaper'] } }
   }
   if (fverdict === 'singleton') {
     rounds.push({ round: rn, flesh, verdict: 'singleton' })
-    status = 'rejected-singleton'
-    break
+    if (uniqueInternalMembers.size < THRESHOLD) { status = 'rejected-singleton'; break }
   }
 
   phase(`Broaden (round ${rn})`)
-  const lone = await agent(
+  const lone = await runAgent(
     PRE + `Broaden coverage for this proposed shape WITHOUT flattening. SPAWN swarmlord for the corpus ` +
     `sweep, then adjudicate each candidate faithful / needs-param / would-flatten. Input:\n` +
     JSON.stringify({ proposed_shape: flesh.proposed_shape, seed_ability_id: args.seed.ability_id,
-      faction_id: args.seed.faction_id }),
-    { agentType: 'kroot-lone-spear', phase: 'Broaden', schema: LONESPEAR_OUT, label: `spear:${args.seed.ability_id}#${rn}` }
+      faction_id: args.seed.faction_id, internal_family: flesh.internal_family }),
+    { agent: 'kroot-lone-spear', schema: LONESPEAR_OUT, label: `spear:${args.seed.ability_id}#${rn}` }
   )
   assertSpawned('kroot-lone-spear', lone, [{ path: 'swarmlord_sweep', msg: 'lone-spear must spawn swarmlord' }])
 
   phase(`Trail (round ${rn})`)
-  const trail = await agent(
+  const trail = await runAgent(
     PRE + `Spec the describer output for this proposed shape across EVERY render form (inline + container; ` +
     `condition lead-in + predicate/negated). SPAWN psyker to cold-read the render. Input:\n` +
     JSON.stringify({ proposed_shape: flesh.proposed_shape,
       lone_spear: { parameter_deltas: lone.parameter_deltas || [], coverage: lone.coverage || [] } }),
-    { agentType: 'kroot-trail-shaper', phase: 'Trail', schema: TRAIL_OUT, label: `trail:${args.seed.ability_id}#${rn}` }
+    { agent: 'kroot-trail-shaper', schema: TRAIL_OUT, label: `trail:${args.seed.ability_id}#${rn}` }
   )
   assertSpawned('kroot-trail-shaper', trail, [
     { path: 'psyker_read', msg: 'trail-shaper must spawn psyker' },
     { path: 'render_rules', msg: 'no render rules specified' },
   ])
+  if (trail.psyker_read.faction_id !== args.seed.faction_id ||
+      trail.psyker_read.findings.some(x => x.ability_id !== args.seed.ability_id) ||
+      trail.psyker_read.clean.some(x => x !== args.seed.ability_id) ||
+      trail.psyker_read.findings.length + trail.psyker_read.clean.length !== 1 ||
+      trail.psyker_read.findings.some(x => x.severity === 3))
+    throw new Error('trail psyker read must exactly cover the seed faction/ability and contain no severity-3 finding')
+  const forms = new Set(trail.render_rules.map(x => x.form))
+  const requiredForms = flesh.proposed_shape.kind === 'condition'
+    ? ['condition-lead-in', 'condition-predicate', 'negated']
+    : flesh.proposed_shape.kind === 'effect-leaf'
+      ? ['inline-single-effect', 'container']
+      : flesh.proposed_shape.kind === 'container'
+        ? ['container'] : ['inline-single-effect', 'container']
+  if (requiredForms.some(form => !forms.has(form)))
+    throw new Error(`render rules omit forms required for ${flesh.proposed_shape.kind}: ${requiredForms.join(', ')}`)
 
   phase(`War (round ${rn})`)
-  const war = await agent(
+  const war = await runAgent(
     PRE + `Adversarially review this proposed shape on all four axes (sprawl / flattening / fidelity-parity / ` +
     `family). SPAWN eversor per sample family member and swarmlord for an INDEPENDENT family recheck. Family ` +
     `threshold is ${THRESHOLD} (exact+near, flatten-excluded). On accept, return a complete shape_package. Input:\n` +
-    JSON.stringify({ flesh, lone_spear: lone, trail, prior_findings, family_threshold: THRESHOLD }),
-    { agentType: 'kroot-war-shaper', phase: 'War', schema: WAR_OUT, label: `war:${args.seed.ability_id}#${rn}` }
+    JSON.stringify({ flesh, lone_spear: lone, trail, prior_findings, family_threshold: THRESHOLD,
+      frozen_manifest_keys: [...MANIFEST_KEYS],
+      package_policy: 'faithful_family is the manifest intersection; report other discoveries for next campaign only' }),
+    { agent: 'kroot-war-shaper', schema: WAR_OUT, label: `war:${args.seed.ability_id}#${rn}` }
   )
   assertSpawned('kroot-war-shaper', war, [
     { path: 'eversor_refutations', msg: 'war-shaper must spawn eversor against sample members' },
@@ -222,9 +387,95 @@ for (let round = 0; round < MAX_ROUNDS; round++) {
   rounds.push({ round: rn, flesh, lone, trail, war, verdict: war.verdict })
 
   if (war.verdict === 'accept') {
-    // Enforce the family bar independently of the agent's self-report (anti cosine/coverage laundering).
-    if ((lone.faithful_family_size || 0) < THRESHOLD) { status = 'rejected-singleton'; break }
+    // A shape may have an external cross-ability family OR an internal family of
+    // homogeneous child records in one closed composite mechanic.
+    const faithfulExternal = new Set((lone.coverage || [])
+      .filter(m => ['faithful', 'needs-param'].includes(m.fit) && ['exact', 'near'].includes(m.match_strength) && m.evidence.trim())
+      .map(m => `${m.faction}/${m.ability_id}`))
+    const invalidParamMember = (lone.coverage || []).some(m => m.fit === 'needs-param' &&
+      (!m.param_needed || !(lone.parameter_deltas || []).some(d => d.param === m.param_needed &&
+        (d.unblocks || []).includes(m.ability_id))))
+    if (invalidParamMember) throw new Error('needs-param family member lacks a matching parameter delta')
+    if (lone.faithful_family_size !== faithfulExternal.size ||
+        lone.internal_family_size !== uniqueInternalMembers.size)
+      throw new Error('lone-spear family counts do not match the supplied member evidence')
+    const internalArchitectureCount = args.seed.architecture?.architecture?.internal_family_size ??
+      args.seed.architecture?.internal_family_size ?? 0
+    const architect = args.seed.architecture?.architecture || args.seed.architecture || {}
+    const architectChildren = (architect.local_actions || []).filter(x => x.parent_closed)
+    const architectIds = new Set(architectChildren.map(x => x.child_id))
+    const architectClauses = architectChildren.flatMap(x => x.clause_ids || [])
+    const fleshClauses = internalMembers.flatMap(x => x.clause_ids)
+    const oneContract = new Set(architectChildren.map(x => x.shared_contract_id)).size === 1 &&
+      new Set(internalMembers.map(x => x.shared_contract_id)).size === 1 &&
+      architectChildren[0]?.shared_contract_id === internalMembers[0]?.shared_contract_id
+    const oneParent = new Set(architectChildren.map(x => x.parent_id)).size === 1 &&
+      new Set(internalMembers.map(x => x.parent_id)).size === 1 &&
+      architectChildren[0]?.parent_id === internalMembers[0]?.parent_id
+    const internalSetsMatch = architectIds.size === uniqueInternalMembers.size &&
+      [...architectIds].every(id => uniqueInternalMembers.has(id)) &&
+      new Set(architectClauses).size === architectClauses.length &&
+      new Set(fleshClauses).size === fleshClauses.length &&
+      architectClauses.length === fleshClauses.length &&
+      architectClauses.every(id => fleshClauses.includes(id)) && oneContract && oneParent
+    const independentFamily = new Set((war.swarmlord_recheck?.candidates || [])
+      .filter(m => ['exact', 'near'].includes(m.match_strength) && m.evidence && m.evidence.trim())
+      .map(m => `${m.faction}/${m.ability_id}`))
+    if (independentFamily.size !== (war.swarmlord_recheck?.candidates || [])
+      .filter(m => ['exact', 'near'].includes(m.match_strength) && m.evidence && m.evidence.trim()).length)
+      throw new Error('independent family sweep contains duplicate qualifying pairs')
+    const externalQualifies = faithfulExternal.size >= THRESHOLD &&
+      faithfulExternal.size === independentFamily.size &&
+      [...faithfulExternal].every(key => independentFamily.has(key))
+    const internalQualifies = uniqueInternalMembers.size >= THRESHOLD &&
+      internalArchitectureCount === uniqueInternalMembers.size && internalSetsMatch
+    const familyQualifies = externalQualifies || internalQualifies
+    if (!familyQualifies) { status = 'rejected-singleton'; break }
+    const unresolvedPrior = prior_findings.filter(prior => !(war.prior_finding_resolutions || []).some(row =>
+      row.round === prior.round && row.axis === prior.axis && row.situation === prior.situation && row.resolved && row.evidence.trim()))
+    const resolutionKeys = (war.prior_finding_resolutions || []).map(row => `${row.round}\0${row.axis}\0${row.situation}`)
+    const priorKeys = prior_findings.map(row => `${row.round}\0${row.axis}\0${row.situation}`)
+    if (new Set(resolutionKeys).size !== resolutionKeys.length || resolutionKeys.length !== priorKeys.length ||
+        resolutionKeys.some(key => !priorKeys.includes(key)) || unresolvedPrior.length ||
+        (war.findings || []).some(x => x.severity === 3))
+      throw new Error('war-shaper cannot accept with a current severity-3 or unresolved prior finding')
+    if ((war.eversor_refutations || []).length < 2 ||
+        war.eversor_refutations.some(x => x.refuted !== false || x.divergences.length))
+      throw new Error('war-shaper acceptance requires at least two non-refuting eversor results')
     if (!war.shape_package) throw new Error('war-shaper accepted but returned no shape_package (false pass)')
+    const sampled = new Set(war.eversor_refutations.map(x => `${x.faction}/${x.ability_id}`))
+    const sampledChildren = new Set(war.eversor_refutations.map(x => x.internal_child_id).filter(Boolean))
+    const family = new Set(war.shape_package.faithful_family.map(x => `${x.faction}/${x.ability_id}`))
+    const campaignExternal = new Set([...faithfulExternal].filter(key => MANIFEST_KEYS.has(key)))
+    if (!family.has(SEED_KEY)) throw new Error('shape package faithful_family must explicitly contain its seed faction/ability pair')
+    const outOfManifest = [...family].filter(key => !MANIFEST_KEYS.has(key))
+    if (outOfManifest.length)
+      throw new Error(`shape package includes out-of-manifest discoveries (record for next campaign; do not edit/render): ${outOfManifest.join(', ')}`)
+    if (war.family_mode === 'external' && (!externalQualifies || family.size !== campaignExternal.size ||
+        [...family].some(key => !campaignExternal.has(key)) || sampled.size < 2 ||
+        [...sampled].some(key => !faithfulExternal.has(key)) || sampledChildren.size))
+      throw new Error('external family requires two distinct faithful refutations; package is manifest-intersection only')
+    if (war.family_mode === 'internal' && (!internalQualifies || sampled.size !== 1 || !sampled.has(SEED_KEY) ||
+        sampledChildren.size < 2 || [...sampledChildren].some(id => !uniqueInternalMembers.has(id))))
+      throw new Error('internal family requires one seed ability and two distinct machine-bound internal-child refutations')
+    if (war.shape_package.name !== flesh.proposed_shape.name || war.shape_package.kind !== flesh.proposed_shape.kind ||
+        war.shape_package.seed_ability_id !== args.seed.ability_id ||
+        JSON.stringify(war.shape_package.schema_branch) !== JSON.stringify(flesh.proposed_shape.schema_sketch) ||
+        JSON.stringify(war.shape_package.parameters) !== JSON.stringify(flesh.proposed_shape.parameters) ||
+        JSON.stringify(war.shape_package.seed_encoding) !== JSON.stringify(flesh.proposed_shape.seed_encoding) ||
+        JSON.stringify(war.shape_package.parameter_deltas) !== JSON.stringify(lone.parameter_deltas) ||
+        JSON.stringify(war.shape_package.describer.render_rules) !== JSON.stringify(trail.render_rules) ||
+        JSON.stringify(war.shape_package.describer.conformance_cases) !== JSON.stringify(trail.conformance_cases))
+      throw new Error('shape_package is inconsistent with the accepted flesh/lone/trail artifacts')
+    const matrix = war.shape_package.implementation_matrix
+    const requiredSurfaces = ['canonical_schema', 'typescript_describer', 'rust_describer',
+      'python_describer', 'go_describer', 'typescript_cruncher', 'rust_cruncher',
+      'python_cruncher', 'go_cruncher', 'conformance', 'spec_version', 'generated_types',
+      'embedded_schemas', 'rust_bundle', 'python_bundle', 'go_bundle', 'version_lockstep', 'data']
+    const missingSurfaces = requiredSurfaces.filter(k => !matrix || !matrix[k] ||
+      matrix[k].required !== true || !Array.isArray(matrix[k].files) || matrix[k].files.length === 0)
+    if (missingSurfaces.length)
+      throw new Error(`war-shaper accepted an incomplete implementation matrix: ${missingSurfaces.join(', ')}`)
     status = 'shipped-ready'
     shape_package = war.shape_package
     break
@@ -236,4 +487,9 @@ for (let round = 0; round < MAX_ROUNDS; round++) {
 }
 
 log(`shape-scout ${args.seed.ability_id}: ${status} after ${rounds.length} round(s)`)
-return { seed: args.seed, status, shape_package, rounds }
+return {
+  seed: args.seed, status, shape_package, rounds, workspace,
+  provenance: { workflow: 'dsl-shape-scout', required_roles: ['data-enginseer', 'kroot-flesh-shaper',
+    'target-dummy', 'chronomancer', 'vox-hound', 'kroot-lone-spear', 'swarmlord',
+    'kroot-trail-shaper', 'psyker', 'kroot-war-shaper', 'eversor'] },
+}

--- a/.omp/skills/dsl-campaign/workflows/wf-verify-batch.js
+++ b/.omp/skills/dsl-campaign/workflows/wf-verify-batch.js
@@ -9,11 +9,22 @@ export const meta = {
 }
 
 // args: {
+//   repo_root: string,
+//   campaign_id: string,
 //   batch_id: string,
+//   campaign_manifest_sha256: string,
+//   candidate_commit_id: string,
+//   expected_candidate_dsl_hashes: { "faction/ability": sha256 },
+//   campaign_base_commit_id?: string, // required for sealed-campaign
+//   baseline_commit_id?: string,      // required for intermediate verification; explicit committed parent
+//   sealed_head?: boolean,           // closure-only: inspect @- after jj new
 //   ability_ids: string[],           // the batch (worklist ids just applied by warpsmith)
 //   faction_ids: string[],           // factions touched by the batch
 //   touched_files: string[],         // data files warpsmith edited
-//   gates?: string[],                // default: all four
+//   allowed_files: string[],         // normalized exact repo-relative paths
+//   decision_kind: "data" | "data-conformance" | "new-shape" | "describer-reword" | "scoring-describer" | "sealed-campaign",
+//   implementation_matrix?: object,  // required and complete for source changes
+//   gates?: string[],                // fixed complete gate set; caller cannot weaken it
 // }
 // Run AFTER warpsmith applied the batch to the working tree and BEFORE the batch
 // commit: cogitator's baseline "committed" diffs working tree vs jj-committed state.
@@ -24,14 +35,223 @@ export const meta = {
 if (typeof args === 'string') args = JSON.parse(args)
 if (!args || !Array.isArray(args.ability_ids) || !args.ability_ids.length) throw new Error('args.ability_ids required')
 if (!Array.isArray(args.faction_ids) || !args.faction_ids.length) throw new Error('args.faction_ids required')
-const GATES = args.gates || ['validate', 'test', 'translate-smoke', 'drift']
-// Pin every agent to the loop workspace: subagents inherit the DRIVER session's cwd,
-// which may be a different checkout of this repo (a parallel session's working copy).
-const PRE = args.repo_root
-  ? `Repo root: ${args.repo_root} — cd there first; run every command and resolve every ` +
-    `relative path (including ../40kdc-abilities and ../40kdc-embeddings) against it. ` +
-    `Never read or write any other checkout of this repo.\n`
-  : ''
+if (!Array.isArray(args.touched_files) || !args.touched_files.length) throw new Error('args.touched_files required')
+if (!args.campaign_id || !args.batch_id || !args.campaign_manifest_sha256 || !args.candidate_commit_id)
+  throw new Error('campaign_id, batch_id, campaign_manifest_sha256, and candidate_commit_id required')
+if (!args.repo_root) throw new Error('args.repo_root required (workspace identity is enforced, not advisory)')
+if (!Array.isArray(args.allowed_files) || !args.allowed_files.length) throw new Error('args.allowed_files required')
+if (!['data', 'data-conformance', 'new-shape', 'describer-reword', 'scoring-describer', 'sealed-campaign'].includes(args.decision_kind))
+  throw new Error('invalid args.decision_kind')
+if (args.sealed_head !== (args.decision_kind === 'sealed-campaign'))
+  throw new Error('sealed_head and decision_kind:sealed-campaign must be used together')
+if (!args.expected_candidate_dsl_hashes || typeof args.expected_candidate_dsl_hashes !== 'object')
+  throw new Error('expected_candidate_dsl_hashes required')
+if (args.sealed_head && !args.campaign_base_commit_id)
+  throw new Error('sealed verification requires campaign_base_commit_id')
+if (!args.sealed_head && !args.baseline_commit_id)
+  throw new Error('intermediate verification requires explicit baseline_commit_id')
+if (args.allowed_files.some(path => path.endsWith('/') || path.startsWith('/') || path.split('/').includes('..')))
+  throw new Error('allowed_files must contain normalized exact repo-relative paths, not prefixes')
+const translateCommands = args.faction_ids.map(f =>
+  `(cd tools && npx tsx src/cli.ts translate ${quoteForCommand(`../data/enrichment/${f}/abilities.json`)})`)
+const FIXED_GATE_COMMANDS = {
+  validate: 'cd tools && npm run validate',
+  test: 'cd tools && npm test',
+  'translate-smoke': translateCommands.join(' && '),
+  drift: 'just verify-regen-stable',
+  'format-lint': 'cargo fmt --all -- --check && test -z "$(gofmt -l go/)" && (cd python && ruff check .)',
+  parity: 'cd tools && npm run codegen:data && npx tsc && cd .. && cargo build --release --bin wh40kdc-runner && ' +
+    '(cd go && go build -o wh40kdc-runner ./cmd/wh40kdc-runner) && ' +
+    'for pair in ts,rust ts,py rust,py ts,go rust,go py,go; do ' +
+    'PATH="$PWD/python/.venv/bin:$PATH" python3 tooling/parity/differ.py --pair "$pair" --quiet; ' +
+    'for area in effect-translation' + (['scoring-describer', 'sealed-campaign'].includes(args.decision_kind) ? ' scoring-translation' : '') + '; do ' +
+    'out=$(mktemp); trap \'rm -f "$out"\' EXIT; PATH="$PWD/python/.venv/bin:$PATH" python3 tooling/parity/differ.py --pair "$pair" --area "$area" --json >"$out"; ' +
+    'python3 - "$out" "$area" <<\'PY\'\nimport json,sys\np=json.load(open(sys.argv[1]))\na=sys.argv[2]\nskipped=p.get("skipped", [])\nif p.get("ok") is not True or not isinstance(p.get("cases_run"), int) or p["cases_run"] <= 0 or a in skipped:\n raise SystemExit(f"fail-closed parity proof for {a}: {p}")\nPY\n' +
+    'rm -f "$out"; trap - EXIT; done; done',
+}
+const GATES = Object.keys(FIXED_GATE_COMMANDS)
+if (args.gates && (args.gates.length !== GATES.length || GATES.some(g => !args.gates.includes(g))))
+  throw new Error('campaign verification gates are fixed and cannot be weakened')
+if (args.faction_ids.length > 1 && args.ability_ids.some(id => !id.includes('/')))
+  throw new Error('multi-faction batches require faction/ability_id keys')
+const quote = s => `'${String(s).replaceAll("'", "'\\''")}'`
+function quoteForCommand(s) { return `'${String(s).replaceAll("'", "'\\''")}'` }
+const ROLE_MANIFEST = ['arch-magos', 'chronomancer', 'cogitator', 'data-enginseer', 'eversor',
+  'inquisitor', 'kroot-flesh-shaper', 'kroot-lone-spear', 'kroot-trail-shaper',
+  'kroot-war-shaper', 'psyker', 'skitarius', 'swarmlord', 'target-dummy', 'vox-hound', 'warpsmith']
+function resultText(v) {
+  if (typeof v === 'string') return v
+  if (!v) return ''
+  if (typeof v.text === 'string') return v.text
+  if (typeof v.output === 'string') return v.output
+  if (typeof v.stdout === 'string') return v.stdout
+  if (Array.isArray(v.content)) return v.content.map(x => typeof x === 'string' ? x : (x.text || '')).join('\n')
+  return ''
+}
+const runAgent = (prompt, options) => agent(prompt, {
+  ...options, model: 'openai-codex/gpt-5.6-luna', schemaMode: 'strict',
+})
+async function assertWorkspaceAndScope() {
+  const root = quote(args.repo_root)
+  const revision = args.sealed_head ? '@-' : '@'
+  const check = await tool.bash({ command:
+    `set -eu; expected=$(cd ${root} && pwd -P); ` +
+    `test "$(pwd -P)" = "$expected"; test "$(jj root)" = "$expected"; ` +
+    `test -f AGENTS.md; grep -q '40kdc-data' AGENTS.md; ` +
+    `for role in ${ROLE_MANIFEST.map(quote).join(' ')}; do file=".omp/agents/$role.md"; ` +
+    `test -f "$file"; model=$(sed -n 's/^model: //p' "$file"); test "$model" = "openai-codex/gpt-5.6-luna"; done; ` +
+    `test "$(jj log -r ${revision} --no-graph -T 'commit_id')" = ${quote(args.candidate_commit_id)}; ` +
+    (!args.sealed_head
+      ? `test "$(jj log -r ${quote(args.baseline_commit_id)} --no-graph -T 'commit_id')" = ${quote(args.baseline_commit_id)}; ` +
+        `test "$(jj log -r ${quote(args.candidate_commit_id)}- --no-graph -T 'commit_id')" = ${quote(args.baseline_commit_id)}; ` +
+        `jj log -r ${quote(args.baseline_commit_id)}'::'${quote(args.candidate_commit_id)} --no-graph -T 'commit_id ++ "\\n"' | grep -Fxq ${quote(args.candidate_commit_id)}; `
+      : '') +
+    `printf '__DSL_WORKSPACE_OK__\\n'; printf '__DSL_CHANGED_BEGIN__\\n'; ` +
+    (args.sealed_head
+      ? `test "$(jj log -r ${quote(args.campaign_base_commit_id)} --no-graph -T 'commit_id')" = ${quote(args.campaign_base_commit_id)}; ` +
+        `jj diff --name-only --from ${quote(args.campaign_base_commit_id)} --to @-; `
+      : `jj diff --name-only -r ${revision}; `) +
+    `printf '__DSL_CHANGED_END__\\n'`, timeout: 30 })
+  const text = resultText(check)
+  if (!text.includes('__DSL_WORKSPACE_OK__'))
+    throw new Error(`workspace preflight failed: cwd and jj root must both equal ${args.repo_root}`)
+  const match = text.match(/__DSL_CHANGED_BEGIN__\s*([\s\S]*?)\s*__DSL_CHANGED_END__/)
+  if (!match) throw new Error('could not read jj changed-path inventory')
+  const changed = match[1].split(/\r?\n/).map(x => x.trim()).filter(Boolean)
+  const generated = path => path === 'tools/src/generated.ts' ||
+    path.startsWith('crates/wh40kdc/schemas/') || path === 'crates/wh40kdc/src/generated.rs' ||
+    path === 'crates/wh40kdc/src/data/bundle.generated.json' ||
+    ['python/src/wh40kdc/_bundle.json', 'python/src/wh40kdc/_spec.py', 'python/src/wh40kdc/_types.py'].includes(path) ||
+    path.startsWith('python/src/wh40kdc/schemas/') ||
+    path.startsWith('go/') && ['bundle.json', 'share_registry.json', 'schemas/', 'spec.go'].some(x => path === `go/${x}` || path.startsWith(`go/${x}`))
+  const dataPath = path => args.faction_ids.some(f => path === `data/enrichment/${f}/abilities.json`)
+  const sourcePath = path => path.startsWith('schemas/enrichment/ability-dsl/') ||
+    path.startsWith('tools/src/translate/') || path.startsWith('tools/src/cruncher/') ||
+    path.startsWith('crates/wh40kdc/src/translate/') || path.startsWith('crates/wh40kdc/src/cruncher/') ||
+    path.startsWith('python/src/wh40kdc/') || path.startsWith('go/translate_') ||
+    path.startsWith('go/cruncher_') || path.startsWith('conformance/') ||
+    ['conformance/SPEC_VERSION', 'tools/package.json', 'crates/wh40kdc/Cargo.toml',
+      'python/src/wh40kdc/_version.py', 'go/version.go', 'Cargo.lock'].includes(path)
+  const outsidePolicy = changed.filter(path => !dataPath(path) && !generated(path) && !sourcePath(path))
+  if (outsidePolicy.length) throw new Error(`changed paths outside fixed campaign policy: ${outsidePolicy.join(', ')}`)
+  const hasConformance = changed.some(path => path.startsWith('conformance/'))
+  const scoringFiles = ['tools/src/translate/scoring.ts', 'python/src/wh40kdc/translate/scoring.py', 'go/translate_scoring.go']
+  const derivedKind = scoringFiles.some(path => changed.includes(path)) ? 'scoring-describer'
+    : hasConformance && changed.some(dataPath) ? 'data-conformance'
+    : changed.some(path => !dataPath(path) && !generated(path)) ? 'source' : 'data'
+  if (args.decision_kind !== 'sealed-campaign' &&
+      (['data', 'data-conformance', 'scoring-describer'].includes(args.decision_kind) ? args.decision_kind : 'source') !== derivedKind)
+    throw new Error(`decision_kind ${args.decision_kind} disagrees with diff-derived ${derivedKind}`)
+  const allowed = path => args.allowed_files.includes(path)
+  const unexpected = changed.filter(path => !allowed(path))
+  if (unexpected.length) throw new Error(`changed paths outside warpsmith allowlist: ${unexpected.join(', ')}`)
+  if (!changed.length) throw new Error('jj changed-path inventory is empty')
+  const undeclared = (args.touched_files || []).filter(path => !changed.includes(path))
+  if (undeclared.length) throw new Error(`declared touched paths absent from jj diff: ${undeclared.join(', ')}`)
+  return { repo_root: args.repo_root, verified: true, role_manifest_verified: ROLE_MANIFEST,
+    changed_files: changed, allowed_files: args.allowed_files, change_kind: derivedKind }
+}
+const workspace = await assertWorkspaceAndScope()
+const PATH_FAMILIES = {
+  data: p => args.faction_ids.some(f => p === `data/enrichment/${f}/abilities.json`),
+  canonical_schema: p => /^schemas\/enrichment\/ability-dsl\/(ability|condition|effect|scope|trigger)\.schema\.json$/.test(p),
+  typescript_describer: p => /^tools\/src\/translate\/(condition|effect|index)\.ts$/.test(p),
+  rust_describer: p => /^crates\/wh40kdc\/src\/translate\/(effect|mod)\.rs$/.test(p),
+  python_describer: p => /^python\/src\/wh40kdc\/translate\/(condition|effect|__init__)\.py$/.test(p),
+  go_describer: p => /^go\/translate_(condition|effect)\.go$/.test(p),
+  typescript_cruncher: p => p === 'tools/src/cruncher/from-dsl.ts',
+  rust_cruncher: p => p === 'crates/wh40kdc/src/cruncher/buffs.rs',
+  python_cruncher: p => p === 'python/src/wh40kdc/cruncher/from_dsl.py',
+  go_cruncher: p => p === 'go/cruncher_from_dsl.go',
+  conformance: p => p.startsWith('conformance/') && p !== 'conformance/SPEC_VERSION' &&
+    !p.startsWith('conformance/scoring-translation/'),
+  scoring_conformance: p => p.startsWith('conformance/scoring-translation/'),
+  spec_version: p => ['conformance/SPEC_VERSION', 'python/src/wh40kdc/_spec.py', 'go/spec.go'].includes(p),
+  generated_types: p => ['tools/src/generated.ts', 'crates/wh40kdc/src/generated.rs',
+    'python/src/wh40kdc/_types.py'].includes(p),
+  typescript_scoring_describer: p => p === 'tools/src/translate/scoring.ts',
+  python_scoring_describer: p => p === 'python/src/wh40kdc/translate/scoring.py',
+  go_scoring_describer: p => p === 'go/translate_scoring.go',
+  embedded_schemas: p => p === 'crates/wh40kdc/schemas/bundled.schema.json' ||
+    p.startsWith('python/src/wh40kdc/schemas/') || p.startsWith('go/schemas/'),
+  rust_bundle: p => p === 'crates/wh40kdc/src/data/bundle.generated.json',
+  python_bundle: p => p === 'python/src/wh40kdc/_bundle.json',
+  go_bundle: p => p === 'go/bundle.json',
+  version_lockstep: p => ['tools/package.json', 'crates/wh40kdc/Cargo.toml',
+    'python/src/wh40kdc/_version.py', 'go/version.go', 'Cargo.lock'].includes(p),
+}
+const REQUIRED = {
+  'new-shape': ['canonical_schema', 'typescript_describer', 'rust_describer', 'python_describer', 'go_describer',
+    'typescript_cruncher', 'rust_cruncher', 'python_cruncher', 'go_cruncher', 'conformance', 'spec_version',
+    'generated_types', 'embedded_schemas', 'rust_bundle', 'python_bundle', 'go_bundle',
+    'version_lockstep', 'data'],
+  'describer-reword': ['typescript_describer', 'rust_describer', 'python_describer', 'go_describer', 'conformance', 'spec_version'],
+  'scoring-describer': ['typescript_scoring_describer', 'python_scoring_describer', 'go_scoring_describer',
+    'scoring_conformance', 'spec_version'],
+  data: ['data', 'rust_bundle', 'python_bundle', 'go_bundle'],
+  'data-conformance': ['data', 'rust_bundle', 'python_bundle', 'go_bundle', 'conformance', 'spec_version'],
+}
+const EXACT_SURFACE_FILES = {
+  data: args.decision_kind === 'sealed-campaign'
+    ? workspace.changed_files.filter(path => PATH_FAMILIES.data(path))
+    : args.faction_ids.map(f => `data/enrichment/${f}/abilities.json`),
+  generated_types: ['tools/src/generated.ts', 'crates/wh40kdc/src/generated.rs',
+    'python/src/wh40kdc/_types.py'],
+  spec_version: ['conformance/SPEC_VERSION', 'python/src/wh40kdc/_spec.py', 'go/spec.go'],
+  rust_bundle: ['crates/wh40kdc/src/data/bundle.generated.json'],
+  python_bundle: ['python/src/wh40kdc/_bundle.json'],
+  go_bundle: ['go/bundle.json'],
+  version_lockstep: ['tools/package.json', 'crates/wh40kdc/Cargo.toml',
+    'python/src/wh40kdc/_version.py', 'go/version.go', 'Cargo.lock'],
+}
+{
+  const requiredForDecision = args.decision_kind === 'sealed-campaign'
+    ? Object.keys(args.implementation_matrix || {}).filter(k => PATH_FAMILIES[k])
+    : REQUIRED[args.decision_kind]
+  if (!requiredForDecision.length) throw new Error('implementation matrix has no recognized decision surfaces')
+  const missing = requiredForDecision.filter(k => !args.implementation_matrix ||
+    !args.implementation_matrix[k] || args.implementation_matrix[k].required !== true ||
+    !Array.isArray(args.implementation_matrix[k].files) || !args.implementation_matrix[k].files.length)
+  if (missing.length) throw new Error(`source change has incomplete implementation matrix: ${missing.join(', ')}`)
+  const changed = new Set(workspace.changed_files)
+  const matrixFiles = requiredForDecision.flatMap(k => args.implementation_matrix[k].files.map(path => ({ k, path })))
+  const invalid = matrixFiles.filter(({ k, path }) => typeof path !== 'string' || path.startsWith('/') ||
+    path.endsWith('/') || path.split('/').includes('..') || !PATH_FAMILIES[k](path))
+  if (invalid.length) throw new Error(`implementation matrix has invalid surface paths: ${invalid.map(x => `${x.k}:${x.path}`).join(', ')}`)
+  const unbound = requiredForDecision.filter(k => !args.implementation_matrix[k].files.some(path => changed.has(path)))
+  if (unbound.length) throw new Error(`implementation matrix rows do not intersect the actual diff: ${unbound.join(', ')}`)
+  const incompleteExact = requiredForDecision.filter(k => EXACT_SURFACE_FILES[k]?.some(path =>
+    !args.implementation_matrix[k].files.includes(path) || !changed.has(path)))
+  if (incompleteExact.length)
+    throw new Error(`implementation matrix omits required exact files: ${incompleteExact.join(', ')}`)
+  if (requiredForDecision.includes('embedded_schemas')) {
+    const schemaFiles = args.implementation_matrix.embedded_schemas.files
+    if (!schemaFiles.some(p => p === 'crates/wh40kdc/schemas/bundled.schema.json') ||
+        !schemaFiles.some(p => p.startsWith('python/src/wh40kdc/schemas/')) ||
+        !schemaFiles.some(p => p.startsWith('go/schemas/')))
+      throw new Error('embedded_schemas must include changed Rust, Python, and Go schema artifacts')
+  }
+  const declared = new Set(matrixFiles.map(x => x.path))
+  const unclassified = workspace.changed_files.filter(path => !declared.has(path))
+  if (unclassified.length) throw new Error(`changed paths not declared on an exact decision surface: ${unclassified.join(', ')}`)
+}
+const PRE = `Verified repo root: ${args.repo_root}; changed paths passed the warpsmith allowlist. ` +
+  `Run every command there and report any requested gate that cannot run in not_run.\n`
+
+async function runFixedGate(gate, command) {
+  phase(`Gate: ${gate}`)
+  const marker = `__DSL_FIXED_GATE_${gate.replaceAll('-', '_').toUpperCase()}_OK__`
+  const result = await tool.bash({ command: `set -eu; ${command}; printf '${marker}\\n'`, timeout: 3600 })
+  const text = resultText(result)
+  const failed = typeof result === 'object' && result &&
+    (result.hasError || result.details?.timedOut ||
+      (result.details?.exitCode != null && result.details.exitCode !== 0) ||
+      ('exitCode' in result && result.exitCode !== 0))
+  if (failed || !text.includes(marker)) throw new Error(`fixed gate ${gate} failed: ${text.slice(-2000)}`)
+  return { gate, command, pass: true, output_tail: text.slice(-2000) }
+}
+const machineGates = []
+for (const gate of GATES) machineGates.push(await runFixedGate(gate, FIXED_GATE_COMMANDS[gate]))
 
 // ---- frozen Output contracts, transcribed to JSON Schema (do not redesign) ----
 const SKITARIUS_OUT = {
@@ -39,18 +259,20 @@ const SKITARIUS_OUT = {
   properties: {
     gates_run: { type: 'array', items: { type: 'object', required: ['gate', 'command', 'pass'],
       properties: { gate: { type: 'string' }, command: { type: 'string' }, pass: { type: 'boolean' },
-        failures: { type: 'array', items: { type: 'string' } } } } },
+        failures: { type: 'array', items: { type: 'object', required: ['file', 'message'],
+          properties: { file: { type: 'string' }, message: { type: 'string' } } } } } } },
     overall_pass: { type: 'boolean' },
     not_run: { type: 'array', items: { type: 'string' } },
   },
 }
 const COGITATOR_OUT = {
-  type: 'object', required: ['ability_ids', 'levers_before', 'levers_after', 'regressions', 'additions', 'verdict'],
+  type: 'object', required: ['abilities', 'levers_before', 'levers_after', 'regressions', 'additions', 'verdict'],
   properties: {
-    ability_ids: { type: 'array', items: { type: 'string' } },
+    abilities: { type: 'array', items: { type: 'object', required: ['faction_id', 'ability_id'],
+      properties: { faction_id: { type: 'string' }, ability_id: { type: 'string' } } } },
     levers_before: { type: 'object', additionalProperties: true }, levers_after: { type: 'object', additionalProperties: true },
-    regressions: { type: 'array', items: { type: 'object', required: ['ability_id', 'lever', 'change'],
-      properties: { ability_id: { type: 'string' }, lever: { type: 'string' }, change: { type: 'string' } } } },
+    regressions: { type: 'array', items: { type: 'object', required: ['faction_id', 'ability_id', 'lever', 'change'],
+      properties: { faction_id: { type: 'string' }, ability_id: { type: 'string' }, lever: { type: 'string' }, change: { type: 'string' } } } },
     additions: { type: 'array', items: { type: 'object', additionalProperties: true } },
     verdict: { enum: ['clean', 'regressed'] },
   },
@@ -70,38 +292,117 @@ const PSYKER_OUT = {
 
 const idsByFaction = {}
 for (const f of args.faction_ids) idsByFaction[f] = []
+const requestedPairs = []
 for (const id of args.ability_ids) {
   // shape-led batches span factions; ability ids arrive as "faction/ability_id" or bare
   const slash = id.indexOf('/')
-  if (slash > 0 && idsByFaction[id.slice(0, slash)]) idsByFaction[id.slice(0, slash)].push(id.slice(slash + 1))
-  else args.faction_ids.forEach(f => idsByFaction[f].push(id))
+  if (slash > 0) {
+    const faction = id.slice(0, slash)
+    const ability = id.slice(slash + 1)
+    if (!idsByFaction[faction] || !ability) throw new Error(`unknown or malformed ability key: ${id}`)
+    idsByFaction[faction].push(ability)
+    requestedPairs.push({ faction_id: faction, ability_id: ability })
+  } else {
+    if (args.faction_ids.length !== 1) throw new Error('bare ability id is ambiguous in a multi-faction batch')
+    idsByFaction[args.faction_ids[0]].push(id)
+    requestedPairs.push({ faction_id: args.faction_ids[0], ability_id: id })
+  }
 }
+const requestedPairKeys = new Set(requestedPairs.map(x => `${x.faction_id}/${x.ability_id}`))
+if (requestedPairKeys.size !== requestedPairs.length) throw new Error('duplicate faction/ability request')
+function canonicalJson(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  return `{${Object.keys(value).sort().map(k => `${JSON.stringify(k)}:${canonicalJson(value[k])}`).join(',')}}`
+}
+const applied_dsl_hashes = {}
+for (const [faction, ids] of Object.entries(idsByFaction)) {
+  const rows = await Bun.file(`data/enrichment/${faction}/abilities.json`).json()
+  for (const ability_id of ids) {
+    const matches = rows.filter(row => row.ability_id === ability_id)
+    const key = `${faction}/${ability_id}`
+    if (matches.length !== 1) throw new Error(`applied ability lookup is not unique: ${key}`)
+    applied_dsl_hashes[key] = new Bun.CryptoHasher('sha256').update(canonicalJson(matches[0])).digest('hex')
+    if (args.expected_candidate_dsl_hashes[key] !== applied_dsl_hashes[key])
+      throw new Error(`applied DSL hash differs from accepted author candidate: ${key}`)
+  }
+}
+const expectedHashKeys = Object.keys(args.expected_candidate_dsl_hashes).sort()
+if (expectedHashKeys.length !== requestedPairKeys.size || [...requestedPairKeys].sort().some((key, i) => key !== expectedHashKeys[i]))
+  throw new Error('expected_candidate_dsl_hashes does not cover the exact requested faction/ability set')
 
 const [skitarius, cogitator, ...psyker] = await parallel([
-  () => agent(
+  () => runAgent(
     PRE + `Run exactly these mechanical gates in this workspace and report honestly (a gate you ` +
     `could not run goes in not_run, never in gates_run as passed). Input:\n` +
-    JSON.stringify({ gates: GATES, touched: { factions: args.faction_ids, files: args.touched_files || [] } }),
-    { agentType: 'skitarius', phase: 'Gates', schema: SKITARIUS_OUT, label: `gates:${args.batch_id}` }
+    JSON.stringify({ gates: GATES, machine_gate_artifacts: machineGates,
+      touched: { factions: args.faction_ids, files: args.touched_files || [] } }),
+    { agent: 'skitarius', schema: SKITARIUS_OUT, label: `gates:${args.batch_id}` }
   ),
-  () => agent(
+  () => runAgent(
     PRE + `Diff cruncher levers for these abilities, working tree vs committed. Any dropped lever is a ` +
     `regression regardless of how much prettier the new phrasing reads. Input:\n` +
-    JSON.stringify({ ability_ids: args.ability_ids.map(i => i.includes('/') ? i.split('/')[1] : i),
-      factions: args.faction_ids, baseline: 'committed' }),
-    { agentType: 'cogitator', phase: 'Levers', schema: COGITATOR_OUT, label: `levers:${args.batch_id}` }
+    JSON.stringify(args.sealed_head
+      ? { abilities: requestedPairs, baseline_commit_id: args.campaign_base_commit_id,
+          candidate_commit_id: args.candidate_commit_id }
+      : { abilities: requestedPairs, baseline: 'committed',
+          baseline_commit_id: args.baseline_commit_id,
+          candidate_commit_id: args.candidate_commit_id }),
+    { agent: 'cogitator', schema: COGITATOR_OUT, label: `levers:${args.batch_id}` }
   ),
   ...args.faction_ids.map(f => () =>
-    agent(
+    runAgent(
       PRE + `Cold-read the describer renders for these just-edited abilities. Input:\n` +
       JSON.stringify({ faction_id: f, scope: idsByFaction[f] }),
-      { agentType: 'psyker', phase: 'ColdRead', schema: PSYKER_OUT, label: `coldread:${f}:${args.batch_id}` }
+      { agent: 'psyker', schema: PSYKER_OUT, label: `coldread:${f}:${args.batch_id}` }
     )
   ),
 ])
 
 const psy = psyker.filter(Boolean)
 const sev3 = psy.flatMap(p => (p.findings || []).filter(x => x.severity === 3))
+const missingRoles = []
+if (!skitarius) missingRoles.push('skitarius')
+if (!cogitator) missingRoles.push('cogitator')
+if (psy.length !== args.faction_ids.length) missingRoles.push('psyker')
+if (missingRoles.length) throw new Error(`verification provenance incomplete: ${missingRoles.join(', ')}`)
+const gateNames = skitarius.gates_run.map(g => g.gate)
+const badGateSet = new Set(gateNames).size !== GATES.length || gateNames.length !== GATES.length ||
+  GATES.some(g => !gateNames.includes(g)) || skitarius.gates_run.some(g => g.pass !== true ||
+    g.command !== FIXED_GATE_COMMANDS[g.gate])
+if (badGateSet) throw new Error('skitarius did not pass the exact fixed campaign gate set')
+const cogitatorPairs = new Set(cogitator.abilities.map(x => `${x.faction_id}/${x.ability_id}`))
+if (cogitatorPairs.size !== cogitator.abilities.length || cogitatorPairs.size !== requestedPairKeys.size ||
+    [...requestedPairKeys].some(key => !cogitatorPairs.has(key)))
+  throw new Error('cogitator result does not cover the exact requested faction/ability set')
+const psykerFactions = new Set(psy.map(p => p.faction_id))
+if (psykerFactions.size !== args.faction_ids.length || args.faction_ids.some(f => !psykerFactions.has(f)))
+  throw new Error('psyker results do not cover the exact requested faction set')
+for (const result of psy) {
+  const reported = [...result.clean, ...result.findings.map(x => x.ability_id)]
+  const actual = new Set(reported)
+  const expected = new Set(idsByFaction[result.faction_id])
+  if (actual.size !== reported.length || actual.size !== expected.size || [...expected].some(id => !actual.has(id)))
+    throw new Error(`psyker result does not cover the exact requested abilities for ${result.faction_id}`)
+}
+const postWorkspace = await assertWorkspaceAndScope()
+if (postWorkspace.changed_files.length !== workspace.changed_files.length ||
+    postWorkspace.changed_files.some(path => !workspace.changed_files.includes(path)))
+  throw new Error('verification gates created new tracked paths after the initial allowlist audit')
+const notRun = skitarius.not_run || []
+const pass = !badGateSet && skitarius.overall_pass === true && notRun.length === 0 &&
+  cogitator.verdict === 'clean' && cogitator.regressions.length === 0 && sev3.length === 0
 log(`verify ${args.batch_id}: gates=${skitarius ? (skitarius.overall_pass ? 'PASS' : 'FAIL') : 'ERROR'} ` +
   `levers=${cogitator ? cogitator.verdict : 'ERROR'} sev3=${sev3.length}`)
-return { batch_id: args.batch_id, skitarius, cogitator, psyker: psy }
+const payload = {
+  batch_id: args.batch_id, pass, workspace, applied_dsl_hashes,
+  machine_gates: machineGates, skitarius, cogitator, psyker: psy,
+  provenance: { workflow: 'dsl-verify-batch', required_roles: ['skitarius', 'cogitator', 'psyker'] },
+}
+const ability_keys = requestedPairs.map(x => `${x.faction_id}/${x.ability_id}`).sort()
+const payload_sha256 = new Bun.CryptoHasher('sha256').update(JSON.stringify(payload)).digest('hex')
+return { binding: { kind: 'verify', campaign_id: args.campaign_id, batch_id: args.batch_id,
+  campaign_manifest_sha256: args.campaign_manifest_sha256, ability_keys,
+  candidate_commit_id: args.candidate_commit_id, candidate_dsl_hashes: applied_dsl_hashes,
+  sealed_head: args.sealed_head === true, campaign_base_commit_id: args.campaign_base_commit_id || null,
+  sealed_head_commit_id: args.sealed_head ? args.candidate_commit_id : null, payload_sha256 }, payload }

--- a/Justfile
+++ b/Justfile
@@ -47,7 +47,7 @@ regen:
     cd python && python3 -m pip install -e ".[dev]" --quiet
     python3 python/codegen/gen_typeddicts.py
     bash go/codegen/sync.sh
-    cd tools && npm run build && npm run gen:conformance
+    cd tools && npm run codegen:data && npx tsc && npm run gen:conformance
 
 # Apply Rust + Go formatting (CI checks these; applying keeps a re-run clean).
 fmt:
@@ -58,11 +58,31 @@ fmt:
 # Drift gate: committed generated artifacts must equal what regen just produced.
 verify-clean:
     @echo "▸ checking generated artifacts match regen output (CI drift gate)"
-    @if ! git diff --exit-code -- {{ARTIFACTS}}; then \
+    @if jj root >/dev/null 2>&1; then \
+        drift=$(jj diff --name-only -r @ -- {{ARTIFACTS}}); \
+      elif git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
+        drift=$(git diff --name-only -- {{ARTIFACTS}}); \
+      else \
+        echo "✗ neither a git worktree nor a jj workspace; cannot verify generated drift." >&2; \
+        exit 1; \
+      fi; \
+      if [ -n "$drift" ]; then \
         echo "✗ generated artifacts drifted — regen changed them; commit the result (CI fails on this same diff)." >&2; \
+        printf '%s\n' "$drift" >&2; \
         exit 1; \
     fi
     @echo "  artifacts up to date."
+
+# Pre-commit drift gate: intended uncommitted generated outputs are the baseline.
+# Snapshot their bytes, regenerate, and require byte-for-byte stability.
+verify-regen-stable:
+    @before=$$(mktemp); after=$$(mktemp); trap 'rm -f "$$before" "$$after"' EXIT; \
+      find {{ARTIFACTS}} -type f -print0 2>/dev/null | sort -z | xargs -0 sha256sum >"$$before"; \
+      just regen; \
+      find {{ARTIFACTS}} -type f -print0 2>/dev/null | sort -z | xargs -0 sha256sum >"$$after"; \
+      if ! cmp -s "$$before" "$$after"; then \
+        echo "✗ regeneration changed the pre-gate generated snapshot." >&2; diff -u "$$before" "$$after" >&2 || true; exit 1; \
+      fi
 
 # All four language suites + conformance.
 test-all: test-ts test-rust test-python test-go conformance
@@ -70,7 +90,7 @@ test-all: test-ts test-rust test-python test-go conformance
 # TS: build + unit tests + data validation.
 test-ts:
     @echo "▸ TS: build + unit tests + data validation"
-    cd tools && npm run build && npm test && npm run validate
+    cd tools && npm run codegen:data && npx tsc && npm test && npm run validate
 
 # Rust: fmt-check + build + test.
 test-rust:


### PR DESCRIPTION
## Summary

- move all 16 campaign roles and every workflow invocation to the exact `openai-codex/gpt-5.6-luna` model
- make authoring architecture-first with immutable clause evidence, explicit ambiguity handling, exact clause coverage, and bounded adversarial quorum
- harden schema-family qualification for both external ability families and homogeneous internal children
- enforce warpsmith-only writes, exact changed-path allowlists, and decision-specific multi-language implementation matrices
- bind campaign manifests, author/verify/review/rescore artifacts, candidate DSL hashes, jj ranges, and sealed-head closure evidence
- add strict batch-review and campaign-close workflows with fixed machine gates, per-faction score checks, non-worklist prose-drift rejection, and non-skippable parity proofs
- add jj-safe regeneration stability checking and a bounded campaign runtime

## Retrospective gaps addressed

The Battle Focus campaign could decompose leaf mechanics before establishing the parent architecture, accept incomplete or stale evidence, struggle to qualify an internal schema family, and rely on driver narration for portions of verification and closure. These changes turn those expectations into fail-closed workflow contracts so unsupported mechanics route to shape-scout rather than requiring maintainer-authored schema recovery during the campaign.

## Validation

- all six workflow scripts compile through `AsyncFunction`
- all agent frontmatter and `.omp/config.yml` parse as YAML
- exactly 16 agent model declarations resolve to Codex Luna; warpsmith is the sole writer
- `git diff --check`
- `just verify-clean`
- TypeScript/Vitest: 85 files passed, 1,506 tests passed, 41 skipped

## Environment limitation

The OMP executable and jj are unavailable in this orb, so the campaign workflows were syntax-, schema-, contract-, and failure-path-reviewed but not executed end-to-end under the OMP runtime.