### PR TITLE
fix: Speed up roster import by memoising and indexing lookups

### DIFF
--- a/python/src/wh40kdc/data/collection.py
+++ b/python/src/wh40kdc/data/collection.py
@@ -60,7 +60,13 @@ class Collection(Generic[T, V]):
         self._items: list[T] = []
         self._by_id: dict[str, T] = {}
         self._by_norm: dict[str, list[T]] = {}
+        # (normalized name, item) in first-seen order, for the substring fallback in
+        # find_all: it is already computed below for _by_norm, and re-deriving it
+        # per lookup made every miss a full scan through name_of and normalize_name.
+        self._norm_names: list[tuple[str, T]] = []
         self._by_faction_id: dict[str, list[T]] = {}
+        # (faction id, item id) -> first-registered item, for get_in_faction.
+        self._by_faction_and_id: dict[tuple[str, str], T] = {}
         self._by_external_ref: dict[tuple[str, str], list[T]] = {}
         # Ids registered under >1 faction; only populated when guarding.
         self._ambiguous_ids: set[str] | None = set() if guard_unscoped else None
@@ -83,7 +89,9 @@ class Collection(Generic[T, V]):
 
             name = name_of(item) if name_of else None
             if name:
-                self._by_norm.setdefault(normalize_name(name), []).append(item)
+                norm = normalize_name(name)
+                self._by_norm.setdefault(norm, []).append(item)
+                self._norm_names.append((norm, item))
 
             # Alias names answer to the same record. Index them after the
             # canonical name and skip any alias that normalizes to the
@@ -105,6 +113,7 @@ class Collection(Generic[T, V]):
             faction = faction_of(item) if faction_of else None
             if faction:
                 self._by_faction_id.setdefault(faction, []).append(item)
+                self._by_faction_and_id.setdefault((faction, id_), item)
                 if id_factions is not None:
                     id_factions.setdefault(id_, set()).add(faction)
 
@@ -177,10 +186,8 @@ class Collection(Generic[T, V]):
         resolved = id
         if id not in self._by_id and self._id_aliases is not None:
             resolved = self._id_aliases.get(id, id)
-        for item in self._by_faction_id.get(faction_id, []):
-            if self._id_of(item) == resolved:
-                return self._wrap(item)
-        return None
+        item = self._by_faction_and_id.get((faction_id, resolved))
+        return self._wrap(item) if item is not None else None
 
     def has(self, id: str) -> bool:
         """Whether a record with this exact id (or a renamed alias of it) exists."""
@@ -223,10 +230,7 @@ class Collection(Generic[T, V]):
 
         if self._name_of is None or key == "":
             return []
-        name_of = self._name_of
-        return [
-            self._wrap(item) for item in self._items if key in normalize_name(name_of(item) or "")
-        ]
+        return [self._wrap(item) for norm, item in self._norm_names if key in norm]
 
     def by_faction(self, faction_id: str) -> list[V]:
         """All records belonging to a faction id (empty if the type has no faction)."""

--- a/python/src/wh40kdc/data/dataset.py
+++ b/python/src/wh40kdc/data/dataset.py
@@ -194,6 +194,12 @@ class Dataset:
         self.interaction_flags: list[dict[str, Any]] = raw["interaction_flags"]
         self.phase_mappings: list[dict[str, Any]] = raw["phase_mappings"]
 
+        # (unit id, faction id) → its composition row; first-wins on duplicates, as
+        # the linear search it replaces returned the first hit.
+        self._composition_by_unit: dict[tuple[Any, Any], dict[str, Any]] = {}
+        for c in self.unit_compositions:
+            self._composition_by_unit.setdefault((c.get("unit_id"), c.get("faction_id")), c)
+
         # `source_type:source_id` → unioned phases.
         self._phase_index: dict[str, list[str]] = {}
         # ability id → units that list it.
@@ -405,14 +411,7 @@ class Dataset:
         both ``unit_id`` and ``faction_id``. ``None`` when the unit has no
         recorded composition. Mirror of TS ``unitCompositionOf``.
         """
-        return next(
-            (
-                c
-                for c in self.unit_compositions
-                if c.get("unit_id") == unit["id"] and c.get("faction_id") == unit.get("faction_id")
-            ),
-            None,
-        )
+        return self._composition_by_unit.get((unit["id"], unit.get("faction_id")))
 
     def leaders_attachable_to(self, bodyguard_unit_id: str) -> list[UnitView]:
         """Leaders whose leader-attachment data lists the unit among its bodyguards.

