### PR TITLE
feat: add world-eaters blood-tithe-pool resource

### DIFF
--- a/data/enrichment/world-eaters/resource-pools.json
+++ b/data/enrichment/world-eaters/resource-pools.json
@@ -42,5 +42,27 @@
       "edition": "11th",
       "dataslate": "pre-launch-provisional"
     }
+  },
+  {
+    "id": "blood-tithe-pool",
+    "name": "Blood Tithe Pool",
+    "faction_id": "world-eaters",
+    "pool_type": "counter",
+    "generation": [
+      {
+        "condition": {
+          "type": "timing-is",
+          "parameters": {
+            "timing": "enemy-unit-destroyed"
+          }
+        },
+        "amount": 1
+      }
+    ],
+    "max_size": null,
+    "game_version": {
+      "edition": "11th",
+      "dataslate": "pre-launch-provisional"
+    }
   }
 ]


### PR DESCRIPTION
Registers the Blood Tithe Pool from World Eaters' Blood Tithe detachment rule (Khorne Daemonkin).

Generation source:
- 1 token when an enemy unit is destroyed (note: the 3+ dice-gate is modeled in the ability, not the pool)

Enables resource-spend and resource-gain operations in World Eaters detachment abilities to function correctly.