### PR TITLE
fix: Flag ability conditions referencing undefined keywords and stratagems

### DIFF
--- a/data/enrichment/adepta-sororitas/abilities.json
+++ b/data/enrichment/adepta-sororitas/abilities.json
@@ -1640,7 +1640,9 @@
       "daemonifuge"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "firing-deck-2",

--- a/data/enrichment/adeptus-astartes/abilities.json
+++ b/data/enrichment/adeptus-astartes/abilities.json
@@ -1111,7 +1111,9 @@
       "repulsor-executioner"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "priority-target-acquisition",
@@ -3255,7 +3257,9 @@
       "ravenwing-command-squad"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "intractable-will",
@@ -3926,7 +3930,9 @@
     ],
     "ability_type": "unit",
     "behavior": "passive",
-    "community_notes": "auto-generated, partial"
+    "community_notes": "auto-generated, partial",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "infiltrators",
@@ -4663,7 +4669,9 @@
       "aethon-shaan"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "chapter-master-of-the-raven-guard",
@@ -5916,7 +5924,9 @@
       "hammerfall-bunker"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "suppression-fire",
@@ -6668,7 +6678,9 @@
       "fire-raptor-gunship"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "press-the-attack",
@@ -7983,7 +7995,9 @@
       "xiphon-interceptor"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "annihilator",
@@ -8536,7 +8550,9 @@
       "ballistus-dreadnought"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "incendiary-terror",
@@ -8680,7 +8696,9 @@
       "uriel-ventris"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "master-of-the-fleet",
@@ -9224,7 +9242,9 @@
       "mortis-dreadnought"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "guidance-of-the-ancients-psychic",
@@ -9369,7 +9389,9 @@
       "tarantula-air-defence-battery"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "deadly-demise-2d6",
@@ -9570,7 +9592,9 @@
       "deredeo-dreadnought"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "death-hold",
@@ -10924,7 +10948,9 @@
     ],
     "ability_type": "unit",
     "behavior": "passive",
-    "community_notes": "auto-generated, partial"
+    "community_notes": "auto-generated, partial",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "high-king-of-fenris",
@@ -10987,7 +11013,9 @@
       "logan-grimnar"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "embarking-within-transports",

--- a/data/enrichment/adeptus-mechanicus/abilities.json
+++ b/data/enrichment/adeptus-mechanicus/abilities.json
@@ -114,7 +114,9 @@
       "archaeopter-stratoraptor"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "command-uplink",

--- a/data/enrichment/aeldari/abilities.json
+++ b/data/enrichment/aeldari/abilities.json
@@ -584,7 +584,9 @@
     ],
     "ability_type": "unit",
     "behavior": "passive",
-    "community_notes": "auto-generated, partial"
+    "community_notes": "auto-generated, partial",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "deadly-demise-d3",
@@ -4110,7 +4112,9 @@
     ],
     "ability_type": "unit",
     "behavior": "passive",
-    "community_notes": "auto-generated, partial"
+    "community_notes": "auto-generated, partial",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "firing-deck-11",
@@ -4825,7 +4829,9 @@
       "phoenix"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "deadly-demise-d6-2",
@@ -5185,7 +5191,9 @@
       "corsair-cloud-dancer-band"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "reaver-band",

--- a/data/enrichment/agents-of-the-imperium/abilities.json
+++ b/data/enrichment/agents-of-the-imperium/abilities.json
@@ -578,7 +578,9 @@
       "callidus-assassin"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "shadow-assignment",
@@ -720,7 +722,9 @@
       "inquisitor-greyfax"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "purge-and-cleanse",
@@ -1801,7 +1805,9 @@
       "vigilant-squad"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "dedication-to-duty",

--- a/data/enrichment/astra-militarum/abilities.json
+++ b/data/enrichment/astra-militarum/abilities.json
@@ -2143,7 +2143,9 @@
       "leman-russ-executioner"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "storm-troopers",
@@ -4084,7 +4086,9 @@
       "hydra-platform"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "urban-warfare",

--- a/data/enrichment/chaos-daemons/abilities.json
+++ b/data/enrichment/chaos-daemons/abilities.json
@@ -3526,7 +3526,9 @@
       "kairos-fateweaver"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "sullen-malevolence-aura",
@@ -4314,7 +4316,9 @@
       "plague-toads"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "warp-spines",

--- a/data/enrichment/chaos-knights/abilities.json
+++ b/data/enrichment/chaos-knights/abilities.json
@@ -115,7 +115,9 @@
       "war-dog-brigand"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "executioner",
@@ -160,7 +162,9 @@
       "war-dog-executioner"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "scouts-6",
@@ -241,7 +245,9 @@
       "war-dog-moirax"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "karnivore",

--- a/data/enrichment/chaos-space-marines/abilities.json
+++ b/data/enrichment/chaos-space-marines/abilities.json
@@ -1302,7 +1302,9 @@
     "behavior": "passive",
     "usage": {
       "frequency": "once-per-turn"
-    }
+    },
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "mutated-bodyguard",
@@ -2486,7 +2488,9 @@
       "chaos-predator-destructor"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "punishing-suppression",
@@ -2651,7 +2655,9 @@
       "heldrake"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "flame-wreathed",
@@ -3044,7 +3050,9 @@
     ],
     "ability_type": "unit",
     "behavior": "passive",
-    "community_notes": "auto-generated, partial"
+    "community_notes": "auto-generated, partial",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "trophy-taker",
@@ -4790,7 +4798,9 @@
       "cypher"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "guns-blazing",
@@ -5092,7 +5102,9 @@
       "hell-blade"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "scuttling-gait",

--- a/data/enrichment/death-guard/abilities.json
+++ b/data/enrichment/death-guard/abilities.json
@@ -1173,7 +1173,9 @@
       "chaos-predator-destructor"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "punishing-suppression",
@@ -2498,7 +2500,9 @@
       "malignant-plaguecaster"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "pestilent-fallout-psychic",

--- a/data/enrichment/drukhari/abilities.json
+++ b/data/enrichment/drukhari/abilities.json
@@ -1917,7 +1917,9 @@
       "lady-malys"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "agonising-suppression",
@@ -2403,7 +2405,9 @@
     ],
     "ability_type": "unit",
     "behavior": "passive",
-    "community_notes": "auto-generated, partial"
+    "community_notes": "auto-generated, partial",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "decapitating-strikes",
@@ -2706,7 +2710,9 @@
       "raven-strike-fighter"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "power-from-pain",

--- a/data/enrichment/emperors-children/abilities.json
+++ b/data/enrichment/emperors-children/abilities.json
@@ -1759,7 +1759,9 @@
       "heldrake"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "flame-wreathed",
@@ -2135,7 +2137,9 @@
     "faction_id": "emperors-children",
     "ability_type": "faction",
     "behavior": "passive",
