### PR TITLE
chore: Bump version to 1.3.1

### DIFF
--- a/crates/wh40kdc/Cargo.toml
+++ b/crates/wh40kdc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wh40kdc"
-version = "1.3.0"
+version = "1.3.1"
 description = "Warhammer 40K dataset for the 40kdc-data schema layer: generated types, an embedded dataset behind a linked typed API, plus ListForge + NewRecruit roster importers and exporters."
 readme = "README.md"
 keywords = ["warhammer", "40k", "wargaming", "schema", "serde"]

--- a/go/version.go
+++ b/go/version.go
@@ -5,4 +5,4 @@ package wh40kdc
 
 // Version is the package version, kept in lockstep with tools/package.json,
 // crates/wh40kdc/Cargo.toml, and python .../_version.py (CI fails on drift).
-const Version = "1.3.0"
+const Version = "1.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11107,7 +11107,7 @@
     },
     "tools": {
       "name": "@alpaca-software/40kdc-data",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "SEE LICENSE IN LICENSE-TOOLS",
       "dependencies": {
         "ajv": "^8.17.0",

--- a/python/src/wh40kdc/_version.py
+++ b/python/src/wh40kdc/_version.py
@@ -4,4 +4,4 @@ Kept in lockstep with tools/package.json and crates/wh40kdc/Cargo.toml;
 CI hard-fails on mismatch.
 """
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alpaca-software/40kdc-data",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "description": "The 40kdc Warhammer 40K dataset behind a linked, typed API — find units, follow them to their weapons, abilities, phases, and factions. Also validates data against the canonical JSON Schemas.",
   "keywords": [


### PR DESCRIPTION
Bumps the npm, Rust, Python, and Go package versions in lockstep after the Battlemaster terrain-map release.