### PR TITLE
feat: add leagues-of-votann yp-pool resource

### DIFF
--- a/data/enrichment/leagues-of-votann/resource-pools.json
+++ b/data/enrichment/leagues-of-votann/resource-pools.json
@@ -1,0 +1,54 @@
+[
+  {
+    "id": "yp-pool",
+    "name": "Yield Point Pool",
+    "faction_id": "leagues-of-votann",
+    "pool_type": "counter",
+    "generation": [
+      {
+        "condition": {
+          "type": "controls-objective",
+          "parameters": {
+            "count_min": 1,
+            "scope": "your-territory"
+          }
+        },
+        "amount": 1
+      },
+      {
+        "condition": {
+          "type": "controls-objective",
+          "parameters": {
+            "count_min": 1,
+            "exclude": "home"
+          }
+        },
+        "amount": 1
+      },
+      {
+        "condition": {
+          "type": "controls-objective",
+          "parameters": {
+            "count_min": 2,
+            "exclude": "home"
+          }
+        },
+        "amount": 1
+      },
+      {
+        "condition": {
+          "type": "objective-majority",
+          "parameters": {
+            "relative_to": "opponent"
+          }
+        },
+        "amount": 1
+      }
+    ],
+    "max_size": null,
+    "game_version": {
+      "edition": "11th",
+      "dataslate": "pre-launch-provisional"
+    }
+  }
+]


### PR DESCRIPTION
Registers the Yield Point (YP) Pool from Prioritised Efficiency faction rule.

Generation sources:
- 1 YP for controlling objectives in your deployment zone
- 1 YP for controlling objectives outside your deployment zone (round 2+)
- 1 YP for controlling 2+ objectives outside your deployment zone (round 2+)
- 1 YP for controlling more objectives than opponent (round 2+)

Needgaârd Oathband detachment enriches this pool via Martial Leverage ability.

Enables resource-spend/resource-gain in Votann abilities to function.