### PR TITLE
feat: add drukhari pain-token-pool resource

### DIFF
--- a/data/enrichment/drukhari/resource-pools.json
+++ b/data/enrichment/drukhari/resource-pools.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "pain-token-pool",
+    "name": "Pain Token Pool",
+    "faction_id": "drukhari",
+    "pool_type": "counter",
+    "generation": [
+      {
+        "condition": {
+          "type": "timing-is",
+          "parameters": {
+            "timing": "start-of-command-phase"
+          }
+        },
+        "amount": 1
+      },
+      {
+        "condition": {
+          "type": "timing-is",
+          "parameters": {
+            "timing": "enemy-unit-destroyed"
+          }
+        },
+        "amount": 1
+      },
+      {
+        "condition": {
+          "type": "timing-is",
+          "parameters": {
+            "timing": "enemy-unit-fails-battle-shock"
+          }
+        },
+        "amount": 1
+      }
+    ],
+    "max_size": null,
+    "game_version": {
+      "edition": "11th",
+      "dataslate": "pre-launch-provisional"
+    }
+  }
+]


### PR DESCRIPTION
Registers the Pain Token Pool from Drukhari's Power from Pain faction rule.

Generation sources:
- 1 token at start-of-command-phase
- 1 token when enemy unit is destroyed
- 1 token when enemy unit fails battle-shock

Enables resource-spend and resource-gain operations in Drukhari abilities to function correctly.