### PR TITLE
fix(tyranids): Norn Emissary Unnatural Resilience triggers only vs mortal wounds

### DIFF
--- a/data/enrichment/tyranids/abilities.json
+++ b/data/enrichment/tyranids/abilities.json
@@ -501,7 +501,8 @@
       "type": "feel-no-pain",
       "target": "unit",
       "modifier": {
-        "threshold": 4
+        "threshold": 4,
+        "scope": "mortal"
       }
     },
     "scope": {


### PR DESCRIPTION
## Problem

Norn Emissary's **Unnatural Resilience** ability (FNP 4+) currently applies to all damage types, but per the Warhammer 40K 11th edition rules, it should trigger only against Mortal Wounds.

**Current behavior:** FNP 4+ vs any damage  
**Correct behavior:** FNP 4+ vs mortal wounds only

## Fix

Added `scope: mortal` to the ability's effect modifier, following the established convention used by chaos-knights, thousand-sons, adepta-sororitas, and world-eaters.

## Changes

The unnatural-resilience entry now has:
```json
"modifier": {
  "threshold": 4,
  "scope": "mortal"
}
```

## Validation

- Schema validation passed
- Diff is minimal: one added field
- No rules text copied — mechanics description per CONTRIBUTING.md IP safety rule