### PR TITLE
fix: correct adeptus-custodes faction_rule_id (martial-katah → martial-ka-tah)

### DIFF
--- a/data/core/adeptus-custodes/factions.json
+++ b/data/core/adeptus-custodes/factions.json
@@ -12,7 +12,7 @@
       "Adeptus Custodes"
     ],
     "aliases": [],
-    "faction_rule_id": "martial-katah",
+    "faction_rule_id": "martial-ka-tah",
     "logo_url": "https://cdn.jsdelivr.net/gh/Certseeds/wh40k-icon@be230023ff0755d19ffb1a1762658c711c2887f9/src/svgs/human_imperium/adeptus-custodes.svg"
   }
 ]


### PR DESCRIPTION
Fixes incorrect faction_rule_id reference. The id 'martial-katah' does not exist in the abilities collection; the correct id is 'martial-ka-tah'.