### PR TITLE
fix: Refresh Codex ability source

### DIFF
--- a/examples/codex/src/App.svelte
+++ b/examples/codex/src/App.svelte
@@ -36,7 +36,7 @@
 
   onMount(() => {
     let active = true;
-    void loadIndex(DEFAULT_SOURCE)
+    void loadIndex(DEFAULT_SOURCE, { force: true })
       .then(({ index }) => {
         if (!active) return;
         sourceIndex = index;

--- a/examples/data-explorer/src/lib/source-store.test.ts
+++ b/examples/data-explorer/src/lib/source-store.test.ts
@@ -94,6 +94,23 @@ describe("loadIndex", () => {
     expect(res.label).toBe("owner/repo@x");
   });
 
+  it("bypasses the cached index when force is requested", async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls += 1;
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => sample,
+      } as Response;
+    }) as typeof fetch;
+
+    await loadIndex("owner/repo@refresh", { fetchImpl });
+    await loadIndex("owner/repo@refresh", { fetchImpl, force: true });
+    expect(calls).toBe(2);
+  });
+
   it("throws on a non-ok response", async () => {
     await expect(
       loadIndex("owner/repo@y", { fetchImpl: fakeFetch(false, null) }),


### PR DESCRIPTION
Forces the Codex runtime source lookup to bypass its 24-hour local cache, so published 40kdc-abilities updates replace stale rendered summaries immediately.