### PR TITLE
fix: correct death-guard faction_rule_id (nurgles-gift → nurgle-s-gift-aura)

### DIFF
--- a/data/core/death-guard/factions.json
+++ b/data/core/death-guard/factions.json
@@ -13,7 +13,7 @@
       "Death Guard"
     ],
     "aliases": [],
-    "faction_rule_id": "nurgles-gift",
+    "faction_rule_id": "nurgle-s-gift-aura",
     "logo_url": "https://cdn.jsdelivr.net/gh/Certseeds/wh40k-icon@be230023ff0755d19ffb1a1762658c711c2887f9/src/svgs/chaos/legions/death-guard.svg"
   }
 ]


### PR DESCRIPTION
Fixes incorrect faction_rule_id reference. The id 'nurgles-gift' is an indirection stub; the actual ability is 'nurgle-s-gift-aura'.