-    "unit_ids": []
+    "unit_ids": [],
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "pact-of-excess",

--- a/data/enrichment/grey-knights/abilities.json
+++ b/data/enrichment/grey-knights/abilities.json
@@ -1090,7 +1090,9 @@
       "brotherhood-techmarine"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "sanctic-hood",
@@ -1309,7 +1311,9 @@
       "stormtalon-gunship"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "personal-teleporters",
@@ -1592,7 +1596,9 @@
       "brotherhood-terminator-squad"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "interceptor",
@@ -1640,7 +1646,9 @@
       "stormhawk-interceptor"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "armoured-resilience",

--- a/data/enrichment/imperial-knights/abilities.json
+++ b/data/enrichment/imperial-knights/abilities.json
@@ -845,7 +845,9 @@
       "armiger-moirax"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "gallant-s-duty-bondsman",
@@ -1900,7 +1902,9 @@
         "Armiger"
       ]
     },
-    "community_notes": "-1 CP when targeting bearer with Fire Overwatch/Heroic Intervention stratagem"
+    "community_notes": "-1 CP when targeting bearer with Fire Overwatch/Heroic Intervention stratagem",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "neural-lash-throne-bonded-outriders",

--- a/data/enrichment/leagues-of-votann/abilities.json
+++ b/data/enrichment/leagues-of-votann/abilities.json
@@ -111,7 +111,9 @@
       "memnyr-strategist"
     ],
     "ability_type": "unit",
-    "behavior": "activated"
+    "behavior": "activated",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "decisive-destruction",
@@ -1090,7 +1092,9 @@
       "berehk-stornbrow"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "merciless-eradication",

--- a/data/enrichment/necrons/abilities.json
+++ b/data/enrichment/necrons/abilities.json
@@ -1285,7 +1285,9 @@
       "lokhust-heavy-destroyers"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "whirling-onslaught",
@@ -2947,7 +2949,9 @@
       "canoptek-tomb-crawlers"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "canoptek-retinue",
@@ -3186,7 +3190,9 @@
     "behavior": "passive",
     "usage": {
       "frequency": "once-per-turn"
-    }
+    },
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "multi-threat-eliminator",

--- a/data/enrichment/orks/abilities.json
+++ b/data/enrichment/orks/abilities.json
@@ -302,7 +302,9 @@
     ],
     "ability_type": "unit",
     "behavior": "passive",
-    "faction_id": "orks"
+    "faction_id": "orks",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "deep-strike",
@@ -614,7 +616,9 @@
       "lootas"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "more-dakka",
@@ -964,7 +968,9 @@
     ],
     "ability_type": "unit",
     "behavior": "passive",
-    "faction_id": "orks"
+    "faction_id": "orks",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "blastajet-force-field",
@@ -2224,7 +2230,9 @@
     ],
     "ability_type": "unit",
     "behavior": "passive",
-    "faction_id": "orks"
+    "faction_id": "orks",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "full-throttle-kult-of-speed",
@@ -3711,7 +3719,9 @@
     ],
     "ability_type": "unit",
     "behavior": "passive",
-    "faction_id": "orks"
+    "faction_id": "orks",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "krumpin-time",
@@ -4179,7 +4189,9 @@
       "attack-fighta"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "small-bomms",

--- a/data/enrichment/thousand-sons/abilities.json
+++ b/data/enrichment/thousand-sons/abilities.json
@@ -1262,7 +1262,9 @@
       "rubric-marines"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "icon-of-flame",
@@ -1694,7 +1696,9 @@
       "chaos-predator-destructor"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "punishing-suppression",
@@ -2193,7 +2197,9 @@
       "sekhetar-robots"
     ],
     "ability_type": "unit",
-    "behavior": "activated"
+    "behavior": "activated",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "illusions-of-tzeentch-psychic",
@@ -3087,7 +3093,9 @@
       "heldrake"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "flame-wreathed",

--- a/data/enrichment/tyranids/abilities.json
+++ b/data/enrichment/tyranids/abilities.json
@@ -643,7 +643,9 @@
       "hierophant"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "stalking-forward",
@@ -734,7 +736,9 @@
       "the-swarmlord"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "domination-of-the-hive-mind-aura",
@@ -1352,7 +1356,9 @@
       "hyperadapted-raveners"
     ],
     "ability_type": "unit",
-    "behavior": "activated"
+    "behavior": "activated",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "harpoon-barbs",
@@ -1446,7 +1452,9 @@
       "sporocyst"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: references stratagem id \"fire-overwatch-or-heroic\", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding."
   },
   {
     "ability_id": "resilient-organism",
@@ -1685,7 +1693,9 @@
     ],
     "ability_type": "unit",
     "behavior": "passive",
-    "community_notes": "auto-generated, partial"
+    "community_notes": "auto-generated, partial",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "spirit-leech-aura-psychic",
@@ -2657,7 +2667,9 @@
       "hive-crone"
     ],
     "ability_type": "unit",
