### PR TITLE
feat: Record what an annotation was authored against

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,38 @@ Then PR the resulting `data/enrichment/<faction>/abilities.json` diffs.
 never GW rules text. The verifier checks fidelity to mechanics; don't paste prose
 into `community_notes` (the audit flags it as `gw-leak`).
 
+### Recording what an annotation was authored against
+
+An annotation is a claim about a printed rule, so it goes stale when a dataslate rewords
+that rule — and `version` alone cannot tell you which ones: it records the dataslate an
+ability was authored for, not whether *this* ability's text actually changed. That makes
+"reviewed and still correct" indistinguishable from "never revisited since".
+
+`source_digest` closes the gap without the repo ever holding rules text. It stores a
+SHA-256 of the *normalised* source text (casefold, collapsed whitespace, punctuation
+stripped) — a one-way fingerprint, so IP safety is unchanged and `gw-leak` stays at zero:
+
+```json
+"source_digest": {
+  "algo": "sha256",
+  "value": "9f2b…",
+  "normalisation": "v1",
+  "source": "mfm-2026-09",
+  "checked_at": "2026-09-03"
+}
+```
+
+Point the audit at your own datasource — the same one `ARMY_ASSIST_JSON` refers to, as a
+`{ability_id: "printed text"}` map — and it reports every annotation whose source has
+changed since it was authored:
+
+```bash
+npm run audit:source-digest -- /path/to/your/rules.json
+```
+
+The corpus is read, never copied. The field is optional, so existing entries validate
+unchanged; add it as you touch an ability.
+
 ### Coverage report — what needs authoring
 
 `npm run audit:coverage` runs the real `effectToBuffs` translator over every

--- a/schemas/enrichment/ability-dsl/ability.schema.json
+++ b/schemas/enrichment/ability-dsl/ability.schema.json
@@ -88,6 +88,19 @@
     },
     "disputed": { "type": "boolean", "default": false },
     "dispute_notes": { "type": "string" },
+    "source_digest": {
+      "description": "Fingerprint of the printed rules text this annotation was authored against. Stores a hash, never the text: lets a consumer detect that a dataslate reworded an ability, so the DSL below may no longer describe it.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algo", "value", "normalisation", "source"],
+      "properties": {
+        "algo": { "const": "sha256" },
+        "value": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "normalisation": { "const": "v1", "description": "casefold, collapse whitespace, strip punctuation; defined in tools/src/source-digest.ts" },
+        "source": { "type": "string", "description": "which corpus the text came from, e.g. a dataslate id; not a URL to rules text" },
+        "checked_at": { "type": "string", "format": "date" }
+      }
+    },
     "community_notes": { "type": "string" }
   },
   "required": ["ability_id", "name", "authored_by", "game_version", "effect", "scope"],

--- a/tools/package.json
+++ b/tools/package.json
@@ -100,7 +100,8 @@
     "pretest": "npm run codegen:data",
     "test": "vitest run",
     "demo:rube-goldberg": "tsx src/rube-goldberg.ts",