--- a/python/src/wh40kdc/data/loadout.py
+++ b/python/src/wh40kdc/data/loadout.py
@@ -26,13 +26,14 @@ Unit = dict[str, Any]
 LoadoutModel = dict[str, Any]
 
 
-def _js_locale_key(value: str) -> tuple[int, ...]:
+def _js_locale_key(value: str) -> str:
     """The ordering domain here is canonical entity ids: lowercase ASCII letters,
     digits, and hyphens. In that domain the repository's Node ``localeCompare``
-    ordering is ordinal, so this is the allocation-free equivalent for the solver's
-    multiset and candidate keys. Entity ids are schema-normalized before reaching
+    ordering is ordinal, and Python compares ``str`` by code point, so the string
+    is its own sort key. Kept as a named function to mark the ``localeCompare``
+    mirror points in the solver. Entity ids are schema-normalized before reaching
     loadout solving."""
-    return tuple(ord(char) for char in value)
+    return value
 
 
 def option_cap(

--- a/python/src/wh40kdc/data/normalize.py
+++ b/python/src/wh40kdc/data/normalize.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import re
 import unicodedata
+from functools import lru_cache
 
 # Mark category (Mn/Mc/Me) — every combining mark. The TS reference strips
 # \p{M}; the smaller \p{Diacritic} property misses some Mn characters, which
@@ -36,6 +37,13 @@ _SPACE_HYPHEN_RE = re.compile(r"[\s-]+")
 _LEADING_THE_RE = re.compile(r"^the\s+(.+)$", re.IGNORECASE)
 
 
+# Pure ASCII alphanumeric/space names -- the overwhelming majority of the corpus --
+# cannot be changed by the NFD pass, carry no combining marks and no quote variants,
+# so only the case fold and the space collapse can apply.
+_ASCII_SIMPLE_RE = re.compile(r"^[A-Za-z0-9 ]*$")
+
+
+@lru_cache(maxsize=65536)
 def normalize_name(input: str) -> str:
     """Reduce a display name to a canonical lookup key.
 
@@ -49,11 +57,19 @@ def normalize_name(input: str) -> str:
 
     The result is intended only for comparison; it is not a display value.
 
+    Memoised: roster import calls this ~135k times per list against a vocabulary of
+    ~17k distinct strings (93% hit rate), because ``Collection.find_all`` re-normalises
+    candidate names on every lookup. Pure function of its argument, so the cache is a
+    behavioural no-op; bounded so that arbitrary roster text cannot grow it without
+    limit.
+
     >>> normalize_name("Khârn the Betrayer")
     'kharn the betrayer'
     >>> normalize_name("T'au")
     'tau'
     """
+    if _ASCII_SIMPLE_RE.match(input):
+        return _SPACE_HYPHEN_RE.sub(" ", input.lower()).strip()
     decomposed = unicodedata.normalize("NFD", input)
     # Strip marks *before* lowercasing — load-bearing for İ (U+0130), whose
     # lowercase form introduces a combining dot that must survive.

--- a/python/src/wh40kdc/imports/resolve.py
+++ b/python/src/wh40kdc/imports/resolve.py
@@ -16,6 +16,7 @@ Python mirror of ``tools/src/import/resolve.ts``.
 from __future__ import annotations
 
 import re
+from functools import cache, lru_cache
 from typing import Any
 
 from wh40kdc.data.dataset import Dataset
@@ -532,20 +533,17 @@ def _unit_lookup_candidates(raw_name: str, faction_id: str | None, ds: Dataset) 
     return deduped
 
 
+# ``s`` at an ASCII word boundary; ``re.ASCII`` matches the un-flagged JS ``\\b``.
+_PLURAL_S_RE = re.compile(r"s\b", re.ASCII)
+
+
+@lru_cache(maxsize=65536)
 def _singular(s: str) -> str:
     """Singular/plural- and case-insensitive form for model-line matching:
     :func:`normalize_name` then drop every 's' at a word boundary — exact mirror
     of the TS ``normalizeName(s).replace(/s\\b/g, "")`` (a boundary is a
     following non-``\\w`` character or end of string)."""
-    n = normalize_name(s)
-    out = []
-    for i, ch in enumerate(n):
-        nxt = n[i + 1] if i + 1 < len(n) else ""
-        next_is_word = nxt.isascii() and (nxt.isalnum() or nxt == "_")
-        if ch == "s" and not next_is_word:
-            continue
-        out.append(ch)
-    return "".join(out)
+    return _PLURAL_S_RE.sub("", normalize_name(s))
 
 
 def _resolve_unit(
@@ -632,6 +630,9 @@ def _resolve_unit(
             if name
         }
 
+        # Called once per wargear line by is_model_line and then once more per
+        # composition model by matches_model_name; the keys depend only on the name.
+        @cache
         def model_line_keys(raw_name: str) -> set[str]:
             variants = [raw_name, *re.split(r"\s+--?\s+", raw_name)]
             if with_base := re.split(r"\s+with\s+", raw_name, flags=re.IGNORECASE)[0].strip():

--- a/python/tests/test_loadout_keys.py
+++ b/python/tests/test_loadout_keys.py
@@ -1,0 +1,81 @@
+"""Sort keys and name folding used by the loadout solver and roster resolver.
+
+These pin behaviour-preserving rewrites against reference implementations.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Any
+
+from wh40kdc.data.loadout import _js_locale_key
+from wh40kdc.data.normalize import normalize_name
+from wh40kdc.imports.resolve import _singular
+
+
+def _reference_singular(value: str) -> str:
+    """The original per-character loop: drop 's' when the next char is not ASCII \\w."""
+    n = normalize_name(value)
+    out = []
+    for i, ch in enumerate(n):
+        nxt = n[i + 1] if i + 1 < len(n) else ""
+        if ch == "s" and not (nxt.isascii() and (nxt.isalnum() or nxt == "_")):
+            continue
+        out.append(ch)
+    return "".join(out)
+
+
+def _vocabulary(dataset: Any) -> list[str]:
+    names = ["", "s", "ss", "boyz", "Kommandos", "bikes-s", "s s", "es_s", "Bob's Boys", "İs"]
+    for collection in ("units", "weapons", "abilities", "wargear", "enhancements"):
+        for item in getattr(dataset, collection, ()) or ():
+            raw = getattr(item, "raw", None)
+            if isinstance(raw, dict):
+                names.extend(
+                    v for k, v in raw.items() if k in ("name", "id") and isinstance(v, str)
+                )
+    return names
+
+
+def test_singular_matches_reference(dataset: Any) -> None:
+    names = _vocabulary(dataset)
+    assert len(names) > 500
+    for name in names:
+        assert _singular(name) == _reference_singular(name), repr(name)
+
+
+def test_locale_key_order_is_code_point_order(dataset: Any) -> None:
+    ids = [w.raw["id"] for w in dataset.weapons] + ["a", "ab", "a-", "a b", "z", "Z", "é", "e"]
+    assert sorted(ids, key=_js_locale_key) == sorted(ids, key=lambda v: tuple(ord(c) for c in v))
+
+
+def test_find_all_substring_fallback_unchanged(dataset: Any) -> None:
+    # No exact match, so this exercises the precomputed-name scan.
+    hits = dataset.weapons.find_all("bolt pisto")
+    assert hits
+    assert all("bolt pisto" in normalize_name(h.raw["name"]) for h in hits)
+    assert unicodedata.normalize("NFD", "x") == "x"  # keep the import honest
+
+
+def test_get_in_faction_is_first_registered_copy(dataset: Any) -> None:
+    # Reference: the scan the index replaced. Shared ids must resolve to the same copy.
+    for w in list(dataset.weapons)[:400]:
+        fac, wid = w.raw.get("faction_id"), w.raw["id"]
+        if not fac:
+            continue
+        expect = next(x for x in dataset.weapons.by_faction(fac) if x.raw["id"] == wid)
+        assert dataset.weapons.get_in_faction(wid, fac).raw is expect.raw
+
+
+def test_unit_composition_of_matches_linear_search(dataset: Any) -> None:
+    for u in list(dataset.units)[:400]:
+        expect = next(
+            (
+                c
+                for c in dataset.unit_compositions
+                if c.get("unit_id") == u.raw["id"]
+                and c.get("faction_id") == u.raw.get("faction_id")
+            ),
+            None,
+        )
+        assert dataset.unit_composition_of(u.raw) is expect

--- a/python/tests/test_normalize.py
+++ b/python/tests/test_normalize.py
@@ -1,0 +1,57 @@
+"""Memoisation and the ASCII fast path in :func:`normalize_name`.
+
+Both are performance changes that must be behaviourally invisible, so the fast path is
+pinned against a reference implementation that always takes the general route.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Any
+
+from wh40kdc.data import normalize as _n
+from wh40kdc.data.normalize import normalize_name
+
+_PROBES = [
+    "",
+    " ",
+    "  padded  ",
+    "Intercessor Squad",
+    "the   betrayer",
+    "MiXeD CaSe",
+    "10 Models",
+    "A-B",
+    "a--b",
+    "hyphen-name",
+    "tab\tsep",
+    "Khârn the Betrayer",
+    "T'au",
+    "Be'lakor",
+    "İ",
+]
+
+
+def _reference(value: str) -> str:
+    """normalize_name with no fast path and no cache."""
+    decomposed = unicodedata.normalize("NFD", value)
+    stripped = "".join(c for c in decomposed if unicodedata.category(c) not in _n._MARK_CATEGORIES)
+    no_quotes = _n._QUOTES_RE.sub("", stripped.lower())
+    return _n._SPACE_HYPHEN_RE.sub(" ", no_quotes).strip()
+
+
+def test_fast_path_matches_general_implementation(dataset: Any) -> None:
+    names = list(_PROBES)
+    for collection in ("units", "weapons", "abilities", "wargear", "enhancements", "factions"):
+        for item in getattr(dataset, collection, ()) or ():
+            raw = getattr(item, "raw", None)
+            if not isinstance(raw, dict):
+                continue
+            names.extend(v for k, v in raw.items() if k in ("name", "id") and isinstance(v, str))
+    assert len(names) > 500, "expected a substantial vocabulary to check against"
+    for name in names:
+        assert normalize_name(name) == _reference(name), repr(name)
+
+
+def test_cache_is_bounded() -> None:
+    # Roster text is normalised too, so an unbounded cache would grow on arbitrary input.
+    assert normalize_name.cache_info().maxsize is not None


### PR DESCRIPTION
Roster import spent about 90% of its time in `normalize_name`: `Collection.find_all` re-normalises candidate names on every lookup, so a single `try_import_roster` made roughly 135k calls over a vocabulary of about 17k distinct strings, driving some 2.1M `unicodedata.category` calls through the per-character generator. Memoising it (bounded, since roster text is normalised too) and skipping the NFD pass for pure ASCII alphanumeric names, which it cannot change, is about 4x on its own.

The next profile was five more places where import work scaled with the size of a collection rather than the size of the roster. Each is replaced with an index built once in the constructor, first-wins where the scan it replaces returned the first hit: the `find_all` substring fallback now reuses the normalised names already computed for `_by_norm`, `get_in_faction` is a `(faction, id)` dict, `unit_composition_of` is a `(unit, faction)` dict, `_singular` is the equivalent `re.sub` under `re.ASCII` (the un-flagged JS `\b`), `model_line_keys` is memoised per resolve, and `_js_locale_key` returns the string itself since Python compares `str` by code point. What remains is the loadout solver.

All changes are Python-only and behaviour-preserving; the TS, Rust and Go mirrors and the conformance corpus are unaffected. Measured on `try_import_roster` with `main`, the first commit and the second interleaved in one session under identical load, medians of four runs: 0.861s, 0.211s and 0.070s per list, about 12x end to end.

Verification:
- `ruff check` clean under the repo config
- Python suite: 1296 passed, including new pins that check each rewrite against a reference implementation over the whole shipped vocabulary (`test_normalize.py`, `test_loadout_keys.py`); `normalize_name` and `_singular` additionally verified identical over 58,411 strings from every name, id and alias in the bundle plus roster text, and `try_import_roster` output byte-identical
- Not run: `just preflight` (the non-Python mirrors are untouched by this change)
