### PR TITLE
Resolve shared abilities in review exports

### DIFF
--- a/examples/data-explorer/src/lib/roundtrip.svelte
+++ b/examples/data-explorer/src/lib/roundtrip.svelte
@@ -204,7 +204,9 @@
   function buildRecords(): FlaggedRecord[] {
     const out: FlaggedRecord[] = [];
     for (const id of notes.exportableIds()) {
-      const a = abilities.get(id);
+      const a =
+        (explorer.factionId ? abilities.getInFaction(id, explorer.factionId) : undefined) ??
+        abilities.getAny(id);
       const n = notes.get(id);
       let desc = "";
       try {


### PR DESCRIPTION
## Summary

- resolve review-export abilities in the selected faction before falling back to the collection's explicit ambiguity-safe lookup
- prevent shared core ability flags from making both Copy JSON and Export Markdown fail before serialization
- preserve missing-id records and the existing ability-id-only notes store

No package version bump is included.

## Verification

- `npm test` (53 tests)
- `npm run check` (0 errors, 0 warnings)
- `npm run build`
- 390×844 browser reproduction with ambiguous `deadly-demise-1`: one completed `ability-dsl-review.md` download containing the persisted synthetic note, with no page errors