### PR TITLE
fix: Keep changelog failures non-blocking

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -612,6 +612,9 @@ jobs:
             exit 1
           fi
       - name: Generate developer changelog
+        # Registry and release-announcement failures remain fatal above; the
+        # AI-generated summary is supplementary and must not fail the release.
+        continue-on-error: true
         if: >-
           needs.publish-crate.outputs.published == 'true' ||
           needs.publish-npm.outputs.published == 'true' ||


### PR DESCRIPTION
The optional AI-generated developer changelog returned HTTP 429 after every 1.4.x release, leaving otherwise successful publication workflows red.

Keep package publication and the deterministic Discord release announcement fatal. Mark only the supplementary AI changelog step as non-blocking.

Verification:
- `actionlint .github/workflows/validate.yml`
- `just preflight`