-    "derive:keystones": "tsx src/derive-keystones.ts"
+    "derive:keystones": "tsx src/derive-keystones.ts",
+    "audit:source-digest": "tsx src/audit-source-digest.ts"
   },
   "dependencies": {
     "ajv": "^8.17.0",

--- a/tools/src/audit-source-digest.ts
+++ b/tools/src/audit-source-digest.ts
@@ -1,0 +1,44 @@
+/**
+ * Report which authored abilities are out of date with respect to their source text.
+ *
+ *   npm run audit:source-digest -- <corpus.json>
+ *
+ * <corpus.json> is the contributor's own rules datasource: {ability_id|name: "printed text"}.
+ * Nothing is written; the corpus is never copied into the repo. Exit code 1 if any
+ * annotation's digest no longer matches, so CI can gate on it.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { sourceDigest, type SourceDigest } from './source-digest.js';
+
+const corpusPath = process.argv[2];
+if (!corpusPath) {
+  console.error('usage: audit-source-digest <corpus.json>');
+  process.exit(2);
+}
+const corpus: Record<string, string> = JSON.parse(readFileSync(corpusPath, 'utf8'));
+
+function walk(dir: string): string[] {
+  return readdirSync(dir).flatMap((e: string) => {
+    const p = join(dir, e);
+    return statSync(p).isDirectory() ? walk(p) : p.endsWith('abilities.json') ? [p] : [];
+  });
+}
+
+let checked = 0, stale = 0, missing = 0, unknown = 0;
+for (const file of walk('data/enrichment')) {
+  for (const a of JSON.parse(readFileSync(file, 'utf8')) as Array<Record<string, unknown>>) {
+    const id = String(a.ability_id);
+    const text = corpus[id] ?? corpus[String(a.name)];
+    if (text === undefined) { unknown++; continue; }
+    const d = a.source_digest as SourceDigest | undefined;
+    if (!d) { missing++; continue; }
+    checked++;
+    if (d.value !== (await sourceDigest(text))) {
+      stale++;
+      console.log(`STALE  ${id}  authored against ${d.source}; source text has changed since`);
+    }
+  }
+}
+console.log(`\nchecked ${checked}; stale ${stale}; no digest recorded ${missing}; not in corpus ${unknown}`);
+process.exit(stale ? 1 : 0);

--- a/tools/src/source-digest.test.ts
+++ b/tools/src/source-digest.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { digestMatches, normaliseSourceText, sourceDigest } from './source-digest.js';
+
+describe('source digest', () => {
+  it('ignores reprint noise that carries no meaning', async () => {
+    const a = 'Each time this model makes an attack, add 1 to the Hit roll.';
+    const b = '  each   time this model makes an attack,\nadd 1 to the Hit roll ';
+    expect(normaliseSourceText(a)).toBe(normaliseSourceText(b));
+    expect(await sourceDigest(a)).toBe(await sourceDigest(b));
+  });
+
+  it('changes when a number changes — the case that invalidates an annotation', async () => {
+    const before = 'This model has a 4+ invulnerable save.';
+    const after = 'This model has a 5+ invulnerable save.';
+    expect(await sourceDigest(before)).not.toBe(await sourceDigest(after));
+  });
+
+  it('changes when a condition is added, which is the common dataslate rewording', async () => {
+    const before = 'Add 1 to the Hit roll.';
+    const after = 'Add 1 to the Hit roll if the target is within range of an objective marker.';
+    expect(await sourceDigest(before)).not.toBe(await sourceDigest(after));
+  });
+
+  it('treats curly and straight quotes alike', async () => {
+    expect(await sourceDigest("the model's weapon")).toBe(await sourceDigest('the model’s weapon'));
+  });
+
+  it('digestMatches is false for an absent digest', async () => {
+    expect(await digestMatches(undefined, 'anything')).toBe(false);
+  });
+
+  it('stores no source text: a digest is 64 hex chars and irreversible', async () => {
+    const d = await sourceDigest('Feel No Pain 5+.');
+    expect(d).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/tools/src/source-digest.ts
+++ b/tools/src/source-digest.ts
@@ -1,0 +1,42 @@
+/**
+ * Source-text fingerprints for authored abilities.
+ *
+ * An annotation is a claim about a printed rule. When a dataslate rewords that rule the
+ * claim may silently stop being true, and today nothing detects it: `version` records the
+ * dataslate an ability was authored for, but not whether THIS ability's text actually
+ * changed, so a consumer cannot tell "reviewed and still correct" from "never revisited".
+ *
+ * A digest of the source text closes that gap without the repo ever holding the text.
+ * Contributors already bring their own core data (see CONTRIBUTING); this hashes it.
+ */
+export const NORMALISATION = 'v1' as const;
+
+/** Casefold, collapse whitespace, drop punctuation that reprints vary freely. */
+export function normaliseSourceText(text: string): string {
+  return text
+    .normalize('NFKD')
+    .replace(/[‘’“”]/g, "'")
+    .toLowerCase()
+    .replace(/[^a-z0-9+\-'" ]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export async function sourceDigest(text: string): Promise<string> {
+  const bytes = new TextEncoder().encode(normaliseSourceText(text));
+  const buf = await crypto.subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export interface SourceDigest {
+  algo: 'sha256';
+  value: string;
+  normalisation: typeof NORMALISATION;
+  source: string;
+  checked_at?: string;
+}
+
+/** Does this ability's recorded digest still match the text we have in hand? */
+export async function digestMatches(d: SourceDigest | undefined, text: string): Promise<boolean> {
+  return !!d && d.value === (await sourceDigest(text));
+}


### PR DESCRIPTION
Closes nothing yet — opening for discussion, since it touches the ability schema.

An authored ability is a claim about a printed rule. When a dataslate rewords that rule the claim can silently stop being true, and nothing in the repo detects it: `version` records the dataslate an ability was authored *for*, not whether *this* ability's text actually changed. That leaves "reviewed and still correct" indistinguishable from "never revisited since", and the gap only widens as dataslates land. For consumers who compute from the DSL, the practical consequence is a unit evaluated against a rule that no longer exists, with nothing to flag it.

Adds an optional `source_digest` to the ability schema: a SHA-256 of the **normalised** source text — never the text. Normalisation casefolds, collapses whitespace and strips punctuation, so reprints and curly-vs-straight quotes do not churn, while a changed value or an added condition does. The hash is one-way, so IP safety is unchanged and `gw-leak` stays at zero; this is deliberately *not* the "paste the prose in" approach that `CONTRIBUTING.md` rules out.

`npm run audit:source-digest -- <corpus.json>` points at the contributor's own rules datasource — the same one `ARMY_ASSIST_JSON` refers to, as a `{ability_id: "printed text"}` map — and lists every annotation whose source changed since it was authored, exiting 1 so CI can gate on it. The corpus is read, never copied into the repo.

The field is optional and `additionalProperties` stays `false`, so every existing entry validates unchanged; authors add it as they touch an ability. A follow-up could backfill digests during the existing `author:*` loop, where the source text is already in hand.

Verification:
- 6 new unit tests: reprint noise and quote style produce the same digest; a changed value and an added condition do not; an absent digest never matches; the digest is 64 hex chars and holds no text
- schema diff is pure addition (0 deleted lines), `package.json` gains one script line
- `tsc --noEmit` adds no new error classes — the tree already reports 556 TS2307/TS2580/TS7006 from `@types/node` not being installed in my environment, and my files contribute none of their own
- Not run: `just preflight` (no core data, bundles or generated artifacts change)
