### PR TITLE
fix: correct blood-angels faction_rule_id (the-red-thirst → oath-of-moment)

### DIFF
--- a/data/core/blood-angels/factions.json
+++ b/data/core/blood-angels/factions.json
@@ -13,7 +13,7 @@
       "Blood Angels"
     ],
     "aliases": [],
-    "faction_rule_id": "the-red-thirst",
+    "faction_rule_id": "oath-of-moment",
     "logo_url": "https://cdn.jsdelivr.net/gh/Certseeds/wh40k-icon@be230023ff0755d19ffb1a1762658c711c2887f9/src/svgs/human_imperium/astartes_legion/blood-angels.svg"
   }
 ]


### PR DESCRIPTION
Blood Angels is a chapter-level subfaction of Adeptus Astartes and shares the faction-wide Oath of Moment army rule. The id 'the-red-thirst' does not exist anywhere in the dataset.