-    "behavior": "passive"
+    "behavior": "passive",
+    "disputed": true,
+    "dispute_notes": "Dangling reference: condition gates on keyword \"A\", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding."
   },
   {
     "ability_id": "spawn-termagants",

--- a/tools/node_modules
+++ b/tools/node_modules
@@ -1,1 +1,0 @@
-/Users/will.mitchell/40kdc-data/node_modules

--- a/tools/node_modules
+++ b/tools/node_modules
@@ -1,0 +1,1 @@
+/Users/will.mitchell/40kdc-data/node_modules

--- a/tools/package.json
+++ b/tools/package.json
@@ -66,6 +66,7 @@
     "audit:missing-units": "tsx src/audit-missing-units.ts",
     "audit:loadout-coverage": "tsx src/audit-loadout-coverage.ts",
     "audit:atc": "tsx src/audit-atc.ts",
+    "audit:dangling-refs": "tsx src/audit-dangling-refs.ts",
     "validate": "tsx src/cli.ts validate-all",
     "validate:core": "tsx src/cli.ts validate-core",
     "validate:enrichment": "tsx src/cli.ts validate-enrichment",

--- a/tools/src/audit-dangling-refs.ts
+++ b/tools/src/audit-dangling-refs.ts
@@ -1,0 +1,62 @@
+/**
+ * Find enrichment conditions and effects that reference things the dataset does not define.
+ *
+ * Two classes exist today and neither is caught by schema validation, because both are
+ * well-formed strings in the right place — they are only wrong relative to the rest of
+ * the data:
+ *
+ *   - `target-has-keyword` naming a keyword no unit has. A gate on a keyword nothing
+ *     carries never fires, so the effect is silently dead.
+ *   - `stratagem` naming an id no stratagem file defines, so the effect points at nothing.
+ *
+ * Exit 1 when any are found, so CI can keep the count at zero once they are resolved.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** repo root, so the audit runs from anywhere (other audits assume cwd; this one should not) */
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function walk(dir: string, leaf: string): string[] {
+  return readdirSync(dir).flatMap((e: string) => {
+    const p = join(dir, e);
+    return statSync(p).isDirectory() ? walk(p, leaf) : p.endsWith(leaf) ? [p] : [];
+  });
+}
+const read = (p: string) => JSON.parse(readFileSync(p, 'utf8'));
+
+/** keywords are written in varying case and spacing across sources; compare normalised */
+const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '');
+const keywords = new Set<string>();
+for (const f of walk(join(ROOT, 'data/core'), 'units.json'))
+  for (const u of read(f) as Array<{ keywords?: string[] }>)
+    for (const k of u.keywords ?? []) keywords.add(norm(k));
+/** weapon keywords (Sustained Hits, Twin-linked, Cleave X) are a separate vocabulary */
+for (const f of walk(join(ROOT, 'data/core'), 'weapon-keywords.json'))
+  for (const k of read(f) as Array<{ id?: string; name?: string }>) {
+    if (k.id) keywords.add(norm(k.id));
+    if (k.name) keywords.add(norm(k.name));
+  }
+
+const stratagems = new Set<string>();
+for (const f of walk(join(ROOT, 'data/core'), 'stratagems.json'))
+  for (const s of read(f) as Array<{ id?: string }>) if (s.id) stratagems.add(s.id);
+
+const bad: Array<{ file: string; id: string; kind: string; ref: string }> = [];
+for (const f of walk(join(ROOT, 'data/enrichment'), 'abilities.json')) {
+  for (const a of read(f) as Array<Record<string, unknown>>) {
+    const blob = JSON.stringify(a.effect ?? {});
+    for (const m of blob.matchAll(/"keyword":\s*"([^"]+)"/g))
+      if (!keywords.has(norm(m[1])) && !keywords.has(norm(m[1].replace(/\s+\d+$/, '')))) bad.push({ file: f.replace(ROOT + '/', ''), id: String(a.ability_id), kind: 'keyword', ref: m[1] });
+    for (const m of blob.matchAll(/"stratagem(?:_id)?":\s*"([^"]+)"/g))
+      if (!stratagems.has(m[1])) bad.push({ file: f.replace(ROOT + '/', ''), id: String(a.ability_id), kind: 'stratagem', ref: m[1] });
+  }
+}
+const byRef = new Map<string, number>();
+for (const b of bad) byRef.set(`${b.kind} ${JSON.stringify(b.ref)}`, (byRef.get(`${b.kind} ${JSON.stringify(b.ref)}`) ?? 0) + 1);
+for (const b of bad) console.log(`${b.kind.padEnd(10)} ${JSON.stringify(b.ref).padEnd(28)} ${b.id}`);
+console.log(`\nknown keywords ${keywords.size}; known stratagems ${stratagems.size}`);
+console.log(`dangling references: ${bad.length}`);
+for (const [k, n] of [...byRef].sort((a, b) => b[1] - a[1])) console.log(`  ${n.toString().padStart(4)}  ${k}`);
+process.exit(bad.length ? 1 : 0);

--- a/tools/src/audit-dangling-refs.ts
+++ b/tools/src/audit-dangling-refs.ts
@@ -1,62 +1,423 @@
+#!/usr/bin/env node
 /**
- * Find enrichment conditions and effects that reference things the dataset does not define.
+ * Dangling-reference audit for the Ability DSL.
  *
- * Two classes exist today and neither is caught by schema validation, because both are
- * well-formed strings in the right place — they are only wrong relative to the rest of
- * the data:
+ * Two DSL positions carry values that name something defined elsewhere in the
+ * dataset, yet are structurally just strings, so AJV cannot check them and the
+ * semantic integrity pass does not own them:
  *
- *   - `target-has-keyword` naming a keyword no unit has. A gate on a keyword nothing
- *     carries never fires, so the effect is silently dead.
- *   - `stratagem` naming an id no stratagem file defines, so the effect points at nothing.
+ *  - `unit-has-keyword` / `target-has-keyword` conditions, whose
+ *    `parameters.keyword` operand must name a keyword some unit, faction, or
+ *    keyword catalog actually defines. An unresolvable operand is dead data: the
+ *    gate can never become true, and nothing reports it.
+ *  - `cp-refund` / `stratagem-cost-modifier` effects, whose `modifier.stratagem`
+ *    value must name a core Stratagem id. An unresolvable value points at no
+ *    entity, and the translators still title-case it into readable prose.
  *
- * Exit 1 when any are found, so CI can keep the count at zero once they are resolved.
+ * This module is deliberately separate from `validate-all`: the repository
+ * currently contains unresolved game-state markers (`"SPOTTED"`, `"RILED UP"`)
+ * used as pseudo-keywords, and classifying those is a maintainer decision rather
+ * than a data defect. The audit is a zero-tolerance check that runs only when
+ * invoked explicitly (`npm run audit:dangling-refs`), so it can exit nonzero on
+ * every unresolved value without breaking the normal validation gates.
  */
