### PR TITLE
fix: resolve leader/bodyguard attachment in NR prose and GW app text imports

### DIFF
--- a/tools/src/import/gw.ts
+++ b/tools/src/import/gw.ts
@@ -62,6 +62,13 @@ const UNIT_HEADER = /^(.+?)\s*\(\s*(\d+)\s*(?:pts?|points?)\s*\)\s*$/i;
 const BULLET_LINE = /^(\s*)([•◦])\s*(.+?)\s*$/u;
 const NX_PREFIX = /^(\d+)x\s+(.+)$/;
 const ENHANCEMENT_ANNOT = /^(.+?)\s*\(\+\s*(\d+)\s*pts?\s*\)\s*$/i;
+// The "Attached Units" preamble groups a Leader/Support character with its
+// bodyguard unit under `Attached Unit N` before the ALL-CAPS role sections
+// begin. `Attached Unit N` itself carries no case-sensitivity signal (mixed
+// case, so it never collides with SECTION_HEADER) and no `(N pts)` suffix (so
+// it never collides with UNIT_HEADER either) — it's purely a pairing fence.
+const ATTACHED_UNIT_HEADER = /^Attached Unit\s+\d+\s*$/i;
+const ATTACHED_AS_BULLET = /^Attached as:\s*(Leader|Support|Bodyguard)\b/i;
 const WITH_LINE = /^[\t ]*\d+\s+with\b/m;
 const BULLET = /^[\t ]*•/mu;
 const EMBEDDED_APP_BATTLE_SIZE =
@@ -172,7 +179,7 @@ interface UnitAcc {
   bullets: Bullet[];
 }
 
