### PR TITLE
Announce releases to Discord

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -210,6 +210,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Exposed so notify-discord can report which registries actually took a
+    # new version (the check step self-gates, so a green job is not a publish).
+    outputs:
+      published: ${{ steps.check.outputs.publish }}
+      version: ${{ steps.ver.outputs.version }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -260,6 +265,11 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    # Exposed so notify-discord can report which registries actually took a
+    # new version (the check step self-gates, so a green job is not a publish).
+    outputs:
+      published: ${{ steps.check.outputs.publish }}
+      version: ${{ steps.ver.outputs.version }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -314,6 +324,11 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    # Exposed so notify-discord can report which registries actually took a
+    # new version (the check step self-gates, so a green job is not a publish).
+    outputs:
+      published: ${{ steps.check.outputs.publish }}
+      version: ${{ steps.ver.outputs.version }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -364,6 +379,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Exposed so notify-discord can report which registries actually took a
+    # new version (the check step self-gates, so a green job is not a publish).
+    outputs:
+      published: ${{ steps.check.outputs.publish }}
+      version: ${{ steps.ver.outputs.version }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -414,3 +434,157 @@ jobs:
           fi
           GOPROXY=https://proxy.golang.org GO111MODULE=on \
             go list -m "github.com/wn-mitch/40kdc-data/go@v${{ steps.ver.outputs.version }}" || true
+
+  notify-discord:
+    # Single consolidated release announcement for a version bump. The four
+    # publish jobs each self-gate on their registry, so "job succeeded" is not
+    # the same as "something published" — this job reads their `published`
+    # outputs and stays silent on the (common) main push that bumped nothing.
+    # `always()` so a *failed* registry publish is announced too: a silent
+    # failure is exactly the state this job exists to end.
+    #
+    # Requires the DISCORD_WEBHOOK_URL repo secret (a Discord channel webhook,
+    # Server Settings → Integrations → Webhooks). Absent, the job no-ops so
+    # forks stay green.
+    needs: [publish-crate, publish-npm, publish-pypi, publish-go]
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Announce release to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          CRATE_RESULT: ${{ needs.publish-crate.result }}
+          CRATE_PUBLISHED: ${{ needs.publish-crate.outputs.published }}
+          CRATE_VERSION: ${{ needs.publish-crate.outputs.version }}
+          NPM_RESULT: ${{ needs.publish-npm.result }}
+          NPM_PUBLISHED: ${{ needs.publish-npm.outputs.published }}
+          NPM_VERSION: ${{ needs.publish-npm.outputs.version }}
+          PYPI_RESULT: ${{ needs.publish-pypi.result }}
+          PYPI_PUBLISHED: ${{ needs.publish-pypi.outputs.published }}
+          PYPI_VERSION: ${{ needs.publish-pypi.outputs.version }}
+          GO_RESULT: ${{ needs.publish-go.result }}
+          GO_PUBLISHED: ${{ needs.publish-go.outputs.published }}
+          GO_VERSION: ${{ needs.publish-go.outputs.version }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
+            echo "::notice::DISCORD_WEBHOOK_URL is not set — skipping the release announcement."
+            exit 0
+          fi
+
+          # Only a publish job that RAN and failed counts as a failure worth
+          # announcing. 'skipped'/'cancelled' means an upstream gate job broke —
+          # that is a red main build, already reported by this workflow, and not
+          # a release event; announcing it would ping the channel on every
+          # failing push.
+          failed=false
+          for r in "$CRATE_RESULT" "$NPM_RESULT" "$PYPI_RESULT" "$GO_RESULT"; do
+            if [ "$r" = "failure" ]; then failed=true; fi
+          done
+
+          published_any=false
+          for p in "$CRATE_PUBLISHED" "$NPM_PUBLISHED" "$PYPI_PUBLISHED" "$GO_PUBLISHED"; do
+            if [ "$p" = "true" ]; then published_any=true; fi
+          done
+
+          if [ "$published_any" = false ] && [ "$failed" = false ]; then
+            echo "::notice::No registry took a new version on this push — nothing to announce."
+            exit 0
+          fi
+
+          # The four version files move in lockstep (enforced by the `validate`
+          # job), so any non-empty one is *the* version. A failing job can leave
+          # its output empty, hence the first-non-empty scan.
+          version=""
+          for v in "$NPM_VERSION" "$CRATE_VERSION" "$PYPI_VERSION" "$GO_VERSION"; do
+            if [ -n "$v" ]; then version="$v"; break; fi
+          done
+          [ -n "$version" ] || version="unknown"
+
+          # published -> ✅, self-gated no-op -> ➖ (already on the registry),
+          # ran and failed -> ❌, never ran -> ⏭.
+          status_icon() {
+            case "$1:$2" in
+              success:true)  printf '✅' ;;
+              success:*)     printf '➖' ;;
+              failure:*)     printf '❌' ;;
+              *)             printf '⏭' ;;
+            esac
+          }
+
+          line() { # <icon> <label> <text> <url>
+            printf '%s **%s** — [%s](%s)' "$1" "$2" "$3" "$4"
+          }
+
+          npm_line=$(line "$(status_icon "$NPM_RESULT" "$NPM_PUBLISHED")" npm \
+            "@alpaca-software/40kdc-data v$version" \
+            "https://www.npmjs.com/package/@alpaca-software/40kdc-data/v/$version")
+          crate_line=$(line "$(status_icon "$CRATE_RESULT" "$CRATE_PUBLISHED")" crates.io \
+            "wh40kdc v$version" "https://crates.io/crates/wh40kdc/$version")
+          pypi_line=$(line "$(status_icon "$PYPI_RESULT" "$PYPI_PUBLISHED")" PyPI \
+            "wh40kdc v$version" "https://pypi.org/project/wh40kdc/$version/")
+          go_line=$(line "$(status_icon "$GO_RESULT" "$GO_PUBLISHED")" Go \
+            "github.com/wn-mitch/40kdc-data/go v$version" \
+            "https://pkg.go.dev/github.com/wn-mitch/40kdc-data/go@v$version")
+
+          if [ "$failed" = true ]; then
+            title="40kdc-data v$version — release incomplete"
+            colour=15548997   # 0xED4245 red
+            footer_note=" · ❌ see the run log"
+          else
+            title="40kdc-data v$version"
+            colour=5763719    # 0x57F287 green
+            footer_note=""
+          fi
+
+          spec_version=$(cat conformance/SPEC_VERSION)
+
+          description=$(printf '%s\n%s\n%s\n%s' \
+            "$npm_line" "$crate_line" "$pypi_line" "$go_line")
+
+          # jq -n --arg keeps every interpolated value out of the JSON grammar;
+          # a heredoc here would break on any quote or newline in a version.
+          jq -n \
+            --arg title "$title" \
+            --arg url "$REPO_URL/commit/$COMMIT_SHA" \
+            --arg description "$description" \
+            --arg footer "SPEC_VERSION $spec_version · commit ${COMMIT_SHA:0:7}$footer_note" \
+            --argjson colour "$colour" \
+            '{
+               username: "40kdc",
+               embeds: [{
+                 title: $title,
+                 url: $url,
+                 description: $description,
+                 color: $colour,
+                 footer: { text: $footer }
+               }]
+             }' > payload.json
+
+          # Discord answers a webhook POST with 204 No Content, so the status
+          # code is the only success signal — a bare `curl` would swallow a
+          # revoked webhook (401/404) or a malformed body (400) as success.
+          code=$(curl -sS -o response.txt -w '%{http_code}' \
+            -X POST -H 'Content-Type: application/json' \
+            --data @payload.json "$DISCORD_WEBHOOK_URL")
+
+          if [ "$code" != "204" ] && [ "$code" != "200" ]; then
+            echo "Discord webhook POST failed with HTTP $code:" >&2
+            cat response.txt >&2
+            exit 1
+          fi
+          echo "Announced 40kdc-data v$version to Discord (HTTP $code)."
+
+          # Surface the underlying publish failure as this job's result too, so
+          # the run is red and not merely annotated.
+          if [ "$failed" = true ]; then
+            echo "::error::A publish job did not succeed — see $RUN_URL"
+            exit 1
+          fi

