### PR TITLE
Keep mobile review exports repeatable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tools/schemas/
 tools/src/data/bundle.generated.ts
 tools/src/share/registry.generated.ts
 .DS_Store
+/.humanlayer/
 *.log
 
 # Local secrets — never commit (e.g. Patreon OAuth client/creator credentials).

--- a/examples/data-explorer/src/lib/export.test.ts
+++ b/examples/data-explorer/src/lib/export.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { toJson, toMarkdown, type FlaggedRecord } from "./export.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { download, toJson, toMarkdown, type FlaggedRecord } from "./export.js";
 
 const records: FlaggedRecord[] = [
   {
@@ -28,6 +28,59 @@ const records: FlaggedRecord[] = [
     stale: false,
   },
 ];
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("download", () => {
+  it("keeps consecutive Blob URLs alive until deferred cleanup", () => {
+    vi.useFakeTimers();
+    const anchors = Array.from({ length: 2 }, () => ({
+      href: "",
+      download: "",
+      click: vi.fn(),
+      remove: vi.fn(),
+    }));
+    const appendChild = vi.fn();
+    vi.stubGlobal("document", {
+      createElement: vi
+        .fn()
+        .mockReturnValueOnce(anchors[0])
+        .mockReturnValueOnce(anchors[1]),
+      body: { appendChild },
+    });
+    const createObjectURL = vi
+      .fn()
+      .mockReturnValueOnce("blob:review-1")
+      .mockReturnValueOnce("blob:review-2");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
+
+    download("ability-dsl-review.md", "first");
+    download("ability-dsl-review.md", "second");
+
+    expect(appendChild).toHaveBeenNthCalledWith(1, anchors[0]);
+    expect(appendChild).toHaveBeenNthCalledWith(2, anchors[1]);
+    expect(anchors.map((anchor) => anchor.href)).toEqual(["blob:review-1", "blob:review-2"]);
+    expect(anchors.map((anchor) => anchor.download)).toEqual([
+      "ability-dsl-review.md",
+      "ability-dsl-review.md",
+    ]);
+    for (const anchor of anchors) {
+      expect(anchor.click).toHaveBeenCalledOnce();
+      expect(anchor.remove).toHaveBeenCalledOnce();
+    }
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1_000);
+
+    expect(revokeObjectURL).toHaveBeenNthCalledWith(1, "blob:review-1");
+    expect(revokeObjectURL).toHaveBeenNthCalledWith(2, "blob:review-2");
+    expect(revokeObjectURL).toHaveBeenCalledTimes(2);
+  });
+});
 
 describe("toJson", () => {
   it("wraps records with a count and kind tag", () => {

--- a/examples/data-explorer/src/lib/export.ts
+++ b/examples/data-explorer/src/lib/export.ts
@@ -82,5 +82,5 @@ export function download(filename: string, text: string, mime = "text/plain"): v
   document.body.appendChild(a);
   a.click();
   a.remove();
-  URL.revokeObjectURL(url);
+  setTimeout(() => URL.revokeObjectURL(url), 1_000);
 }


### PR DESCRIPTION
## Summary

- keep each Blob URL alive for one second after the temporary download anchor is clicked, allowing WebKit to consume repeated Markdown exports
- cover consecutive same-filename downloads and deferred cleanup with fake timers
- ignore root-level HumanLayer workspace metadata

## Verification

- `npm test` (53 tests)
- `npm run check` (0 errors, 0 warnings)
- `npm run build`
- 390×844 production-browser smoke test: three completed `ability-dsl-review.md` download events; every payload retained the synthetic note, including after reload