-function finishUnit(acc: UnitAcc): ParsedUnit {
+function finishUnit(acc: UnitAcc): { unit: ParsedUnit; attachedRole: "leader" | "support" | "bodyguard" | null } {
   const topIndent = acc.bullets.length
     ? Math.min(...acc.bullets.map((b) => b.indent))
     : 0;
@@ -183,6 +190,7 @@ function finishUnit(acc: UnitAcc): ParsedUnit {
   let is_character = acc.section === CHARACTERS_SECTION;
   let enhancement_raw_name: string | null = null;
   let enhancement_points: number | null = null;
+  let attachedRole: "leader" | "support" | "bodyguard" | null = null;
 
   const addWargear = (raw_name: string, count: number): void => {
     wargear.set(raw_name, (wargear.get(raw_name) ?? 0) + count);
@@ -198,7 +206,8 @@ function finishUnit(acc: UnitAcc): ParsedUnit {
       continue;
     }
 
-    // Top-level annotation (no `Nx` count): enhancement / character / warlord.
+    // Top-level annotation (no `Nx` count): enhancement / character / warlord /
+    // attached-as (Leader/Support/Bodyguard, from the "Attached Units" preamble).
     if (b.count === null) {
       const enh = ENHANCEMENT_ANNOT.exec(b.text);
       if (enh) {
@@ -206,6 +215,12 @@ function finishUnit(acc: UnitAcc): ParsedUnit {
           enhancement_raw_name = enh[1].trim();
           enhancement_points = Number.parseInt(enh[2], 10);
         }
+        continue;
+      }
+      const attachedAs = ATTACHED_AS_BULLET.exec(b.text);
+      if (attachedAs) {
+        attachedRole = attachedAs[1].toLowerCase() as "leader" | "support" | "bodyguard";
+        if (attachedRole !== "bodyguard") is_character = true;
         continue;
       }
       for (const token of b.text.split(",").map((s) => s.trim()).filter(Boolean)) {
@@ -240,14 +255,17 @@ function finishUnit(acc: UnitAcc): ParsedUnit {
   for (const [raw_name, count] of wargear) wargearList.push({ raw_name, count });
 
   return {
-    raw_name: acc.raw_name,
-    is_character,
-    model_count,
-    points,
-    is_warlord,
-    enhancement_raw_name,
-    enhancement_points,
-    wargear: wargearList,
+    unit: {
+      raw_name: acc.raw_name,
+      is_character,
+      model_count,
+      points,
+      is_warlord,
+      enhancement_raw_name,
+      enhancement_points,
+      wargear: wargearList,
+    },
+    attachedRole,
   };
 }
 
@@ -260,9 +278,31 @@ function parseBody(lines: string[], bodyStart: number): {
   let section: string | null = null;
   let alliedUnits = 0;
 
+  // Units finished while inside an "Attached Unit N" fence, pending pairing
+  // once both the character (Leader/Support role) and its Bodyguard have
+  // been seen. Resolved — and cleared — whenever the fence closes (a new
+  // `Attached Unit N` marker, a real section header, or end of input).
+  let attachedGroupBuffer: { unit: ParsedUnit; role: "leader" | "support" | "bodyguard" }[] = [];
+
+  const resolveAttachedGroup = (): void => {
+    if (attachedGroupBuffer.length === 0) return;
+    const character = attachedGroupBuffer.find((e) => e.role === "leader" || e.role === "support");
+    const bodyguard = attachedGroupBuffer.find((e) => e.role === "bodyguard");
+    if (character && bodyguard) {
+      character.unit.leader_attachment = {
+        bodyguard_raw_name: bodyguard.unit.raw_name,
+        role: character.role as "leader" | "support",
+        provisional: false,
+      };
+    }
+    attachedGroupBuffer = [];
+  };
+
   const finalize = (): void => {
     if (current) {
-      units.push(finishUnit(current));
+      const { unit, attachedRole } = finishUnit(current);
+      if (attachedRole) attachedGroupBuffer.push({ unit, role: attachedRole });
+      units.push(unit);
       current = null;
     }
   };
@@ -271,6 +311,12 @@ function parseBody(lines: string[], bodyStart: number): {
     const raw = lines[i];
     const line = raw.trim();
     if (!line || FENCE.test(line) || HEADER_LINE.test(line)) continue;
+
+    if (ATTACHED_UNIT_HEADER.test(line)) {
+      finalize();
+      resolveAttachedGroup();
+      continue;
+    }
 
     const bulletMatch = BULLET_LINE.exec(raw);
     if (bulletMatch) {
@@ -317,11 +363,13 @@ function parseBody(lines: string[], bodyStart: number): {
 
     if (SECTION_HEADER.test(line)) {
       finalize();
+      resolveAttachedGroup();
       section = line;
     }
   }
 
   finalize();
+  resolveAttachedGroup();
   return { units, multi_force: alliedUnits > 0 };
 }
 

--- a/tools/src/import/newrecruit-wtc.ts
+++ b/tools/src/import/newrecruit-wtc.ts
@@ -156,6 +156,14 @@ const ENHANCEMENT_LINE =
   /^Enhancement:\s*(.+?)(?:\s*\(\+\s*(\d+)\s*pts?\s*\))?\s*$/i;
 const ATTACHMENT_LINE =
   /^Attachment:\s*(leader|support)\s*->\s*(.+?)(\s+\[provisional\])?\s*$/i;
+// The plain-text NewRecruit copy export (as opposed to the WTC-serialized
+// `Attachment: leader -> X` line above) states the same pairing in prose on
+// either end of the link: `Leading <bodyguard>` on the character's own block,
+// or `  Attached to <character>` (indented, no bullet) on the bodyguard's
+// block. Both are explicit — not inferred — so they're handled the same way
+// as `ATTACHMENT_LINE`, not routed through resolve()'s support-only fallback.
+const LEADING_LINE = /^Leading\s+(.+?)\s*$/i;
+const ATTACHED_TO_LINE = /^Attached to\s+(.+?)\s*$/i;
 const WITH_PREFIX = /^(\d+)\s+with\s+(.*)$/i;
 // Optional trailing `: <wargear>` — NewRecruit inlines a model group's loadout
 // after the model type (`• 1x Champion: Chainblades`, `• 5x Eightbound: 5 with
@@ -281,6 +289,32 @@ function attachEnhancement(unit: UnitBuilder, raw_name: string, pts: number | nu
   unit.enhancement_pts = pts;
 }
 
+/**
+ * Resolve `Attached to <character>` refs collected while parsing (see
+ * `pendingAttachedTo` in each body parser) against the fully-parsed unit
+ * list. Only fills a gap left by an absent `Leading`/`Attachment:` line on
+ * the character's own block — that signal already carries an explicit role
+ * (leader/support) and takes precedence. `Attached to` alone doesn't state a
+ * role, so it defaults to "leader" (the overwhelmingly common case; a
+ * support character that *only* the bodyguard-side text names would be
+ * mislabeled, a known best-effort limitation).
+ */
+function applyPendingAttachedTo(
+  units: ParsedUnit[],
+  pendingAttachedTo: { bodyguardRawName: string; characterRawName: string }[],
+): void {
+  for (const pending of pendingAttachedTo) {
+    const character = units.find((u) => u.raw_name === pending.characterRawName);
+    if (character && !character.leader_attachment) {
+      character.leader_attachment = {
+        role: "leader",
+        bodyguard_raw_name: pending.bodyguardRawName,
+        provisional: false,
+      };
+    }
+  }
+}
+
 // --- compact body parser ----------------------------------------------------
 
 function parseCompactBody(body: string): { units: ParsedUnit[]; enhancementPts: (number | null)[] } {
@@ -288,6 +322,12 @@ function parseCompactBody(body: string): { units: ParsedUnit[]; enhancementPts: 
   const units: ParsedUnit[] = [];
   const enhancementPts: (number | null)[] = [];
   let current: UnitBuilder | null = null;
+  // `Attached to <character>` names the character from the bodyguard's own
+  // block, so it can't be resolved to `current.leader_attachment` inline (the
+  // character unit may not exist yet). Deferred to a post-pass once every
+  // unit has been parsed. Only fills a gap left by an absent `Leading` line —
+  // see the post-pass below.
+  const pendingAttachedTo: { bodyguardRawName: string; characterRawName: string }[] = [];
 
   const finalize = (): void => {
     if (current) {
@@ -321,6 +361,20 @@ function parseCompactBody(body: string): { units: ParsedUnit[]; enhancementPts: 
       };
       continue;
     }
+    const leadingMatch = LEADING_LINE.exec(line);
+    if (leadingMatch && current) {
+      current.leader_attachment = {
+        role: "leader",
+        bodyguard_raw_name: leadingMatch[1],
+        provisional: false,
+      };
+      continue;
+    }
+    const attachedToMatch = ATTACHED_TO_LINE.exec(line);
+    if (attachedToMatch && current) {
+      pendingAttachedTo.push({ bodyguardRawName: current.raw_name, characterRawName: attachedToMatch[1] });
+      continue;
+    }
     const breakdown = MODEL_BREAKDOWN.exec(raw);
     if (breakdown && current) {
       const count = Number.parseInt(breakdown[1], 10);
@@ -349,6 +403,7 @@ function parseCompactBody(body: string): { units: ParsedUnit[]; enhancementPts: 
   }
 
   finalize();
+  applyPendingAttachedTo(units, pendingAttachedTo);
   return { units, enhancementPts };
 }
 
@@ -367,6 +422,8 @@ function parseFullBody(body: string): { units: ParsedUnit[]; enhancementPts: (nu
         assigned_count: number;
       }
     | null = null;
+  // See `parseCompactBody`'s identical field for the rationale.
+  const pendingAttachedTo: { bodyguardRawName: string; characterRawName: string }[] = [];
 
   // A full-format model bullet introduces a parent model type; every following
   // `N with` line is a separate exact subgroup of that parent. Delay an empty
@@ -420,6 +477,20 @@ function parseFullBody(body: string): { units: ParsedUnit[]; enhancementPts: (nu
         bodyguard_raw_name: attachmentMatch[2],
         provisional: attachmentMatch[3] !== undefined,
       };
+      continue;
+    }
+    const leadingMatch = LEADING_LINE.exec(line);
+    if (leadingMatch && current) {
+      current.leader_attachment = {
+        role: "leader",
+        bodyguard_raw_name: leadingMatch[1],
+        provisional: false,
+      };
+      continue;
+    }
+    const attachedToMatch = ATTACHED_TO_LINE.exec(line);
+    if (attachedToMatch && current) {
+      pendingAttachedTo.push({ bodyguardRawName: current.raw_name, characterRawName: attachedToMatch[1] });
       continue;
     }
 
@@ -483,6 +554,7 @@ function parseFullBody(body: string): { units: ParsedUnit[]; enhancementPts: (nu
   }
 
   finalize();
+  applyPendingAttachedTo(units, pendingAttachedTo);
   return { units, enhancementPts };
 }
 

--- a/tools/test/import/gw.test.ts
+++ b/tools/test/import/gw.test.ts
@@ -288,3 +288,134 @@ Jain Zar (100 pts)
     expect(names).not.toContain("strike");
   });
 });
+
+describe("gwAdapter — Attached Units preamble", () => {
+  // GW app export groups a Leader/Support character with its bodyguard unit
+  // under "Attached Units" > "Attached Unit N" before the ALL-CAPS role
+  // sections begin, marking each entry's role via "• Attached as: Leader
+  // (Character)" / "• Attached as: Bodyguard". This block previously carried
+  // no attachment signal at all (silently dropped, matched as two standalone
+  // units).
+  const SAMPLE = `+++++++++++++++++++++++++++++++++++++++++++++++
++ FACTION KEYWORD: Chaos - Chaos Knights
++ DETACHMENT: Houndpack Lance (Marked Prey)
++ TOTAL ARMY POINTS: 2000pts
++++++++++++++++++++++++++++++++++++++++++++++++
+
+Attached Units
+Attached Unit 1
+
+War Dog Karnivore (165 pts)
+• Attached as: Leader (Character)
+• 1x Reaper chaintalon
+• 1x Slaughterclaw
+• 1x Havoc multi-launcher
+
+Nurglings (40 pts)
+• Attached as: Bodyguard
+• 3x Nurgling Swarm
+    • 3x Diseased claws and teeth
+
+BATTLELINE
+
+War Dog Brigand (140 pts)
+• 1x Armoured feet
+• 1x Avenger chaincannon
+`;
+
+  const parsed = gwAdapter.parse(SAMPLE);
+
+  it("sets leader_attachment on the character (Leader role) pointing at its bodyguard", () => {
+    const karnivore = parsed.units.find((u) => u.raw_name === "War Dog Karnivore")!;
+    expect(karnivore.leader_attachment).toEqual({
+      role: "leader",
+      bodyguard_raw_name: "Nurglings",
+      provisional: false,
+    });
+  });
+
+  it("flags the attached character as is_character even without a trailing 'Character' token", () => {
+    const karnivore = parsed.units.find((u) => u.raw_name === "War Dog Karnivore")!;
+    expect(karnivore.is_character).toBe(true);
+  });
+
+  it("does not set leader_attachment on the bodyguard unit itself", () => {
+    const nurglings = parsed.units.find((u) => u.raw_name === "Nurglings")!;
+    expect(nurglings.leader_attachment).toBeUndefined();
+  });
+
+  it("does not misparse 'Attached as: Bodyguard' as wargear or an annotation", () => {
+    const nurglings = parsed.units.find((u) => u.raw_name === "Nurglings")!;
+    const wargearNames = nurglings.wargear.map((w) => w.raw_name);
+    expect(wargearNames).not.toContain("Attached as: Bodyguard");
+    expect(nurglings.model_count).toBe(3);
+  });
+
+  it("still parses units outside the Attached Units preamble normally", () => {
+    const brigand = parsed.units.find((u) => u.raw_name === "War Dog Brigand")!;
+    expect(brigand.leader_attachment).toBeUndefined();
+    expect(brigand.points).toBe(140);
+  });
+
+  it("keeps every unit — 3 total (2 attached + 1 battleline)", () => {
+    expect(parsed.units).toHaveLength(3);
+  });
+
+  it("resolves end-to-end via tryImportRoster with the bodyguard_ref matched", () => {
+    const result = tryImportRoster(SAMPLE);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const karnivore = result.roster.units.find((u) => u.ref.raw_name === "War Dog Karnivore")!;
+    expect(karnivore.leader_attachment).not.toBeNull();
+    expect(karnivore.leader_attachment?.role).toBe("leader");
+    expect(karnivore.leader_attachment?.bodyguard_ref.raw_name).toBe("Nurglings");
+    expect(karnivore.leader_attachment?.bodyguard_ref.resolved).toBe(true);
+  });
+
+  it("resolves an Attached Unit group with a Support-role character", () => {
+    const supportSample = SAMPLE.replace(
+      "• Attached as: Leader (Character)",
+      "• Attached as: Support (Character)",
+    );
+    const p = gwAdapter.parse(supportSample);
+    const karnivore = p.units.find((u) => u.raw_name === "War Dog Karnivore")!;
+    expect(karnivore.leader_attachment?.role).toBe("support");
+  });
+
+  it("does not pair across two separate Attached Unit blocks", () => {
+    const twoBlocks = `+++++++++++++++++++++++++++++++++++++++++++++++
++ FACTION KEYWORD: Chaos - Chaos Knights
++ DETACHMENT: Houndpack Lance (Marked Prey)
++ TOTAL ARMY POINTS: 2000pts
++++++++++++++++++++++++++++++++++++++++++++++++
+
+Attached Units
+Attached Unit 1
+
+War Dog Karnivore (165 pts)
+• Attached as: Leader (Character)
+• 1x Reaper chaintalon
+
+Nurglings (40 pts)
+• Attached as: Bodyguard
+• 3x Nurgling Swarm
+    • 3x Diseased claws and teeth
+
+Attached Unit 2
+
+War Dog Executioner (130 pts)
+• Attached as: Leader (Character)
+• 1x Armoured feet
+
+Beasts of Nurgle (140 pts)
+• Attached as: Bodyguard
+• 3x Beast of Nurgle
+    • 3x Fleshy Claws
+`;
+    const p = gwAdapter.parse(twoBlocks);
+    const karnivore = p.units.find((u) => u.raw_name === "War Dog Karnivore")!;
+    const executioner = p.units.find((u) => u.raw_name === "War Dog Executioner")!;
+    expect(karnivore.leader_attachment?.bodyguard_raw_name).toBe("Nurglings");
+    expect(executioner.leader_attachment?.bodyguard_raw_name).toBe("Beasts of Nurgle");
+  });
+});

--- a/tools/test/import/newrecruit-wtc.test.ts
+++ b/tools/test/import/newrecruit-wtc.test.ts
@@ -132,6 +132,69 @@ describe("newRecruitWtcCompactAdapter", () => {
   });
 });
 
+describe("newRecruitWtcCompactAdapter — Leading/Attached to attachment prose", () => {
+  // The plain-text NewRecruit copy export (newrecruit.eu) states leader
+  // attachment in prose on either end of the link, not via the WTC-serialized
+  // `Attachment: leader -> X` line: `Leading <bodyguard>` on the character's
+  // own block, and/or `  Attached to <character>` (indented, no bullet) on
+  // the bodyguard's own block.
+  const SAMPLE = `+++++++++++++++++++++++++++++++++++++++++++++++
++ FACTION KEYWORD: Chaos - Chaos Knights
++ DETACHMENT: Houndpack Lance (Marked Prey)
++ TOTAL ARMY POINTS: 2000pts
++++++++++++++++++++++++++++++++++++++++++++++++
+
+Char1: 1x War Dog Karnivore (165 pts): Houndpack Lance Character, Reaper chaintalon, Slaughterclaw, Havoc multi-launcher
+Leading Nurglings
+
+3x Nurglings (40 pts): 3 with Diseased claws and teeth
+  Attached to War Dog Karnivore
+`;
+
+  const parsed = newRecruitWtcCompactAdapter.parse(SAMPLE);
+
+  it("sets leader_attachment on the character from a 'Leading X' line", () => {
+    const karnivore = parsed.units.find((u) => u.raw_name === "War Dog Karnivore")!;
+    expect(karnivore.leader_attachment).toEqual({
+      role: "leader",
+      bodyguard_raw_name: "Nurglings",
+      provisional: false,
+    });
+  });
+
+  it("does not duplicate or overwrite the attachment when 'Attached to' echoes the same pair", () => {
+    // Only one signal should win — the explicit 'Leading' line found first.
+    const karnivore = parsed.units.find((u) => u.raw_name === "War Dog Karnivore")!;
+    expect(karnivore.leader_attachment?.bodyguard_raw_name).toBe("Nurglings");
+  });
+
+  it("does not set leader_attachment on the bodyguard unit itself", () => {
+    const nurglings = parsed.units.find((u) => u.raw_name === "Nurglings")!;
+    expect(nurglings.leader_attachment).toBeNull();
+  });
+
+  it("falls back to 'Attached to' alone (defaulting to leader role) when no 'Leading' line is present", () => {
+    const attachedToOnly = `+++++++++++++++++++++++++++++++++++++++++++++++
++ FACTION KEYWORD: Chaos - Chaos Knights
++ DETACHMENT: Houndpack Lance (Marked Prey)
++ TOTAL ARMY POINTS: 2000pts
++++++++++++++++++++++++++++++++++++++++++++++++
+
+Char1: 1x War Dog Karnivore (165 pts): Houndpack Lance Character, Reaper chaintalon, Slaughterclaw, Havoc multi-launcher
+
+3x Nurglings (40 pts): 3 with Diseased claws and teeth
+  Attached to War Dog Karnivore
+`;
+    const p = newRecruitWtcCompactAdapter.parse(attachedToOnly);
+    const karnivore = p.units.find((u) => u.raw_name === "War Dog Karnivore")!;
+    expect(karnivore.leader_attachment).toEqual({
+      role: "leader",
+      bodyguard_raw_name: "Nurglings",
+      provisional: false,
+    });
+  });
+});
+
 describe("newRecruitWtcFullAdapter", () => {
   it("matches full text only and disambiguates from compact", () => {
     expect(newRecruitWtcFullAdapter.matches(FULL_SAMPLE)).toBe(true);
@@ -440,5 +503,44 @@ Char1: 1x Palatine (50 pts): Palatine blade, Plasma pistol, Warlord
       expect(melta.ref.id).not.toBeNull();
       expect(ds.weapons.getAny(melta.ref.id!)).toBeTruthy();
     }
+  });
+});
+
+describe("newRecruitWtcFullAdapter — Leading/Attached to attachment prose", () => {
+  // Same prose-based attachment signal as the compact-parser test above, but
+  // in the full-body (section-header) dialect — exercises the second copy of
+  // the LEADING_LINE/ATTACHED_TO_LINE handling in parseFullBody.
+  const SAMPLE = `+++++++++++++++++++++++++++++++++++++++++++++++
++ FACTION KEYWORD: Chaos - Chaos Knights
++ DETACHMENT: Houndpack Lance (Marked Prey)
++ TOTAL ARMY POINTS: 2000pts
++++++++++++++++++++++++++++++++++++++++++++++++
+
+BATTLELINE
+
+Char1: 1x War Dog Karnivore (165 pts)
+1 with Reaper chaintalon, Slaughterclaw, Havoc multi-launcher, Houndpack Lance Character
+Leading Nurglings
+
+3x Nurglings (40 pts)
+• 3x Nurgling Swarm
+    3 with Diseased claws and teeth
+  Attached to War Dog Karnivore
+`;
+
+  const parsed = newRecruitWtcFullAdapter.parse(SAMPLE);
+
+  it("sets leader_attachment on the character from a 'Leading X' line", () => {
+    const karnivore = parsed.units.find((u) => u.raw_name === "War Dog Karnivore")!;
+    expect(karnivore.leader_attachment).toEqual({
+      role: "leader",
+      bodyguard_raw_name: "Nurglings",
+      provisional: false,
+    });
+  });
+
+  it("does not set leader_attachment on the bodyguard unit itself", () => {
+    const nurglings = parsed.units.find((u) => u.raw_name === "Nurglings")!;
+    expect(nurglings.leader_attachment).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Two source text dialects state Leader→Bodyguard/Support attachment in prose that neither matching adapter currently recognizes — the units still import correctly, but the attachment link is silently dropped (each unit lands as an unrelated standalone).

- **NewRecruit plain-text copy export** (newrecruit.eu): states it as `Leading <bodyguard>` on the character's own block and/or `  Attached to <character>` (indented, no bullet) on the bodyguard's own block. `newrecruit-wtc.ts` already handles the WTC-serialized form (`Attachment: leader -> X`) but not this prose form.
- **GW app text export**: groups a Leader/Support character with its bodyguard under `Attached Units` > `Attached Unit N`, marking each entry's role via `• Attached as: Leader/Support/Bodyguard`. `gw.ts` (the adapter that matches this dialect) has no handling for this block at all — it's silently skipped since it matches neither `SECTION_HEADER` (mixed case) nor `UNIT_HEADER` (no `(N pts)` suffix). A different, lower-priority adapter (`gw-headerless.ts`) already parses similar phrasing, but it never gets a chance to run here since `gwAdapter.matches()` claims the payload first.

## Changes

- `newrecruit-wtc.ts`: extend both body parsers (compact and full) to recognize `Leading X` inline (explicit `role: leader`, same handling path as the existing `Attachment:` regex) and `Attached to Y` via a deferred post-pass — resolved once every unit in the body is known, and only fills a gap left by an absent `Leading` line (defaults to leader role, since the bodyguard-side phrasing alone doesn't state one — documented as a best-effort limitation).
- `gw.ts`: teach `finishUnit` to recognize `Attached as: Leader/Support/Bodyguard` bullets (also sets `is_character` for Leader/Support, mirroring how the `CHARACTERS` section already does it), and `parseBody` to track pairs within an `Attached Unit N` fence, resolving `leader_attachment` on the character once the fence closes.

Both changes are purely additive parsing paths — no change to output shape for any list that doesn't carry this phrasing (all 45 pre-existing tests across both files still pass unmodified).

## Test plan

- [x] `npx vitest run test/import/gw.test.ts test/import/newrecruit-wtc.test.ts` — 60/60 pass (45 pre-existing + 15 new)
- [x] `npx vitest run` (full tools suite) — 1607/1607 pass (1 unrelated pre-existing failure: `project-battlemaster.test.ts` needs an optional `bson` dep not installed in this environment, untouched by this change)
- [x] `npm run validate` — 18775/18775 items, 0 failures; referential integrity 3624/3624
- [x] Verified end-to-end against two real 16-unit army lists (one NR, one GW export of the same list) via `tryImportRoster()` — both now resolve `leader_attachment` correctly for both attached pairs, matching each other
- [ ] `just preflight` — not run; `just`/`cargo`/`go` are unavailable in this environment. Change is TS-only and touches neither `data/` nor `schemas/`, so no cross-language artifact regen should be needed, but flagging for a maintainer to confirm/run before merge

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>