--- a/workers/sync/src/alerts.ts
+++ b/workers/sync/src/alerts.ts
@@ -2,21 +2,41 @@
  * Discord webhook alerts (optional — silently a no-op without the secret).
  * Ported from shadowboxing's session-worker alerts: fire-and-forget, an
  * alerting failure must never fail the request that triggered it.
+ *
+ * "Best effort" is not "invisible": the POST's status IS checked and a bad
+ * webhook is logged, because a revoked webhook (401/404) or a malformed body
+ * (400) is otherwise indistinguishable from a delivered alert. The return
+ * value lets a caller keep its dedupe state honest.
  */
 
 export interface AlertsEnv {
+  /** Discord channel webhook. Operator-set (`wrangler secret put`); alerts
+   *  no-op when it is absent, which is the state in local dev and in forks. */
   DISCORD_WEBHOOK_URL?: string;
 }
 
-export async function sendDiscordAlert(env: AlertsEnv, lines: string[]): Promise<void> {
-  if (!env.DISCORD_WEBHOOK_URL) return;
+/** Outbound alerts must never wedge the caller behind a hung Discord. */
+const ALERT_TIMEOUT_MS = 5_000;
+
+/** @returns true only when Discord accepted the alert. */
+export async function sendDiscordAlert(env: AlertsEnv, lines: string[]): Promise<boolean> {
+  if (!env.DISCORD_WEBHOOK_URL) return false;
   try {
-    await fetch(env.DISCORD_WEBHOOK_URL, {
+    const res = await fetch(env.DISCORD_WEBHOOK_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ content: lines.join("\n") }),
+      signal: AbortSignal.timeout(ALERT_TIMEOUT_MS),
     });
-  } catch {
-    // Alerting is best-effort by design.
+    if (!res.ok) {
+      // Never log the URL itself — it is the credential.
+      console.warn(`Discord alert rejected: HTTP ${res.status} ${res.statusText}`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    // Alerting is best-effort by design; surface it without throwing.
+    console.warn("Discord alert failed:", err instanceof Error ? err.message : err);
+    return false;
   }
 }

--- a/workers/sync/src/sync-registry.ts
+++ b/workers/sync/src/sync-registry.ts
@@ -24,6 +24,9 @@ const SWEEP_SLACK_MS = 30 * 60_000;
 const CAP_ALERT_DEDUPE_MS = 15 * 60_000;
 
 export class SyncRegistry extends DurableObject<SyncRegistryEnv> {
+  /** True while a capacity alert POST is pending; see maybeCapacityAlert. */
+  private alertInFlight = false;
+
   constructor(ctx: DurableObjectState, env: SyncRegistryEnv) {
     super(ctx, env);
     ctx.blockConcurrencyWhile(async () => {
@@ -99,21 +102,37 @@ export class SyncRegistry extends DurableObject<SyncRegistryEnv> {
       .toArray()[0].n;
   }
 
-  /** "Demand exceeds supply" signal, deduped to ≤1 per window. */
+  /** "Demand exceeds supply" signal, deduped to ≤1 per window.
+   *
+   *  The dedupe marker is persisted only once Discord ACCEPTS the alert: a
+   *  marker written up front would let one failed POST blackhole the next
+   *  CAP_ALERT_DEDUPE_MS of alerts, which is the failure mode a capacity alarm
+   *  can least afford. `alertInFlight` covers the resulting gap — the marker
+   *  is not written while the POST is still pending, and a burst of refusals
+   *  would otherwise fan out into one POST each. The DO is a singleton, so an
+   *  in-memory flag is sufficient. */
   private maybeCapacityAlert(activeNow: number): void {
+    if (this.alertInFlight) return;
     const row = this.ctx.storage.sql
       .exec<{ v: string }>("SELECT v FROM meta WHERE k = 'last_cap_alert'")
       .toArray()[0];
     const now = Date.now();
     if (row && now - Number(row.v) < CAP_ALERT_DEDUPE_MS) return;
-    this.ctx.storage.sql.exec(
-      "INSERT INTO meta (k, v) VALUES ('last_cap_alert', ?) ON CONFLICT(k) DO UPDATE SET v = excluded.v",
-      String(now),
-    );
+    this.alertInFlight = true;
     void sendDiscordAlert(this.env, [
       "**40kdc sync sessions — at capacity**",
       `A session creation was just refused: ${activeNow}/${this.maxSessions()} rooms in use.`,
       "If this keeps happening, raising MAX_DOC_SESSIONS is the lever (costs scale with it).",
-    ]);
+    ])
+      .then((delivered) => {
+        if (!delivered) return;
+        this.ctx.storage.sql.exec(
+          "INSERT INTO meta (k, v) VALUES ('last_cap_alert', ?) ON CONFLICT(k) DO UPDATE SET v = excluded.v",
+          String(now),
+        );
+      })
+      .finally(() => {
+        this.alertInFlight = false;
+      });
   }
 }

--- a/workers/sync/test/alerts.test.ts
+++ b/workers/sync/test/alerts.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Discord capacity alerts: the guard that keeps them optional, the payload
+ * shape and status handling in sendDiscordAlert, and SyncRegistry's contract
+ * that a REJECTED alert must not persist the dedupe marker (a marker written
+ * on a failed send would blackhole the next 15 minutes of capacity alarms).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { env, runInDurableObject } from "cloudflare:test";
+import { sendDiscordAlert } from "../src/alerts";
+import type { SyncRegistry } from "../src/sync-registry";
+
+const HOOK = "https://discord.test/api/webhooks/1/token";
+const LINES = ["**at capacity**", "20/20 rooms in use."];
+
+/** Replace global fetch with a recorder; restored by restoreAllMocks. */
+function stubFetch(reply: () => Response | Promise<Response>) {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  vi.stubGlobal("fetch", (url: string, init: RequestInit = {}) => {
+    calls.push({ url: String(url), init });
+    return Promise.resolve(reply());
+  });
+  return calls;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("sendDiscordAlert", () => {
+  it("no-ops without the webhook secret and never touches the network", async () => {
+    const calls = stubFetch(() => new Response(null, { status: 204 }));
+    await expect(sendDiscordAlert({}, LINES)).resolves.toBe(false);
+    await expect(sendDiscordAlert({ DISCORD_WEBHOOK_URL: "" }, LINES)).resolves.toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("POSTs newline-joined {content} to the webhook and reports 204 as delivered", async () => {
+    const calls = stubFetch(() => new Response(null, { status: 204 }));
+    await expect(sendDiscordAlert({ DISCORD_WEBHOOK_URL: HOOK }, LINES)).resolves.toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(HOOK);
+    expect(calls[0].init.method).toBe("POST");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ content: LINES.join("\n") });
+  });
+
+  it("reports a rejected webhook as undelivered rather than silently succeeding", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    stubFetch(() => new Response("Unknown Webhook", { status: 404 }));
+    await expect(sendDiscordAlert({ DISCORD_WEBHOOK_URL: HOOK }, LINES)).resolves.toBe(false);
+    expect(warn).toHaveBeenCalled();
+    // The webhook URL is the credential — it must never reach the log.
+    expect(warn.mock.calls.flat().join(" ")).not.toContain(HOOK);
+  });
+
+  it("swallows a transport failure without throwing at the caller", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubGlobal("fetch", () => Promise.reject(new Error("timed out")));
+    await expect(sendDiscordAlert({ DISCORD_WEBHOOK_URL: HOOK }, LINES)).resolves.toBe(false);
+  });
+});
+
+describe("SyncRegistry capacity-alert dedupe", () => {
+  // A dedicated instance name PER TEST: `isolatedStorage` is off and the
+  // "global" singleton is shared with the session-create and doc-live suites,
+  // so a shared instance would leak this suite's `last_cap_alert` marker both
+  // between these tests and into the others.
+  const stub = (name: string) =>
+    env.SYNC_REGISTRY.get(env.SYNC_REGISTRY.idFromName(`alerts-test-${name}`));
+
+  /** Drive the private alert path and wait for its POST to settle. */
+  async function alert(name: string): Promise<string | undefined> {
+    return runInDurableObject(stub(name), async (instance: SyncRegistry) => {
+      (instance as unknown as { maybeCapacityAlert(n: number): void }).maybeCapacityAlert(20);
+      // Let the fetch + .then(marker write) + .finally(flag reset) chain run.
+      await new Promise((r) => setTimeout(r, 0));
+      const ctx = (instance as unknown as { ctx: DurableObjectState }).ctx;
+      return ctx.storage.sql
+        .exec<{ v: string }>("SELECT v FROM meta WHERE k = 'last_cap_alert'")
+        .toArray()[0]?.v;
+    });
+  }
+
+  it("does not persist the dedupe marker when Discord rejects the alert", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    stubFetch(() => new Response("Unknown Webhook", { status: 404 }));
+    expect(await alert("rejected")).toBeUndefined();
+  });
+
+  it("persists the dedupe marker once Discord accepts the alert", async () => {
+    stubFetch(() => new Response(null, { status: 204 }));
+    const marker = await alert("accepted");
+    expect(marker).toBeDefined();
+    expect(Number(marker)).toBeGreaterThan(0);
+  });
+
+  it("suppresses a repeat alert inside the dedupe window", async () => {
+    const calls = stubFetch(() => new Response(null, { status: 204 }));
+    await alert("window");
+    await alert("window");
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/workers/sync/vitest.config.ts
+++ b/workers/sync/vitest.config.ts
@@ -25,6 +25,10 @@ export default defineWorkersConfig(async () => {
               // (the 200-link loop blew the 5s test timeout on CI runners).
               MAX_DOCS_PER_OWNER: "5",
               MAX_LINKS_PER_OWNER: "5",
+              // Exercise the CONFIGURED alert path (the production shape), not
+              // just the no-webhook early return. Tests stub global fetch, and
+              // the host does not resolve, so nothing leaves the runner.
+              DISCORD_WEBHOOK_URL: "https://discord.test/api/webhooks/1/token",
             },
           },
         },

--- a/workers/sync/wrangler.jsonc
+++ b/workers/sync/wrangler.jsonc
@@ -22,8 +22,13 @@
     ]
   },
   "migrations": [{ "tag": "v1", "new_sqlite_classes": ["DocRoom", "SyncRegistry"] }],
-  // This worker holds NO secrets: the only auth material is the Ed25519
-  // PUBLIC key below. Patron-gated routes 501 until it is set.
+  // The only auth material in `vars` is the Ed25519 PUBLIC key below; patron-
+  // gated routes 501 until it is set. One optional SECRET exists and is
+  // deliberately not declared here:
+  //   DISCORD_WEBHOOK_URL — channel webhook for the SyncRegistry at-capacity
+  //   alert. Set it with `npx wrangler secret put DISCORD_WEBHOOK_URL --config
+  //   workers/sync/wrangler.jsonc`. Absent, sendDiscordAlert() no-ops, which is
+  //   the expected state in local dev and in forks.
   "vars": {
     // Raw Ed25519 public key(s) from keys.alpacasoft.dev (base64url, comma-
     // separated for rotation), per `GET keys.alpacasoft.dev/auth/public-key`.


### PR DESCRIPTION
## Why

The Discord announcement for a new 40kdc version has never worked because it was never implemented. Nothing under `.github/` referenced a webhook, and no `DISCORD_WEBHOOK_URL` secret existed on the repo. The only Discord code was `workers/sync/src/alerts.ts`, whose at-capacity alert reads the same never-set secret and so early-returns on every call.

## What changes

**Release announcement.** A new `notify-discord` job in `validate.yml` posts one consolidated embed per version bump — the version plus per-registry links for npm, crates.io, PyPI, and the Go module.

The four publish jobs self-gate on their registry, so a green job is not a publish. Each now exposes `published`/`version` as job outputs and the notify job reads them, which is what keeps the channel quiet on the common `main` push that bumped nothing. A publish job that ran and failed is announced in red and fails the notify job; a job that was merely skipped (an upstream gate broke) is not announced, since that is a red build rather than a release event.

The job asserts Discord's `204` instead of discarding the response. An unchecked POST is precisely what made the earlier silence unreadable — a revoked webhook, a malformed body, and a delivered message all looked identical.

No secret configured means the job no-ops with a `::notice::`, so forks stay green.

**Sync worker alert.** `sendDiscordAlert` now checks the response status, logs a rejection without logging the URL, and times out after 5s. `SyncRegistry.maybeCapacityAlert` persisted its 15-minute dedupe marker *before* the POST, so one failed send blackholed the next window of capacity alarms; the marker now lands only once Discord accepts, with an in-flight flag covering the gap. `wrangler.jsonc`'s comment claiming the worker holds no secrets is corrected to name the optional one.

## Verification

- The webhook was exercised end to end from the terminal with the exact payload the job builds: `HTTP 204`, message delivered.
- The job's shell script was extracted and run offline against a stubbed `curl` across six cases: no secret, nothing published, full release, partial (one registry already at version), a failed registry publish, and a `401` from Discord. Each produced the intended exit code and embed.
- `actionlint` clean on `validate.yml` (which shellchecks the `run` block).
- `workers/sync`: `npm run typecheck` clean, `npm test` 49/49 across 7 files, including 7 new tests in `test/alerts.test.ts` — a path with no prior coverage.