### PR TITLE
fix: Update crate lockfile version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "wh40kdc"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "base64",
  "chrono",


### PR DESCRIPTION
Keeps Cargo.lock synchronized with the 1.3.1 crate manifest version so cargo publish --locked can release the crate.