-import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { readFileSync } from "node:fs";
+import { resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { glob } from "glob";
 
-/** repo root, so the audit runs from anywhere (other audits assume cwd; this one should not) */
-const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const currentDirectory = fileURLToPath(new URL(".", import.meta.url));
 
-function walk(dir: string, leaf: string): string[] {
-  return readdirSync(dir).flatMap((e: string) => {
-    const p = join(dir, e);
-    return statSync(p).isDirectory() ? walk(p, leaf) : p.endsWith(leaf) ? [p] : [];
+/** Default data root: the repository's `data/` tree. */
+export const DATA_ROOT = resolve(currentDirectory, "../../data");
+
+/** Which vocabulary a reference failed to resolve against. */
+export type DanglingReferenceKind = "keyword" | "stratagem";
+
+/**
+ * The DSL node type that produced the reference. Retained on every finding so a
+ * reviewer can tell an attacker gate from a target gate, and a CP refund from a
+ * cost modifier, without re-reading the source record.
+ */
+export type DanglingReferenceType =
+  | "unit-has-keyword"
+  | "target-has-keyword"
+  | "cp-refund"
+  | "stratagem-cost-modifier";
+
+/** One unresolved reference, located precisely enough to fix by hand. */
+export interface DanglingReference {
+  kind: DanglingReferenceKind;
+  reference_type: DanglingReferenceType;
+  /** POSIX path of the ability file, relative to the audited data root. */
+  source_file: string;
+  ability_id: string;
+  /** JSON Pointer to the offending value, rooted at the file's top-level array. */
+  path: string;
+  value: string;
+}
+
+/** The core vocabularies each reference class resolves against. */
+export interface ReferenceVocabularies {
+  /** Keyword labels, ids, and catalog names, each passed through {@link normalizeKeyword}. */
+  keywords: Set<string>;
+  /** Core stratagem ids, compared exactly. */
+  stratagems: Set<string>;
+}
+
+/**
+ * Effect types whose `modifier.stratagem` names a core Stratagem.
+ *
+ * Deliberately a closed list: other effects carry a `stratagem` property as
+ * display text, so matching on the property name alone would invent references
+ * the schemas never promised.
+ */
+const STRATAGEM_EFFECT_TYPES = new Set<DanglingReferenceType>([
+  "cp-refund",
+  "stratagem-cost-modifier",
+]);
+
+/** Condition types whose `parameters.keyword` names a gameplay keyword. */
+const KEYWORD_CONDITION_TYPES = new Set<DanglingReferenceType>([
+  "unit-has-keyword",
+  "target-has-keyword",
+]);
+
+/**
+ * Narrow keyword normalization: trim, drop all whitespace, lowercase.
+ *
+ * This matches how the runtime cruncher compares keyword operands and absorbs
+ * the spelling variation the sources actually contain (`VEHICLE` vs `Vehicle`,
+ * `Feel No Pain` vs `feelnopain`). It deliberately stops short of the
+ * display-name normalizer in `data/normalize.ts`: folding punctuation and
+ * diacritics would merge distinct free-form markers and hide real defects.
+ */
+export function normalizeKeyword(value: string): string {
+  return value.trim().replace(/\s+/gu, "").toLowerCase();
+}
+
+/** Escape one object key for use as a JSON Pointer segment (RFC 6901). */
+function pointerSegment(key: string): string {
+  return key.replace(/~/gu, "~0").replace(/\//gu, "~1");
+}
+
+function readArray<T>(file: string): T[] {
+  return JSON.parse(readFileSync(file, "utf-8")) as T[];
+}
+
+/**
+ * Discover data files under `root`, sorted for deterministic output.
+ *
+ * `skipUnderscoreDirs` excludes `_example`-style scratch directories. Vocabulary
+ * sources use it so fixture data cannot silently widen the accepted vocabulary;
+ * the enrichment scan does not, because `enrichment/_core/abilities.json` is
+ * production data shared by every faction.
+ */
+async function dataFiles(
+  root: string,
+  pattern: string,
+  skipUnderscoreDirs: boolean,
+): Promise<string[]> {
+  const matches = await glob(pattern, { cwd: root, absolute: true });
+  const files = skipUnderscoreDirs
+    ? matches.filter(
+        (file) =>
+          !relativePosix(root, file)
+            .split("/")
+            .slice(0, -1)
+            .some((segment) => segment.startsWith("_")),
+      )
+    : matches;
+  return files.sort();
+}
+
+/** Path of `file` relative to `root`, always with `/` separators. */
+function relativePosix(root: string, file: string): string {
+  const normalizedRoot = resolve(root);
+  const normalizedFile = resolve(file);
+  const relative = normalizedFile.startsWith(normalizedRoot + sep)
+    ? normalizedFile.slice(normalizedRoot.length + sep.length)
+    : normalizedFile;
+  return relative.split(sep).join("/");
+}
+
+function addKeyword(into: Set<string>, value: unknown): void {
+  if (typeof value !== "string") return;
+  const normalized = normalizeKeyword(value);
+  if (normalized.length > 0) into.add(normalized);
+}
+
+/**
+ * Build the vocabularies every reference is resolved against.
+ *
+ * Keywords come from all three of the repository's keyword models: free-form
+ * unit/faction display labels, the universal unit-keyword catalog, and the
+ * weapon-keyword catalog (both ids and names, since authored operands use
+ * either spelling). Without the catalogs, common operands such as `VEHICLE` or
+ * `Lethal Hits` produce hundreds of false positives.
+ *
+ * Unreadable or non-array files are skipped: structural problems belong to the
+ * AJV pass, and this audit must not turn a malformed file into a wall of
+ * spurious dangling references.
+ */
+export async function buildReferenceVocabularies(
+  dataRoot: string = DATA_ROOT,
+): Promise<ReferenceVocabularies> {
+  const root = resolve(dataRoot);
+  const keywords = new Set<string>();
+  const stratagems = new Set<string>();
+
+  for (const file of await dataFiles(root, "core/**/units.json", true)) {
+    let units: Array<{ keywords?: unknown; faction_keywords?: unknown }>;
+    try {
+      units = readArray(file);
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(units)) continue;
+    for (const unit of units) {
+      if (unit === null || typeof unit !== "object") continue;
+      for (const label of Array.isArray(unit.keywords) ? unit.keywords : []) {
+        addKeyword(keywords, label);
+      }
+      for (const label of Array.isArray(unit.faction_keywords)
+        ? unit.faction_keywords
+        : []) {
+        addKeyword(keywords, label);
+      }
+    }
+  }
+
+  for (const file of await dataFiles(root, "core/**/factions.json", true)) {
+    let factions: Array<{ keywords?: unknown }>;
+    try {
+      factions = readArray(file);
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(factions)) continue;
+    for (const faction of factions) {
+      if (faction === null || typeof faction !== "object") continue;
+      for (const label of Array.isArray(faction.keywords)
+        ? faction.keywords
+        : []) {
+        addKeyword(keywords, label);
+      }
+    }
+  }
+
+  for (const catalog of ["core/unit-keywords.json", "core/weapon-keywords.json"]) {
+    let records: Array<{ id?: unknown; name?: unknown }>;
+    try {
+      records = readArray(resolve(root, catalog));
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(records)) continue;
+    for (const record of records) {
+      if (record === null || typeof record !== "object") continue;
+      addKeyword(keywords, record.id);
+      addKeyword(keywords, record.name);
+    }
+  }
+
+  for (const file of await dataFiles(root, "core/**/stratagems.json", true)) {
+    let records: Array<{ id?: unknown }>;
+    try {
+      records = readArray(file);
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(records)) continue;
+    for (const record of records) {
+      if (record === null || typeof record !== "object") continue;
+      if (typeof record.id === "string" && record.id.length > 0) {
+        stratagems.add(record.id);
+      }
+    }
+  }
+
+  return { keywords, stratagems };
+}
+
+/**
+ * Visit every object in a value tree, carrying its JSON Pointer.
+ *
+ * The Ability DSL nests conditions and effects under triggers, conditionals,
+ * sequences, choices, selectors, and resource actions, so a generic walk is the
+ * only way to reach every reference site. Type-awareness lives in the visitor,
+ * not the traversal.
+ */
+function visitObjects(
+  node: unknown,
+  path: string,
+  visit: (node: Record<string, unknown>, path: string) => void,
+): void {
+  if (Array.isArray(node)) {
+    node.forEach((child, index) => visitObjects(child, `${path}/${index}`, visit));
+    return;
+  }
+  if (node === null || typeof node !== "object") return;
+  const record = node as Record<string, unknown>;
+  visit(record, path);
+  for (const [key, value] of Object.entries(record)) {
+    visitObjects(value, `${path}/${pointerSegment(key)}`, visit);
+  }
+}
+
+/** Order findings so repeated runs and diffed reports stay byte-stable. */
+function compareFindings(
+  left: DanglingReference,
+  right: DanglingReference,
+): number {
+  return (
+    left.source_file.localeCompare(right.source_file) ||
+    left.ability_id.localeCompare(right.ability_id) ||
+    left.path.localeCompare(right.path) ||
+    left.kind.localeCompare(right.kind) ||
+    left.value.localeCompare(right.value)
+  );
+}
+
+/**
+ * Collect every enrichment ability reference that resolves to nothing.
+ *
+ * Keyword operands are compared after {@link normalizeKeyword}; stratagem values
+ * are compared exactly, because stratagem ids are canonical kebab-case
+ * identifiers rather than display labels.
+ */
+export async function collectDanglingAbilityReferences(
+  dataRoot: string = DATA_ROOT,
+): Promise<DanglingReference[]> {
+  const root = resolve(dataRoot);
+  const vocabularies = await buildReferenceVocabularies(root);
+  const findings: DanglingReference[] = [];
+
+  for (const file of await dataFiles(root, "enrichment/**/abilities.json", false)) {
+    let abilities: Array<Record<string, unknown>>;
+    try {
+      abilities = readArray(file);
+    } catch {
+      continue; // structural problems are the AJV pass's job
+    }
+    if (!Array.isArray(abilities)) continue;
+
+    const sourceFile = relativePosix(root, file);
+    abilities.forEach((ability, index) => {
+      if (ability === null || typeof ability !== "object") return;
+      const abilityId =
+        typeof ability.ability_id === "string"
+          ? ability.ability_id
+          : typeof ability.id === "string"
+            ? ability.id
+            : "";
+
+      visitObjects(ability, `/${index}`, (node, path) => {
+        const type = node.type;
+        if (typeof type !== "string") return;
+
+        if (KEYWORD_CONDITION_TYPES.has(type as DanglingReferenceType)) {
+          const parameters = node.parameters;
+          if (parameters !== null && typeof parameters === "object") {
+            const keyword = (parameters as Record<string, unknown>).keyword;
+            if (
+              typeof keyword === "string" &&
+              !vocabularies.keywords.has(normalizeKeyword(keyword))
+            ) {
+              findings.push({
+                kind: "keyword",
+                reference_type: type as DanglingReferenceType,
+                source_file: sourceFile,
+                ability_id: abilityId,
+                path: `${path}/parameters/keyword`,
+                value: keyword,
+              });
+            }
+          }
+        }
+
+        if (STRATAGEM_EFFECT_TYPES.has(type as DanglingReferenceType)) {
+          const modifier = node.modifier;
+          if (modifier !== null && typeof modifier === "object") {
+            const stratagem = (modifier as Record<string, unknown>).stratagem;
+            if (
+              typeof stratagem === "string" &&
+              !vocabularies.stratagems.has(stratagem)
+            ) {
+              findings.push({
+                kind: "stratagem",
+                reference_type: type as DanglingReferenceType,
+                source_file: sourceFile,
+                ability_id: abilityId,
+                path: `${path}/modifier/stratagem`,
+                value: stratagem,
+              });
+            }
+          }
+        }
+      });
+    });
+  }
+
+  return findings.sort(compareFindings);
+}
+
+/** Render findings as the deterministic lines the command prints. */
+export function formatDanglingRefs(
+  findings: DanglingReference[],
+  dataRoot: string = DATA_ROOT,
+): string[] {
+  const lines = [
+    "40kdc Dangling Ability References",
+    `Data root: ${resolve(dataRoot)}`,
+    "",
+  ];
+
+  let currentFile = "";
+  for (const finding of findings) {
+    if (finding.source_file !== currentFile) {
+      if (currentFile !== "") lines.push("");
+      currentFile = finding.source_file;
+      lines.push(currentFile);
+    }
+    lines.push(
+      `  ${finding.ability_id || "(no ability_id)"} ${finding.path} ` +
+        `${finding.kind} (${finding.reference_type}) → ${JSON.stringify(finding.value)}`,
+    );
+  }
+
+  const keywordCount = findings.filter((f) => f.kind === "keyword").length;
+  const stratagemCount = findings.length - keywordCount;
+  if (findings.length > 0) lines.push("");
+  lines.push(
+    findings.length === 0
+      ? "No dangling ability references."
+      : `${findings.length} dangling ability reference(s): ${keywordCount} keyword, ${stratagemCount} stratagem.`,
+  );
+  return lines;
+}
+
+/**
+ * Print every unresolved reference and fail the process when any exist.
+ *
+ * Zero tolerance is intentional and is why this is not wired into `build`,
+ * `validate-all`, `just preflight`, or CI: it answers "does every reference
+ * resolve today?", not "did we regress against a baseline?".
+ */
+export async function runDanglingRefsAudit(
+  dataRoot: string = DATA_ROOT,
+): Promise<void> {
+  const findings = await collectDanglingAbilityReferences(dataRoot);
+  for (const line of formatDanglingRefs(findings, dataRoot)) console.log(line);
+  if (findings.length > 0) process.exitCode = 1;
+}
+
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+) {
+  runDanglingRefsAudit().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
   });
 }
-const read = (p: string) => JSON.parse(readFileSync(p, 'utf8'));
-
-/** keywords are written in varying case and spacing across sources; compare normalised */
-const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '');
-const keywords = new Set<string>();
-for (const f of walk(join(ROOT, 'data/core'), 'units.json'))
-  for (const u of read(f) as Array<{ keywords?: string[] }>)
-    for (const k of u.keywords ?? []) keywords.add(norm(k));
-/** weapon keywords (Sustained Hits, Twin-linked, Cleave X) are a separate vocabulary */
-for (const f of walk(join(ROOT, 'data/core'), 'weapon-keywords.json'))
-  for (const k of read(f) as Array<{ id?: string; name?: string }>) {
-    if (k.id) keywords.add(norm(k.id));
-    if (k.name) keywords.add(norm(k.name));
-  }
-
-const stratagems = new Set<string>();
-for (const f of walk(join(ROOT, 'data/core'), 'stratagems.json'))
-  for (const s of read(f) as Array<{ id?: string }>) if (s.id) stratagems.add(s.id);
-
-const bad: Array<{ file: string; id: string; kind: string; ref: string }> = [];
-for (const f of walk(join(ROOT, 'data/enrichment'), 'abilities.json')) {
-  for (const a of read(f) as Array<Record<string, unknown>>) {
-    const blob = JSON.stringify(a.effect ?? {});
-    for (const m of blob.matchAll(/"keyword":\s*"([^"]+)"/g))
-      if (!keywords.has(norm(m[1])) && !keywords.has(norm(m[1].replace(/\s+\d+$/, '')))) bad.push({ file: f.replace(ROOT + '/', ''), id: String(a.ability_id), kind: 'keyword', ref: m[1] });
-    for (const m of blob.matchAll(/"stratagem(?:_id)?":\s*"([^"]+)"/g))
-      if (!stratagems.has(m[1])) bad.push({ file: f.replace(ROOT + '/', ''), id: String(a.ability_id), kind: 'stratagem', ref: m[1] });
-  }
-}
-const byRef = new Map<string, number>();
-for (const b of bad) byRef.set(`${b.kind} ${JSON.stringify(b.ref)}`, (byRef.get(`${b.kind} ${JSON.stringify(b.ref)}`) ?? 0) + 1);
-for (const b of bad) console.log(`${b.kind.padEnd(10)} ${JSON.stringify(b.ref).padEnd(28)} ${b.id}`);
-console.log(`\nknown keywords ${keywords.size}; known stratagems ${stratagems.size}`);
-console.log(`dangling references: ${bad.length}`);
-for (const [k, n] of [...byRef].sort((a, b) => b[1] - a[1])) console.log(`  ${n.toString().padStart(4)}  ${k}`);
-process.exit(bad.length ? 1 : 0);

--- a/tools/test/audit-dangling-refs.test.ts
+++ b/tools/test/audit-dangling-refs.test.ts
@@ -1,0 +1,404 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildReferenceVocabularies,
+  collectDanglingAbilityReferences,
+  DATA_ROOT,
+  formatDanglingRefs,
+  normalizeKeyword,
+  runDanglingRefsAudit,
+  type DanglingReference,
+} from "../src/audit-dangling-refs.js";
+
+const KEYWORD_DISPUTE_NOTE =
+  'Dangling reference: condition gates on keyword "A", which no unit in the dataset has, so the gate never fires and the effect is dead; the intended keyword is unrecoverable from the encoding.';
+const STRATAGEM_DISPUTE_NOTE =
+  'Dangling reference: references stratagem id "fire-overwatch-or-heroic", which no stratagem file defines; the intended stratagem is unrecoverable from the encoding.';
+
+/** Create an isolated `data/` root so no test depends on the production tree. */
+function setupDataRoot(): string {
+  const base = mkdtempSync(join(tmpdir(), "audit-dangling-refs-"));
+  const root = join(base, "data");
+  for (const sub of [
+    "core/alpha",
+    "core/beta",
+    "core/_example",
+    "enrichment/alpha",
+    "enrichment/beta",
+    "enrichment/_core",
+  ]) {
+    mkdirSync(join(root, sub), { recursive: true });
+  }
+  return root;
+}
+
+function write(root: string, rel: string, data: unknown): void {
+  writeFileSync(join(root, rel), `${JSON.stringify(data, null, 2)}\n`);
+}
+
+/** A minimal but realistic core vocabulary covering all four keyword sources. */
+function writeCoreVocabulary(root: string): void {
+  write(root, "core/alpha/units.json", [
+    { id: "alpha-hero", keywords: ["INFANTRY", "Character"], faction_keywords: ["Alpha Legion"] },
+  ]);
+  write(root, "core/beta/units.json", [
+    { id: "beta-brute", keywords: ["MONSTER"], faction_keywords: ["Beta Host"] },
+  ]);
+  write(root, "core/alpha/factions.json", [
+    { id: "alpha", keywords: ["Alpha Faction Label"] },
+  ]);
+  write(root, "core/unit-keywords.json", [
+    { id: "feel-no-pain", name: "Feel No Pain" },
+  ]);
+  write(root, "core/weapon-keywords.json", [
+    { id: "lethal-hits", name: "Lethal Hits" },
+  ]);
+  write(root, "core/stratagems.json", [{ id: "counter-offensive" }]);
+  write(root, "core/alpha/stratagems.json", [{ id: "go-to-ground-alpha" }]);
+  // Scratch/example directories must not widen the accepted vocabulary.
+  write(root, "core/_example/units.json", [{ id: "x", keywords: ["EXAMPLE ONLY"] }]);
+  write(root, "core/_example/stratagems.json", [{ id: "example-only-stratagem" }]);
+}
+
+function keywordCondition(type: string, keyword: string): unknown {
+  return { type, parameters: { keyword } };
+}
+
+/** A realistic `conditional` effect whose gate gates on one keyword. */
+function keywordGate(type: string, keyword: string): unknown {
+  return {
+    type: "conditional",
+    condition: keywordCondition(type, keyword),
+    effect: { type: "modify-stat", modifier: { stat: "toughness", value: 1 } },
+  };
+}
+
+describe("normalizeKeyword", () => {
+  it("trims, removes all whitespace, and lowercases", () => {
+    expect(normalizeKeyword("  Feel No Pain ")).toBe("feelnopain");
+    expect(normalizeKeyword("VEHICLE")).toBe("vehicle");
+    expect(normalizeKeyword("Adeptus\tAstartes\nGuard")).toBe("adeptusastartesguard");
+  });
+
+  it("does not fold punctuation or diacritics", () => {
+    expect(normalizeKeyword("Emperor’s Children")).toBe("emperor’schildren");
+    expect(normalizeKeyword("Twin-linked")).toBe("twin-linked");
+    expect(normalizeKeyword("twinlinked")).not.toBe(normalizeKeyword("twin-linked"));
+  });
+});
+
+describe("buildReferenceVocabularies", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = setupDataRoot();
+    writeCoreVocabulary(root);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("collects normalized keywords from unit, faction, and both catalogs", async () => {
+    const { keywords } = await buildReferenceVocabularies(root);
+    // unit keywords and faction_keywords
+    expect(keywords.has("infantry")).toBe(true);
+    expect(keywords.has("character")).toBe(true);
+    expect(keywords.has("alphalegion")).toBe(true);
+    expect(keywords.has("monster")).toBe(true);
+    // faction record keywords
+    expect(keywords.has("alphafactionlabel")).toBe(true);
+    // unit-keyword catalog ids and names
+    expect(keywords.has("feel-no-pain")).toBe(true);
+    expect(keywords.has("feelnopain")).toBe(true);
+    // weapon-keyword catalog ids and names
+    expect(keywords.has("lethal-hits")).toBe(true);
+    expect(keywords.has("lethalhits")).toBe(true);
+  });
+
+  it("collects stratagem ids from the root and every faction file, exactly", async () => {
+    const { stratagems } = await buildReferenceVocabularies(root);
+    expect([...stratagems].sort()).toEqual(["counter-offensive", "go-to-ground-alpha"]);
+    expect(stratagems.has("Counter-Offensive")).toBe(false);
+  });
+
+  it("ignores underscore-prefixed scratch directories", async () => {
+    const { keywords, stratagems } = await buildReferenceVocabularies(root);
+    expect(keywords.has("exampleonly")).toBe(false);
+    expect(stratagems.has("example-only-stratagem")).toBe(false);
+  });
+
+  it("skips unreadable and non-array files instead of throwing", async () => {
+    writeFileSync(join(root, "core/beta/factions.json"), "{ not json");
+    write(root, "core/beta/stratagems.json", { id: "not-an-array" });
+    const { keywords, stratagems } = await buildReferenceVocabularies(root);
+    expect(keywords.has("infantry")).toBe(true);
+    expect(stratagems.has("not-an-array")).toBe(false);
+  });
+});
+
+describe("collectDanglingAbilityReferences", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = setupDataRoot();
+    writeCoreVocabulary(root);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("resolves keywords supplied by any of the four vocabulary sources", async () => {
+    write(root, "enrichment/alpha/abilities.json", [
+      { ability_id: "unit-label", effect: keywordCondition("unit-has-keyword", "infantry") },
+      { ability_id: "faction-label", effect: keywordCondition("target-has-keyword", "ALPHA LEGION") },
+      { ability_id: "faction-record-label", effect: keywordCondition("unit-has-keyword", "Alpha Faction Label") },
+      { ability_id: "unit-catalog", effect: keywordCondition("unit-has-keyword", "Feel No Pain") },
+      { ability_id: "weapon-catalog", effect: keywordCondition("target-has-keyword", "lethal-hits") },
+    ]);
+    expect(await collectDanglingAbilityReferences(root)).toEqual([]);
+  });
+
+  it("reports unresolved keyword operands with their exact DSL location", async () => {
+    write(root, "enrichment/alpha/abilities.json", [
+      { ability_id: "resolved", effect: keywordGate("unit-has-keyword", "MONSTER") },
+      { ability_id: "dangling", effect: keywordGate("target-has-keyword", "A") },
+    ]);
+    expect(await collectDanglingAbilityReferences(root)).toEqual([
+      {
+        kind: "keyword",
+        reference_type: "target-has-keyword",
+        source_file: "enrichment/alpha/abilities.json",
+        ability_id: "dangling",
+        path: "/1/effect/condition/parameters/keyword",
+        value: "A",
+      },
+    ]);
+  });
+
+  it("finds references nested under every recursive DSL wrapper", async () => {
+    write(root, "enrichment/alpha/abilities.json", [
+      {
+        ability_id: "nested",
+        trigger: { condition: keywordCondition("unit-has-keyword", "TRIGGERED") },
+        effect: {
+          type: "sequence",
+          steps: [
+            {
+              type: "conditional",
+              condition: {
+                type: "and",
+                operands: [
+                  keywordCondition("target-has-keyword", "OPERAND"),
+                  { type: "not", operands: [keywordCondition("unit-has-keyword", "DEEP")] },
+                ],
+              },
+              effect: { type: "cp-refund", modifier: { stratagem: "not-a-stratagem" } },
+            },
+          ],
+        },
+      },
+    ]);
+    const findings = await collectDanglingAbilityReferences(root);
+    expect(findings.map((finding) => finding.path)).toEqual([
+      "/0/effect/steps/0/condition/operands/0/parameters/keyword",
+      "/0/effect/steps/0/condition/operands/1/operands/0/parameters/keyword",
+      "/0/effect/steps/0/effect/modifier/stratagem",
+      "/0/trigger/condition/parameters/keyword",
+    ]);
+    expect(findings.map((finding) => finding.value)).toEqual([
+      "OPERAND",
+      "DEEP",
+      "not-a-stratagem",
+      "TRIGGERED",
+    ]);
+  });
+
+  it("treats only supported node types as references", async () => {
+    write(root, "enrichment/alpha/abilities.json", [
+      {
+        ability_id: "lookalikes",
+        // A bare `keyword` property with no keyword-condition parent.
+        applies_to: { keyword: "NOT A REFERENCE" },
+        effect: {
+          type: "sequence",
+          steps: [
+            // A condition type outside the supported pair.
+            { type: "unit-has-role", parameters: { keyword: "ALSO NOT A REFERENCE" } },
+            // An effect that carries a stratagem string as display text.
+            { type: "ability-grant", modifier: { stratagem: "display text only" } },
+            // Non-string operands stay out of the report.
+            { type: "target-has-keyword", parameters: { keyword: ["A"] } },
+          ],
+        },
+      },
+    ]);
+    expect(await collectDanglingAbilityReferences(root)).toEqual([]);
+  });
+
+  it("compares stratagem ids exactly while keyword matching normalizes", async () => {
+    write(root, "enrichment/alpha/abilities.json", [
+      { ability_id: "exact", effect: { type: "cp-refund", modifier: { stratagem: "counter-offensive" } } },
+      { ability_id: "wrong-case", effect: { type: "cp-refund", modifier: { stratagem: "Counter-Offensive" } } },
+      {
+        ability_id: "cost-modifier",
+        effect: { type: "stratagem-cost-modifier", modifier: { stratagem: "counter offensive" } },
+      },
+    ]);
+    const findings = await collectDanglingAbilityReferences(root);
+    expect(findings.map((finding) => [finding.ability_id, finding.reference_type, finding.value])).toEqual([
+      ["cost-modifier", "stratagem-cost-modifier", "counter offensive"],
+      ["wrong-case", "cp-refund", "Counter-Offensive"],
+    ]);
+    expect(findings.every((finding) => finding.kind === "stratagem")).toBe(true);
+  });
+
+  it("audits the shared _core enrichment pool and sorts findings deterministically", async () => {
+    write(root, "enrichment/_core/abilities.json", [
+      { ability_id: "shared", effect: keywordCondition("unit-has-keyword", "SHARED MARKER") },
+    ]);
+    write(root, "enrichment/beta/abilities.json", [
+      { ability_id: "zulu", effect: keywordCondition("unit-has-keyword", "ZULU") },
+      { ability_id: "alfa", effect: keywordCondition("unit-has-keyword", "ALFA") },
+    ]);
+    write(root, "enrichment/alpha/abilities.json", [
+      { ability_id: "mike", effect: keywordCondition("unit-has-keyword", "MIKE") },
+    ]);
+    const findings = await collectDanglingAbilityReferences(root);
+    expect(findings.map((finding) => [finding.source_file, finding.ability_id])).toEqual([
+      ["enrichment/_core/abilities.json", "shared"],
+      ["enrichment/alpha/abilities.json", "mike"],
+      ["enrichment/beta/abilities.json", "alfa"],
+      ["enrichment/beta/abilities.json", "zulu"],
+    ]);
+    // Repeating the scan yields byte-identical output.
+    expect(await collectDanglingAbilityReferences(root)).toEqual(findings);
+  });
+
+  it("leaves malformed and non-array ability files to the structural validator", async () => {
+    writeFileSync(join(root, "enrichment/alpha/abilities.json"), "[ { broken");
+    write(root, "enrichment/beta/abilities.json", { ability_id: "not-an-array" });
+    write(root, "enrichment/_core/abilities.json", [
+      { ability_id: "readable", effect: keywordCondition("unit-has-keyword", "MISSING") },
+    ]);
+    const findings = await collectDanglingAbilityReferences(root);
+    expect(findings.map((finding) => finding.ability_id)).toEqual(["readable"]);
+  });
+});
+
+describe("runDanglingRefsAudit", () => {
+  let root: string;
+  let previousExitCode: number | string | undefined;
+
+  beforeEach(() => {
+    root = setupDataRoot();
+    writeCoreVocabulary(root);
+    previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    process.exitCode = previousExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it("prints a clean report and leaves the exit status untouched", async () => {
+    write(root, "enrichment/alpha/abilities.json", [
+      { ability_id: "resolved", effect: keywordCondition("unit-has-keyword", "INFANTRY") },
+    ]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await runDanglingRefsAudit(root);
+    expect(log.mock.calls.map(([line]) => line)).toContain("No dangling ability references.");
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("prints every diagnostic and fails the process when findings exist", async () => {
+    write(root, "enrichment/alpha/abilities.json", [
+      { ability_id: "dangling-keyword", effect: keywordGate("target-has-keyword", "A") },
+      {
+        ability_id: "dangling-stratagem",
+        effect: { type: "cp-refund", modifier: { stratagem: "fire-overwatch-or-heroic" } },
+      },
+    ]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await runDanglingRefsAudit(root);
+    const output = log.mock.calls.map(([line]) => String(line)).join("\n");
+    expect(output).toContain("enrichment/alpha/abilities.json");
+    expect(output).toContain(
+      '  dangling-keyword /0/effect/condition/parameters/keyword keyword (target-has-keyword) → "A"',
+    );
+    expect(output).toContain(
+      '  dangling-stratagem /1/effect/modifier/stratagem stratagem (cp-refund) → "fire-overwatch-or-heroic"',
+    );
+    expect(output).toContain("2 dangling ability reference(s): 1 keyword, 1 stratagem.");
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+describe("formatDanglingRefs", () => {
+  it("groups findings by source file and summarizes both reference classes", () => {
+    const findings: DanglingReference[] = [
+      {
+        kind: "keyword",
+        reference_type: "target-has-keyword",
+        source_file: "enrichment/alpha/abilities.json",
+        ability_id: "one",
+        path: "/0/effect/condition/parameters/keyword",
+        value: "A",
+      },
+      {
+        kind: "stratagem",
+        reference_type: "stratagem-cost-modifier",
+        source_file: "enrichment/beta/abilities.json",
+        ability_id: "two",
+        path: "/3/effect/modifier/stratagem",
+        value: "missing-stratagem",
+      },
+    ];
+    const lines = formatDanglingRefs(findings, "/tmp/example/data");
+    expect(lines[0]).toBe("40kdc Dangling Ability References");
+    expect(lines[1]).toBe("Data root: /tmp/example/data");
+    expect(lines).toContain("enrichment/alpha/abilities.json");
+    expect(lines).toContain("enrichment/beta/abilities.json");
+    expect(lines.at(-1)).toBe("2 dangling ability reference(s): 1 keyword, 1 stratagem.");
+  });
+});
+
+describe("production dangling-reference disputes", () => {
+  it("marks every confirmed defect without changing its dangling operand", async () => {
+    const confirmed = (await collectDanglingAbilityReferences()).filter(
+      (finding) =>
+        (finding.kind === "keyword" && finding.value === "A") ||
+        (finding.kind === "stratagem" && finding.value === "fire-overwatch-or-heroic"),
+    );
+    const keywordFindings = confirmed.filter(
+      (finding) => finding.kind === "keyword" && finding.value === "A",
+    );
+    const stratagemFindings = confirmed.filter(
+      (finding) => finding.kind === "stratagem" && finding.value === "fire-overwatch-or-heroic",
+    );
+
+    expect(
+      new Set(keywordFindings.map((finding) => `${finding.source_file}:${finding.ability_id}`)).size,
+    ).toBe(51);
+    expect(stratagemFindings).toHaveLength(19);
+
+    for (const finding of confirmed) {
+      const abilities = JSON.parse(
+        readFileSync(join(DATA_ROOT, finding.source_file), "utf-8"),
+      ) as Array<Record<string, unknown>>;
+      const index = Number(finding.path.split("/")[1]);
+      const ability = abilities[index];
+      const expectedNote =
+        finding.kind === "keyword" ? KEYWORD_DISPUTE_NOTE : STRATAGEM_DISPUTE_NOTE;
+
+      expect(ability?.ability_id).toBe(finding.ability_id);
+      expect(ability?.disputed).toBe(true);
+      expect(ability?.dispute_notes).toBe(expectedNote);
+    }
+  });
+});


### PR DESCRIPTION
[#218](https://github.com/wn-mitch/40kdc-data/issues/218) | [HumanLayer Task](https://cloud.humanlayer.com/artifacts/01a067fe-b559-7583-b30e-85e43cdecd7c) | [PR Walkthrough (alpha)](https://github.com/wn-mitch/40kdc-data/pull/218/files)

## Why the change

Structurally valid ability strings can point to keywords or stratagems that do not exist, leaving dead conditions and effects invisible to schema validation.

## Special things to note

- The 51 keyword and 19 stratagem defects keep their unresolved values because the intended replacements cannot be recovered from the encodings; dispute metadata makes them visible for source-backed correction.
- The explicit audit currently reports 292 unresolved references and exits 1; the remaining findings include ambiguous game-state and faction markers and are not marked as disputed here.

## Change outline

The data annotations and standalone audit remain separate from normal validation.

```diff
 data/enrichment/
+├── 19 faction abilities.json files  # mark 70 confirmed dangling references as disputed
 tools/
+├── package.json                     # expose audit:dangling-refs
+└── src/audit-dangling-refs.ts       # collect vocabularies, scan effects, report findings
```

The command resolves reference-bearing strings against vocabularies derived from core data.

```text
npm run audit:dangling-refs
  keyword vocabulary <- unit/faction labels + unit/weapon keyword ids and names
  stratagem vocabulary <- core stratagem ids
  recursively scan each enrichment ability
    typed keyword condition -> normalized keyword lookup
    typed stratagem effect -> exact stratagem-id lookup
  print deterministic findings with file, ability, and JSON path
  exit 1 when findings remain
```
