### PR TITLE
fix: Allow complete changelog responses

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -678,7 +678,7 @@ jobs:
             --rawfile diff "$diff_file" \
             '{
               model: $model,
-              max_output_tokens: 700,
+              max_output_tokens: 2000,
               store: false,
               input: [
                 {


### PR DESCRIPTION
Raises the Responses API output budget from 700 to 2,000 tokens. The live 1.3.2 changelog test reached the prior limit and returned `incomplete`; the same release diff completed with the new budget.

Validation: `actionlint`, Prettier, `just preflight`, and a live OpenAI Responses API request over the 1.3.2 release diff.